### PR TITLE
[QHC-972] Improving `ptrace` function

### DIFF
--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -158,7 +158,7 @@ class QuantumObject:
         Raises:
             ValueError: If the product of the dimensions in dims does not match the
                 shape of the QuantumObject's dense representation or if any dimension is non-positive.
-            ValueError: If the indices in 'keep' are not unique, or are out of range, or duplicates.
+            ValueError: If the indices in 'keep' are not unique or are out of range.
 
         Returns:
             QuantumObject: A new QuantumObject representing the reduced density matrix
@@ -184,15 +184,15 @@ class QuantumObject:
         rho_t = rho.reshape(*(dims + dims))
 
         # 4) Loop backwards over subsystems, so that when we trace out one, the remaining axes still line up.
-        n = len(dims)
+        column_axis_offset = len(dims)
         # trace out in descending subsystem order
         for subsystem in reversed(range(len(dims))):
             if subsystem not in keep_set:
                 # axis1 is the "row" index for that subsystem
-                # axis2 is the "column" index, which sits n dims later
-                rho_t = np.trace(rho_t, axis1=subsystem, axis2=subsystem + n)
+                # axis2 is the "column" index, which sits column_axis_offset dims later
+                rho_t = np.trace(rho_t, axis1=subsystem, axis2=subsystem + column_axis_offset)
                 # now we've removed one subsystem, so future column-axes shift down
-                n -= 1
+                column_axis_offset -= 1
 
         # 5) Reassemble the “kept” dims into a flat matrix
         dims_keep = [dims[i] for i in sorted(keep)]

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -169,7 +169,7 @@ class QuantumObject:
         # 1) Basic checks for dims
         total_dim = int(np.prod(dims))
         if rho.shape != (total_dim, total_dim):
-            raise ValueError("Dimension mismatch between dims and QuantumObject shape (rho.shape != prod(dims))")
+            raise ValueError(f"Dimension mismatch: QuantumObject shape {rho.shape} does not match the expected shape ({total_dim}, {total_dim}) from prod(dims).")
         if any(d <= 0 for d in dims):
             raise ValueError("All subsystem dimensions must be positive")
 

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -166,15 +166,15 @@ class QuantumObject:
             QuantumObject: A new QuantumObject representing the reduced density matrix
                 for the subsystems specified in 'keep'.
         """
-        if self.is_ket() or self.is_bra():
-            rho = self.to_density_matrix().dense
-        else:
-            rho = self.dense
+        # 0) Get the density matrix representation:
+        rho = self.to_density_matrix().dense if self.is_ket() or self.is_bra() else self.dense
 
         # 1) Basic checks for dims
         total_dim = int(np.prod(dims))
         if rho.shape != (total_dim, total_dim):
-            raise ValueError(f"Dimension mismatch: QuantumObject shape {rho.shape} does not match the expected shape ({total_dim}, {total_dim}) from prod(dims).")
+            raise ValueError(
+                f"Dimension mismatch: QuantumObject shape {rho.shape} does not match the expected shape ({total_dim}, {total_dim}) from prod(dims)."
+            )
         if any(d <= 0 for d in dims):
             raise ValueError("All subsystem dimensions must be positive")
 

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -152,7 +152,8 @@ class QuantumObject:
         Args:
             dims (list[int]): A list specifying the dimensions of each subsystem.
             keep (list[int]): A list of indices corresponding to the subsystems to retain.
-                The order of the indices in 'keep' is not important, but they must be unique.
+                The order of the indices in 'keep' is not important, since dimensions will
+                be returned in the original order, but the indices must be unique.
 
         Raises:
             ValueError: If the product of the dimensions in dims does not match the

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -153,6 +153,7 @@ class QuantumObject:
         Args:
             dims (list[int]): A list specifying the dimensions of each subsystem.
             keep (list[int]): A list of indices corresponding to the subsystems to retain.
+                The order of the indices in 'keep' is not important, but they must be unique.
 
         Raises:
             ValueError: If the product of the dimensions in dims does not match the

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -149,6 +149,8 @@ class QuantumObject:
         The input 'dims' represents the dimensions of each subsystem,
         and 'keep' indicates the indices of the subsystems to be retained.
 
+        If the QuantumObject is a ket or bra, it will first be converted to a density matrix.
+
         Args:
             dims (list[int]): A list specifying the dimensions of each subsystem.
             keep (list[int]): A list of indices corresponding to the subsystems to retain.
@@ -164,7 +166,10 @@ class QuantumObject:
             QuantumObject: A new QuantumObject representing the reduced density matrix
                 for the subsystems specified in 'keep'.
         """
-        rho = self.dense
+        if self.is_ket() or self.is_bra():
+            rho = self.to_density_matrix().dense
+        else:
+            rho = self.dense
 
         # 1) Basic checks for dims
         total_dim = int(np.prod(dims))

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -164,14 +164,11 @@ class QuantumObject:
                 for the subsystems specified in 'keep'.
         """
         rho = self.dense
+
+        # 1) Basic checks for dims
         total_dim = np.prod(dims)
         if rho.shape != (total_dim, total_dim):
-            raise ValueError("Dimension mismatch between provided dims and QuantumObject shape")
-
-        # 1) Basic checks
-        total = int(np.prod(dims))
-        if rho.shape != (total, total):
-            raise ValueError("rho.shape != prod(dims)")
+            raise ValueError("Dimension mismatch between dims and QuantumObject shape (rho.shape != prod(dims))")
         if any(d <= 0 for d in dims):
             raise ValueError("All subsystem dimensions must be positive")
 

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import string
 from typing import Literal
 
 import numpy as np

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -143,7 +143,7 @@ class QuantumObject:
 
     def ptrace(self, dims: list[int], keep: list[int]) -> "QuantumObject":
         """
-        Compute the partial trace over all subsystems not in 'keep'.
+        Compute the partial trace over subsystems not in 'keep'.
 
         This method calculates the reduced density matrix by tracing out
         the subsystems that are not specified in the 'keep' parameter.
@@ -151,28 +151,34 @@ class QuantumObject:
         and 'keep' indicates the indices of the subsystems to be retained.
 
         Args:
-            dims (list[int]): A list specifying the dimensions of each subsystem [d0, d1, ..., dn-1].
+            dims (list[int]): A list specifying the dimensions of each subsystem.
             keep (list[int]): A list of indices corresponding to the subsystems to retain.
 
         Raises:
             ValueError: If the product of the dimensions in dims does not match the
-                shape of the QuantumObject's dense representation.
+                shape of the QuantumObject's dense representation or if any dimension is non-positive.
+            ValueError: If the indices in 'keep' are not unique, or are out of range, or duplicates.
 
         Returns:
             QuantumObject: A new QuantumObject representing the reduced density matrix
                 for the subsystems specified in 'keep'.
         """
         rho = self.dense
+        total_dim = np.prod(dims)
+        if rho.shape != (total_dim, total_dim):
+            raise ValueError("Dimension mismatch between provided dims and QuantumObject shape")
 
         # 1) Basic checks
         total = int(np.prod(dims))
         if rho.shape != (total, total):
-            raise ValueError("rho.shape != prod(dims)²")
+            raise ValueError("rho.shape != prod(dims)")
+        if any(d <= 0 for d in dims):
+            raise ValueError("All subsystem dimensions must be positive")
 
         # 2) Validate & sort `keep`
         keep_set = set(keep)
         if any(i < 0 or i >= len(dims) for i in keep_set):
-            raise IndexError("keep indices out of range (0, len(dims))")
+            raise ValueError("keep indices out of range (0, len(dims))")
         if len(keep_set) != len(keep):
             raise ValueError("duplicate indices in keep")
 
@@ -181,7 +187,8 @@ class QuantumObject:
 
         # 4) Loop backwards over subsystems, so that when we trace out one, the remaining axes still line up.
         n = len(dims)
-        for subsystem in sorted(range(n), reverse=True):
+        # trace out in descending subsystem order
+        for subsystem in reversed(range(len(dims))):
             if subsystem not in keep_set:
                 # axis1 is the "row" index for that subsystem
                 # axis2 is the "column" index, which sits n dims later
@@ -190,11 +197,10 @@ class QuantumObject:
                 n -= 1
 
         # 5) Reassemble the “kept” dims into a flat matrix
-        dims_keep = [dims[i] for i in sorted(keep_set)]
+        dims_keep = [dims[i] for i in sorted(keep)]
         new_dim = int(np.prod(dims_keep)) if dims_keep else 1
-        rho_t.reshape((new_dim, new_dim))
 
-        return QuantumObject(rho_t)
+        return QuantumObject(rho_t.reshape((new_dim, new_dim)))
 
     def norm(self, order: int | Literal["fro", "tr"] = 1) -> float:
         """

--- a/src/qilisdk/analog/quantum_objects.py
+++ b/src/qilisdk/analog/quantum_objects.py
@@ -166,7 +166,7 @@ class QuantumObject:
         rho = self.dense
 
         # 1) Basic checks for dims
-        total_dim = np.prod(dims)
+        total_dim = int(np.prod(dims))
         if rho.shape != (total_dim, total_dim):
             raise ValueError("Dimension mismatch between dims and QuantumObject shape (rho.shape != prod(dims))")
         if any(d <= 0 for d in dims):


### PR DESCRIPTION
## PENDING TODOs: 
- [x] Contrast code vs Deepseek, Copilot and ChatGPT-mini-high ✅
- [x] Performance comparison against old implementation (by @amirazzam2000), more info on: https://github.com/qilimanjaro-tech/qilisdk/pull/37#issuecomment-2886670640

## Problems the original code had, which now work:

1. Running out of einsum labels
string.ascii_letters gives you 52 distinct single-character labels. But you need 2·n labels for an n-partite system. If n > 26, you’ll exhaust the iterator (or violate numpy’s one-char-per-axis requirement) and get a cryptic error.

2. No validation of keep
You should check that every index in keep lies in [0, len(dims)) and that there aren’t duplicates. Otherwise you could index out of range or double-count.

3. Minor type/coercion nit
np.prod(dims) can return a numpy scalar. It’s safer to do
`total_dim = int(np.prod(dims))`
so that your shape‐check and reshape calls can’t trip over dtype mismatches.

4. Didn't work for Bra's and Ket's

5. (GPT msg): Mismatched ordering when rebuilding the output shape. You collect the “kept” letters in ascending subsystem-index order, but then do
`dims_keep = [dims[i] for i in keep]`
If the user passes keep = [2,0], the einsum output indices will be in the order (0,2) but you’ll build dims_keep = [dims[2], dims[0]]. That will mis‐reshape your tensor.
