### PR TITLE
Removing manual installation of CUDAQ from Github Actions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -42,10 +42,7 @@ jobs:
 
       - name: Install the project
         run: uv sync --all-groups --all-extras
-
-      - name: Explicit installation of cudaq
-        run: uv pip install cudaq==0.10.0
-
+        
       - name: Ruff
         run: uv run ruff check --output-format=github .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,5 @@ jobs:
       - name: Install qilisdk
         run: uv sync --all-groups --all-extras
 
-      - name: Explicit installation of cudaq
-        run: uv pip install cudaq==0.10.0
-
       - name: Run tests
         run: uv run pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ wheels/
 # Folder for storing user files
 .tmp
 
-# VS Code workspace settings
+# development environment files
 .vscode
+.coverage

--- a/changes/40.bugfix.md
+++ b/changes/40.bugfix.md
@@ -1,0 +1,1 @@
+- Removing the manual installation of CudaQ from the github workflows for the tests and the code quality.


### PR DESCRIPTION
removing
```
- name: Explicit installation of cudaq
        run: uv pip install cudaq==0.10.0
```

from `code_quality.yml` and `test.yml`.