### PR TITLE
[ALGP-298] Rename QaaS to SpeQtrum

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/README.md
+++ b/README.md
@@ -149,23 +149,24 @@ print("Optimal cost:", result.optimal_cost)
 print("Optimal Parameters:", result.optimal_parameters)
 ```
 
-### Quantum-as-a-Service (QaaS)
+### SpeQtrum
 
-QiliSDK now includes a draft backend for interfacing with Qilimanjaro's QaaS platform. This module supports secure login and a unified interface for both digital circuits and analog evolutions:
+QiliSDK includes a client for interacting with Qilimanjaro's SpeQtrum platform. This module supports secure login and a unified interface for both digital circuits and analog evolutions:
 
 ```python
-from qilisdk.extras import QaaSBackend
+from qilisdk.speqtrum import SpeQtrum
+from qilisdk.functionals import Sampling
 
 # Login to QaaSBackend with credentials (or use environment variables)
 # This only needs to be run once.
-QaaSBackend.login(username="your_username", apikey="your_apikey")
+SpeQtrum.login(username="your_username", apikey="your_apikey")
 
 # Instantiate QaaSBackend
-qaas_backend = QaaSBackend()
+client = SpeQtrum()
 
 # Execute a pre-built circuit (see Digital Quantum Circuits section)
-results = qaas_backend.execute(circuit)
-print("QaaS Simulation Results:", results)
+results = client.submit(Sampling(circuit, 1000))
+print("Results:", results)
 ```
 
 ### CUDA-Accelerated Simulation

--- a/changes/59.misc.md
+++ b/changes/59.misc.md
@@ -1,0 +1,1 @@
+Renamed all occurrences of QaaS to **SpeQtrum** in line with Qilimanjaro’s official Quantum-as-a-Service platform branding.

--- a/docs/fundamentals/analog.rst
+++ b/docs/fundamentals/analog.rst
@@ -1,4 +1,4 @@
-Analog Module
+Analog
 =============
 
 The :mod:`~qilisdk.analog` module in Qili SDK enables the construction and simulation of analog quantum systems. It is composed of the following core components:

--- a/docs/fundamentals/common.rst
+++ b/docs/fundamentals/common.rst
@@ -1,4 +1,4 @@
-Common Module
+Common
 =============
 
 The :mod:`~qilisdk.common` module in the Qili SDK provides a collection of utilities useful for building quantum algorithms and performing simulations. It consists of the following primary components:

--- a/docs/fundamentals/digital.rst
+++ b/docs/fundamentals/digital.rst
@@ -1,4 +1,4 @@
-Digital Module
+Digital
 ==============
 
 The :mod:`~qilisdk.digital` module in the Qili SDK facilitates the construction and simulation of digital quantum systems. It is composed of the following primary components:

--- a/docs/fundamentals/speqtrum.rst
+++ b/docs/fundamentals/speqtrum.rst
@@ -1,8 +1,8 @@
-Quantum as a Service (QaaS)
+SpeQtrum
 ====
 
-The :mod:`~qilisdk.qaas` module provides a synchronous client for the Qilimanjaro QaaS REST API via the
-:class:`~qilisdk.qaas.qaas.QaaS` class. It handles authentication, device selection, job management, and submission
+The :mod:`~qilisdk.speqtrum` module provides a synchronous client for the Qilimanjaro SpeQtrum API via the
+:class:`~qilisdk.speqtrum.speqtrum.SpeQtrum` class. It handles authentication, device selection, job management, and submission
 of quantum functionals (Sampling, TimeEvolution) and VQE workflows to remote hardware or simulators.
 
 Authentication
@@ -14,14 +14,14 @@ Before making any API calls, you must authenticate and cache credentials in your
 
 .. code-block:: python
 
-    from qilisdk.qaas import QaaS
+    from qilisdk.speqtrum import SpeQtrum
 
     # You can provide credentials directly...
-    success = QaaS.login(username="alice", apikey="MY_SECRET_KEY")
+    success = SpeQtrum.login(username="alice", apikey="MY_SECRET_KEY")
 
     # ...or omit them to read from environment variables:
-    #   QILISDK_QAAS_USERNAME and QILISDK_QAAS_APIKEY
-    success = QaaS.login()
+    #   QILISDK_SPEQTRUM_USERNAME and QILISDK_SPEQTRUM_APIKEY
+    success = SpeQtrum.login()
 
     if not success:
         raise RuntimeError("Authentication failed")
@@ -30,9 +30,9 @@ Before making any API calls, you must authenticate and cache credentials in your
 
 .. code-block:: python
 
-    from qilisdk.qaas import QaaS
+    from qilisdk.speqtrum import SpeQtrum
 
-    QaaS.logout()
+    SpeQtrum.logout()
     # Credentials removed from keyring
 
 Device Management
@@ -44,7 +44,7 @@ Once authenticated, you can list available devices, select one for subsequent jo
 
 .. code-block:: python
 
-    client = QaaS()
+    client = SpeQtrum()
     devices = client.list_devices()
     for dev in devices:
         print(f"{dev.id}: {dev.name} ({dev.status})")
@@ -92,7 +92,7 @@ You can list existing jobs, inspect their details, and wait for completion.
 Functional Submission
 ---------------------
 
-Use :meth:`~qilisdk.qaas.qaas.QaaS.submit` to dispatch a :class:`~qilisdk.functionals.sampling.Sampling` or :class:`~qilisdk.functionals.time_evolution.TimeEvolution` functional.
+Use :meth:`~qilisdk.speqtrum.speqtrum.SpeQtrum.submit` to dispatch a :class:`~qilisdk.functionals.sampling.Sampling` or :class:`~qilisdk.functionals.time_evolution.TimeEvolution` functional.
 
 .. code-block:: python
 
@@ -124,7 +124,7 @@ Use :meth:`~qilisdk.qaas.qaas.QaaS.submit` to dispatch a :class:`~qilisdk.functi
 Variational Quantum Eigensolver (VQE)
 -------------------------------------
 
-For end-to-end VQE workflows, use :meth:`~qilisdk.qaas.qaas.QaaS.submit_vqe`:
+For end-to-end VQE workflows, use :meth:`~qilisdk.speqtrum.speqtrum.SpeQtrum.submit_vqe`:
 
 **Parameters**
 
@@ -137,7 +137,6 @@ For end-to-end VQE workflows, use :meth:`~qilisdk.qaas.qaas.QaaS.submit_vqe`:
 
 .. code-block:: python
 
-    from qilisdk.qaas import QaaS
     from qilisdk.digital.vqe import VQE
     from qilisdk.optimizers import COBYLA
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ QiliSDK
 
 .. rst-class:: lead center
 
-Welcome to **QiliSDK**, a unified Python framework for developing, simulating, and running both digital and analog quantum algorithms across a variety of backends (CPU, GPU, and Qilimanjaro's QaaS). Its modular design makes it easy to prototype circuits, build Hamiltonians, design variational workflows, and deploy them on local or remote quantum simulators and hardware.
+Welcome to **QiliSDK**, a unified Python framework for developing, simulating, and running both digital and analog quantum algorithms across a variety of backends (QPU, CPU, GPU) and Qilimanjaro's SpeQtrum. Its modular design makes it easy to prototype circuits, build Hamiltonians, design variational workflows, and deploy them on local or remote quantum simulators and hardware.
 
 .. grid:: 2
 
@@ -40,7 +40,7 @@ Welcome to **QiliSDK**, a unified Python framework for developing, simulating, a
    fundamentals/common
    fundamentals/functionals
    fundamentals/backends
-   fundamentals/qaas
+   fundamentals/speqtrum
 
 .. toctree::
    :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "qilisdk"
 version = "0.1.5"
-description = "qilisdk is a Python framework for writing digital and analog quantum algorithms and executing them across multiple quantum backends. Its modular design streamlines the development process and enables easy integration with a variety of quantum platforms."
+description = "QiliSDK is a Python framework for writing digital and analog quantum algorithms and executing them across multiple quantum backends. Its modular design streamlines the development process and enables easy integration with a variety of quantum platforms."
 readme = "README.md"
 authors = [{name = "Qilimanjaro Quantum Tech", email = "info@qilimanjaro.tech"}]
 requires-python = ">=3.10"
@@ -39,7 +39,7 @@ cuda = [
     "cutensornet-cu12==2.7.0",
     "custatevec-cu12==1.8.0"
 ]
-qaas = [
+speqtrum = [
     "httpx>=0.28.1",
     "keyring>=25.6.0",
     "keyrings-alt>=5.0.2",
@@ -183,7 +183,7 @@ exclude = ["\\.ipynb$"]
 markers = [
     "core: tests that only exercise the core library",
     "cuda: tests that require the cuda extra",
-    "qaas: tests that require the qaas extra"
+    "speqtrum: tests that require the speqtrum extra"
 ]
 
 [tool.towncrier]

--- a/src/qilisdk/settings.py
+++ b/src/qilisdk/settings.py
@@ -28,21 +28,21 @@ class QiliSDKSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="qilisdk_", env_file=".env", env_file_encoding="utf-8")
 
-    qaas_username: str | None = Field(
+    speqtrum_username: str | None = Field(
         default=None,
-        description="QaaS username used for authentication. [env: QILISDK_QAAS_USERNAME]",
+        description="SpeQtrum username used for authentication. [env: QILISDK_SPEQTRUM_USERNAME]",
     )
-    qaas_apikey: str | None = Field(
+    speqtrum_apikey: str | None = Field(
         default=None,
-        description="QaaS API key associated with the user account. [env: QILISDK_QAAS_APIKEY]",
+        description="SpeQtrum API key associated with the user account. [env: QILISDK_SPEQTRUM_APIKEY]",
     )
-    qaas_api_url: str = Field(
+    speqtrum_api_url: str = Field(
         default="https://qilimanjaro.ddns.net/public-api/api/v1",
-        description="Base URL of the QaaS API endpoint. [env: QILISDK_QAAS_API_URL]",
+        description="Base URL of the SpeQtrum API endpoint. [env: QILISDK_SPEQTRUM_API_URL]",
     )
-    qaas_audience: str = Field(
+    speqtrum_audience: str = Field(
         default="urn:qilimanjaro.tech:public-api:beren",
-        description="Audience claim expected in the JWT used for authentication. [env: QILISDK_QAAS_AUDIENCE]",
+        description="Audience claim expected in the JWT used for authentication. [env: QILISDK_SPEQTRUM_AUDIENCE]",
     )
 
 

--- a/src/qilisdk/speqtrum/__init__.py
+++ b/src/qilisdk/speqtrum/__init__.py
@@ -19,12 +19,12 @@ __all__ = []
 
 OPTIONAL_FEATURES: list[OptionalFeature] = [
     OptionalFeature(
-        name="qaas",
+        name="speqtrum",
         dependencies=["httpx", "keyring", "keyrings-alt"],
         symbols=[
-            Symbol(path="qilisdk.qaas.qaas", name="QaaS"),
-            Symbol(path="qilisdk.qaas.qaas_models", name="DeviceStatus"),
-            Symbol(path="qilisdk.qaas.qaas_models", name="DeviceType"),
+            Symbol(path="qilisdk.speqtrum.speqtrum", name="SpeQtrum"),
+            Symbol(path="qilisdk.speqtrum.speqtrum_models", name="DeviceStatus"),
+            Symbol(path="qilisdk.speqtrum.speqtrum_models", name="DeviceType"),
         ],
     ),
 ]

--- a/src/qilisdk/speqtrum/__init__.pyi
+++ b/src/qilisdk/speqtrum/__init__.pyi
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .qaas import QaaS
-from .qaas_models import DeviceStatus, DeviceType
+from .speqtrum import SpeQtrum
+from .speqtrum_models import DeviceStatus, DeviceType
 
-__all__ = ["DeviceStatus", "DeviceType", "QaaS"]
+__all__ = ["DeviceStatus", "DeviceType", "SpeQtrum"]

--- a/src/qilisdk/speqtrum/keyring.py
+++ b/src/qilisdk/speqtrum/keyring.py
@@ -15,9 +15,9 @@
 import keyring
 from pydantic import ValidationError
 
-from .qaas_models import Token
+from .speqtrum_models import Token
 
-KEYRING_IDENTIFIER = "QaaSKeyring"
+KEYRING_IDENTIFIER = "SpeQtrumKeyring"
 
 
 def store_credentials(username: str, token: Token) -> None:

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -26,14 +26,14 @@ from qilisdk.optimizers.optimizer import Optimizer
 from qilisdk.utils.serialization import deserialize, serialize
 
 
-class QaaSModel(BaseModel):
+class SpeQtrumModel(BaseModel):
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, arbitrary_types_allowed=True)
 
 
 class LoginPayload(BaseModel): ...
 
 
-class Token(QaaSModel):
+class Token(SpeQtrumModel):
     """
     Represents the structure of the login response:
     {
@@ -68,7 +68,7 @@ class DeviceType(str, Enum):
     SIMULATOR = "simulator"
 
 
-class Device(QaaSModel):
+class Device(SpeQtrumModel):
     # TODO (vyron): Remove `id: int` when `code` is implemented server-side.
     id: int = Field(...)
     code: str = Field(...)
@@ -86,7 +86,7 @@ class ExecuteType(str, Enum):
     VQE = "vqe"
 
 
-class SamplingPayload(QaaSModel):
+class SamplingPayload(SpeQtrumModel):
     sampling: Sampling = Field(...)
 
     @field_serializer("sampling")
@@ -100,7 +100,7 @@ class SamplingPayload(QaaSModel):
         return v
 
 
-class TimeEvolutionPayload(QaaSModel):
+class TimeEvolutionPayload(SpeQtrumModel):
     time_evolution: TimeEvolution = Field(...)
 
     @field_serializer("time_evolution")
@@ -114,7 +114,7 @@ class TimeEvolutionPayload(QaaSModel):
         return v
 
 
-class VQEPayload(QaaSModel):
+class VQEPayload(SpeQtrumModel):
     vqe: VQE = Field(...)
     optimizer: Optimizer = Field(...)
     nshots: int = Field(...)
@@ -141,14 +141,14 @@ class VQEPayload(QaaSModel):
         return v
 
 
-class ExecutePayload(QaaSModel):
+class ExecutePayload(SpeQtrumModel):
     type: ExecuteType = Field(...)
     sampling_payload: SamplingPayload | None = None
     time_evolution_payload: TimeEvolutionPayload | None = None
     vqe_payload: VQEPayload | None = None
 
 
-class ExecuteResult(QaaSModel):
+class ExecuteResult(SpeQtrumModel):
     type: ExecuteType = Field(...)
     sampling_result: SamplingResult | None = None
     time_evolution_result: TimeEvolutionResult | None = None
@@ -195,7 +195,7 @@ class JobStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
-class JobId(QaaSModel):
+class JobId(SpeQtrumModel):
     """Handle/reference you normally get back immediately after `POST /execute`."""
 
     id: int = Field(...)

--- a/tests/speqtrum/test_keyring.py
+++ b/tests/speqtrum/test_keyring.py
@@ -2,8 +2,8 @@
 import keyring
 from pydantic import ValidationError
 
-from qilisdk.qaas.keyring import KEYRING_IDENTIFIER, delete_credentials, load_credentials, store_credentials
-from qilisdk.qaas.qaas_models import Token
+from qilisdk.speqtrum.keyring import KEYRING_IDENTIFIER, delete_credentials, load_credentials, store_credentials
+from qilisdk.speqtrum.speqtrum_models import Token
 
 
 class FakeToken:

--- a/uv.lock
+++ b/uv.lock
@@ -2284,15 +2284,15 @@ cuda = [
     { name = "custatevec-cu12" },
     { name = "cutensornet-cu12" },
 ]
-qaas = [
-    { name = "httpx" },
-    { name = "keyring" },
-    { name = "keyrings-alt" },
-]
 qutip = [
     { name = "matplotlib" },
     { name = "qutip" },
     { name = "qutip-qip" },
+]
+speqtrum = [
+    { name = "httpx" },
+    { name = "keyring" },
+    { name = "keyrings-alt" },
 ]
 
 [package.dev-dependencies]
@@ -2327,9 +2327,9 @@ requires-dist = [
     { name = "custatevec-cu12", marker = "extra == 'cuda'", specifier = "==1.8.0" },
     { name = "cutensornet-cu12", marker = "extra == 'cuda'", specifier = "==2.7.0" },
     { name = "dill", specifier = ">=0.3.9" },
-    { name = "httpx", marker = "extra == 'qaas'", specifier = ">=0.28.1" },
-    { name = "keyring", marker = "extra == 'qaas'", specifier = ">=25.6.0" },
-    { name = "keyrings-alt", marker = "extra == 'qaas'", specifier = ">=5.0.2" },
+    { name = "httpx", marker = "extra == 'speqtrum'", specifier = ">=0.28.1" },
+    { name = "keyring", marker = "extra == 'speqtrum'", specifier = ">=25.6.0" },
+    { name = "keyrings-alt", marker = "extra == 'speqtrum'", specifier = ">=5.0.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "matplotlib", marker = "extra == 'qutip'", specifier = ">=3.10.3" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2340,7 +2340,7 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18.10" },
     { name = "scipy", specifier = ">=1.15.3" },
 ]
-provides-extras = ["cuda", "qaas", "qutip"]
+provides-extras = ["cuda", "speqtrum", "qutip"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Renamed all occurrences of QaaS to **SpeQtrum** in line with Qilimanjaro’s official Quantum-as-a-Service platform branding.