### PR TITLE
[QHC-961] Implement models and methods for QaaSBackend's Execute requests

### DIFF
--- a/changes/27.misc.md
+++ b/changes/27.misc.md
@@ -1,0 +1,1 @@
+Add your info here

--- a/src/qilisdk/digital/ansatz.py
+++ b/src/qilisdk/digital/ansatz.py
@@ -103,6 +103,23 @@ class HardwareEfficientAnsatz(Ansatz):
             "grouped": self._construct_layer_grouped,
         }
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Exclude the mapping that contains bound methods (not serializable).
+        state.pop("construct_layer_handlers", None)
+        return state
+
+    def __setstate__(self, state):
+        """
+        Restore the object's state after deserialization and reinitialize any attributes that were omitted.
+        """
+        self.__dict__.update(state)
+        # Reconstruct the mapping with the proper bound methods.
+        self.construct_layer_handlers = {
+            "interposed": self._construct_layer_interposed,
+            "grouped": self._construct_layer_grouped,
+        }
+
     @property
     def nparameters(self) -> int:
         """

--- a/src/qilisdk/digital/ansatz.py
+++ b/src/qilisdk/digital/ansatz.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import ClassVar, Literal, Union
+from typing import Any, ClassVar, Literal, Union
 
 from qilisdk.digital.circuit import Circuit
 from qilisdk.digital.gates import CNOT, CZ, U1, U2, U3, M
@@ -103,13 +103,13 @@ class HardwareEfficientAnsatz(Ansatz):
             "grouped": self._construct_layer_grouped,
         }
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         # Exclude the mapping that contains bound methods (not serializable).
         state.pop("construct_layer_handlers", None)
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:  # noqa: ANN001
         """
         Restore the object's state after deserialization and reinitialize any attributes that were omitted.
         """

--- a/src/qilisdk/digital/vqe.py
+++ b/src/qilisdk/digital/vqe.py
@@ -83,6 +83,7 @@ class VQEResult(Result):
         )
 
 
+@yaml.register_class
 class VQE(DigitalAlgorithm):
     """
     Implements the Variational Quantum Eigensolver (VQE) algorithm.

--- a/src/qilisdk/extras/qaas/models.py
+++ b/src/qilisdk/extras/qaas/models.py
@@ -25,6 +25,7 @@ from .qaas_analog_result import QaaSAnalogResult
 from .qaas_digital_result import QaaSDigitalResult
 from .qaas_time_evolution_result import QaaSTimeEvolutionResult
 from .qaas_vqe_result import QaaSVQEResult
+from qilisdk.yaml import yaml
 
 
 class QaaSModel(BaseModel):
@@ -69,6 +70,7 @@ class DeviceType(str, Enum):
     SIMULATOR = "simulator_device"
 
 
+@yaml.register_class
 class Device(QaaSModel):
     id: int = Field(...)
     name: str = Field(...)
@@ -83,30 +85,31 @@ class ExecutePayloadType(str, Enum):
     TIME_EVOLUTION = "time_evolution"
 
 
+@yaml.register_class
 class DigitalPayload(QaaSModel):
     circuit: Circuit = Field(...)
     nshots: int = Field(...)
 
-
+@yaml.register_class
 class AnalogPayload(QaaSModel):
     schedule: Schedule = Field(...)
     initial_state: QuantumObject = Field(...)
     observables: list[PauliOperator | Hamiltonian] = Field(...)
     store_intermediate_results: bool = Field(...)
 
-
+@yaml.register_class
 class VQEPayload(QaaSModel):
     vqe: VQE = Field(...)
     optimizer: Optimizer = Field(...)
     nshots: int = Field(...)
     store_intermediate_results: bool = Field(...)
 
-
+@yaml.register_class
 class TimeEvolutionPayload(QaaSModel):
     time_evolution: TimeEvolution = Field()
     store_intermediate_results: bool = Field()
 
-
+@yaml.register_class
 class ExecutePayload(QaaSModel):
     type: ExecutePayloadType = Field(...)
     device_id: int = Field(...)
@@ -115,7 +118,7 @@ class ExecutePayload(QaaSModel):
     vqe_payload: VQEPayload | None = None
     time_evolution_payload: TimeEvolutionPayload | None = None
 
-
+@yaml.register_class
 class ExecuteResponse(QaaSModel):
     type: ExecutePayloadType = Field(...)
     digital_result: QaaSDigitalResult | None = None

--- a/src/qilisdk/extras/qaas/models.py
+++ b/src/qilisdk/extras/qaas/models.py
@@ -20,12 +20,12 @@ from qilisdk.analog import Hamiltonian, QuantumObject, Schedule, TimeEvolution
 from qilisdk.analog.hamiltonian import PauliOperator
 from qilisdk.common.optimizer import Optimizer
 from qilisdk.digital import VQE, Circuit
+from qilisdk.yaml import yaml
 
 from .qaas_analog_result import QaaSAnalogResult
 from .qaas_digital_result import QaaSDigitalResult
 from .qaas_time_evolution_result import QaaSTimeEvolutionResult
 from .qaas_vqe_result import QaaSVQEResult
-from qilisdk.yaml import yaml
 
 
 class QaaSModel(BaseModel):
@@ -90,12 +90,14 @@ class DigitalPayload(QaaSModel):
     circuit: Circuit = Field(...)
     nshots: int = Field(...)
 
+
 @yaml.register_class
 class AnalogPayload(QaaSModel):
     schedule: Schedule = Field(...)
     initial_state: QuantumObject = Field(...)
     observables: list[PauliOperator | Hamiltonian] = Field(...)
     store_intermediate_results: bool = Field(...)
+
 
 @yaml.register_class
 class VQEPayload(QaaSModel):
@@ -104,10 +106,12 @@ class VQEPayload(QaaSModel):
     nshots: int = Field(...)
     store_intermediate_results: bool = Field(...)
 
+
 @yaml.register_class
 class TimeEvolutionPayload(QaaSModel):
     time_evolution: TimeEvolution = Field()
     store_intermediate_results: bool = Field()
+
 
 @yaml.register_class
 class ExecutePayload(QaaSModel):
@@ -117,6 +121,7 @@ class ExecutePayload(QaaSModel):
     analog_payload: AnalogPayload | None = None
     vqe_payload: VQEPayload | None = None
     time_evolution_payload: TimeEvolutionPayload | None = None
+
 
 @yaml.register_class
 class ExecuteResponse(QaaSModel):

--- a/src/qilisdk/extras/qaas/qaas_backend.py
+++ b/src/qilisdk/extras/qaas/qaas_backend.py
@@ -66,8 +66,6 @@ class QaaSBackend(DigitalBackend, AnalogBackend):
     """
 
     _api_url: str = "https://qilimanjaroqaas.ddns.net:8080/api/v1"
-    _authorization_request_url: str = "https://qilimanjaroqaas.ddns.net:8080/api/v1/authorisation-tokens"
-    _authorization_refresh_url: str = "https://qilimanjaroqaas.ddns.net:8080/api/v1/authorisation-tokens/refresh"
 
     def __init__(self) -> None:
         """
@@ -124,7 +122,7 @@ class QaaSBackend(DigitalBackend, AnalogBackend):
             encoded_assertion = urlsafe_b64encode(json.dumps(assertion, indent=2).encode("utf-8")).decode("utf-8")
             with httpx.Client(timeout=10.0) as client:
                 response = client.post(
-                    QaaSBackend._authorization_request_url,
+                    QaaSBackend._api_url + "/authorisation-tokens",
                     json={
                         "grantType": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                         "assertion": encoded_assertion,
@@ -157,7 +155,7 @@ class QaaSBackend(DigitalBackend, AnalogBackend):
             devices_list_adapter = TypeAdapter(list[Device])
             devices = devices_list_adapter.validate_python(response.json()["items"])
 
-            # Previous 2 lines are the same as doing:
+            # Previous two lines are the same as doing:
             # response_json = response.json()
             # devices = [Device(**item) for item in response_json["items"]]
 

--- a/src/qilisdk/extras/qaas/qaas_time_evolution_result.py
+++ b/src/qilisdk/extras/qaas/qaas_time_evolution_result.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from qilisdk.analog.analog_result import AnalogResult
+from qilisdk.yaml import yaml
+
+
+@yaml.register_class
+class QaaSTimeEvolutionResult(AnalogResult): ...

--- a/src/qilisdk/extras/qaas/qaas_vqe_result.py
+++ b/src/qilisdk/extras/qaas/qaas_vqe_result.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from qilisdk.digital.vqe import VQEResult
+from qilisdk.yaml import yaml
+
+
+@yaml.register_class
+class QaaSVQEResult(VQEResult): ...

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -65,10 +65,7 @@ def lambda_constructor(constructor, node):
 
 def pydantic_model_representer(representer, data):
     """Representer for Pydantic Models."""
-    value = {
-        "type": f"{data.__class__.__module__}.{data.__class__.__name__}",
-        "data": data.model_dump()
-    }
+    value = {"type": f"{data.__class__.__module__}.{data.__class__.__name__}", "data": data.model_dump()}
     return representer.represent_mapping("!PydanticModel", value)
 
 

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -16,10 +16,10 @@
 
 import base64
 import types
-from pydantic import BaseModel
 
 import numpy as np
 from dill import dumps, loads
+from pydantic import BaseModel
 from ruamel.yaml import YAML
 
 
@@ -62,6 +62,7 @@ def lambda_constructor(constructor, node):
     serialized_lambda = base64.b64decode(node.value)
     return loads(serialized_lambda)  # noqa: S301
 
+
 def pydantic_model_representer(representer, data):
     """Representer for Pydantic Models."""
     value = {
@@ -69,6 +70,7 @@ def pydantic_model_representer(representer, data):
         "data": data.model_dump()
     }
     return representer.represent_mapping("!PydanticModel", value)
+
 
 def pydantic_model_constructor(constructor, node):
     """Constructor for Pydantic Models."""
@@ -80,9 +82,11 @@ def pydantic_model_constructor(constructor, node):
     model_cls = getattr(mod, class_name)
     return model_cls.model_validate(data)
 
+
 def complex_representer(representer, data: complex):
     value = {"real": data.real, "imag": data.imag}
     return representer.represent_mapping("!complex", value)
+
 
 def complex_constructor(constructor, node):
     mapping = constructor.construct_mapping(node, deep=True)

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -16,6 +16,7 @@
 
 import base64
 import types
+from pydantic import BaseModel
 
 import numpy as np
 from dill import dumps, loads
@@ -39,7 +40,7 @@ def ndarray_constructor(constructor, node):
 
 def function_representer(representer, data):
     """Represent a non-lambda function by serializing it."""
-    serialized_function = base64.b64encode(dumps(data)).decode("utf-8")
+    serialized_function = base64.b64encode(dumps(data, recurse=True)).decode("utf-8")
     return representer.represent_scalar("!function", serialized_function)
 
 
@@ -51,7 +52,7 @@ def function_constructor(constructor, node):
 
 def lambda_representer(representer, data):
     """Represent a lambda function by serializing its code."""
-    serialized_lambda = base64.b64encode(dumps(data)).decode("utf-8")
+    serialized_lambda = base64.b64encode(dumps(data, recurse=True)).decode("utf-8")
     return representer.represent_scalar("!lambda", serialized_lambda)
 
 
@@ -61,6 +62,32 @@ def lambda_constructor(constructor, node):
     serialized_lambda = base64.b64decode(node.value)
     return loads(serialized_lambda)  # noqa: S301
 
+def pydantic_model_representer(representer, data):
+    """Representer for Pydantic Models."""
+    value = {
+        "type": f"{data.__class__.__module__}.{data.__class__.__name__}",
+        "data": data.model_dump()
+    }
+    return representer.represent_mapping("!PydanticModel", value)
+
+def pydantic_model_constructor(constructor, node):
+    """Constructor for Pydantic Models."""
+    mapping = constructor.construct_mapping(node, deep=True)
+    model_type_str = mapping["type"]
+    data = mapping["data"]
+    module_name, class_name = model_type_str.rsplit(".", 1)
+    mod = __import__(module_name, fromlist=[class_name])
+    model_cls = getattr(mod, class_name)
+    return model_cls.model_validate(data)
+
+def complex_representer(representer, data: complex):
+    value = {"real": data.real, "imag": data.imag}
+    return representer.represent_mapping("!complex", value)
+
+def complex_constructor(constructor, node):
+    mapping = constructor.construct_mapping(node, deep=True)
+    return complex(mapping["real"], mapping["imag"])
+
 
 yaml = YAML(typ="unsafe")
 yaml.representer.add_representer(np.ndarray, ndarray_representer)
@@ -69,3 +96,7 @@ yaml.representer.add_representer(types.FunctionType, function_representer)
 yaml.constructor.add_constructor("!function", function_constructor)
 yaml.representer.add_representer(types.LambdaType, lambda_representer)
 yaml.constructor.add_constructor("!lambda", lambda_constructor)
+yaml.representer.add_representer(BaseModel, pydantic_model_representer)
+yaml.constructor.add_constructor("!PydanticModel", pydantic_model_constructor)
+yaml.representer.add_representer(complex, complex_representer)
+yaml.constructor.add_constructor("!complex", complex_constructor)


### PR DESCRIPTION
Improved `QaaSBacked` functionality to include methods for executing digital and analog algorithms.