### PR TITLE
[QHC-963] Making `pydantic` a mandatory requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "numpy>=2.2.4",
     "ruamel-yaml>=0.18.10",
     "scipy>=1.15.1",
+    "pydantic>=2.10.6",
+    "pydantic-settings>=2.8.0",
 ]
 
 [project.optional-dependencies]
@@ -35,8 +37,6 @@ cuda = [
 qaas = [
     "httpx>=0.28.1",
     "keyring>=25.6.0",
-    "pydantic>=2.10.6",
-    "pydantic-settings>=2.8.0",
 ]
 
 [dependency-groups]

--- a/src/qilisdk/extras/__init__.py
+++ b/src/qilisdk/extras/__init__.py
@@ -25,7 +25,7 @@ OPTIONAL_FEATURES: list[OptionalFeature] = [
     ),
     OptionalFeature(
         name="qaas",
-        dependencies=["httpx", "keyring", "pydantic", "pydantic-settings"],
+        dependencies=["httpx", "keyring"],
         symbols=[Symbol(path="qilisdk.extras.qaas.qaas_backend", name="QaaSBackend")],
     ),
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1518,13 +1518,15 @@ wheels = [
 
 [[package]]
 name = "qilisdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },
     { name = "numpy" },
     { name = "ruamel-yaml" },
     { name = "scipy" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.optional-dependencies]
@@ -1534,8 +1536,6 @@ cuda = [
 qaas = [
     { name = "httpx" },
     { name = "keyring" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -1557,8 +1557,8 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'qaas'", specifier = ">=0.28.1" },
     { name = "keyring", marker = "extra == 'qaas'", specifier = ">=25.6.0" },
     { name = "numpy", specifier = ">=2.2.4" },
-    { name = "pydantic", marker = "extra == 'qaas'", specifier = ">=2.10.6" },
-    { name = "pydantic-settings", marker = "extra == 'qaas'", specifier = ">=2.8.0" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pydantic-settings", specifier = ">=2.8.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.10" },
     { name = "scipy", specifier = ">=1.15.1" },
 ]


### PR DESCRIPTION
Made `pydantic` pass to be a mandatory requirement, and not only for qaas as before. Solving a problem with installation overseen in previous PRs.