### PR TITLE
[ALGP-299] Add VSCode Settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "PKief.material-icon-theme",
+    "PKief.material-product-icons"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    // Use the Material themes
+    "workbench.iconTheme": "material-icon-theme",
+    "workbench.productIconTheme": "material-product-icons",
+    // QiliSDK-specific folder icons
+    "material-icon-theme.folders.associations": {
+        "common": "app",
+        "analog": "functions",
+        "digital": "core",
+        "qilisdk": "src",
+        "functionals": "organism",
+        "optimizers": "target",
+        "speqtrum": "cloudflare"
+    },
+}


### PR DESCRIPTION
Committed `.vscode/settings.json` and `extensions.json` to pin the **Material Product Icons** theme (`workbench.productIconTheme`), recommend the `PKief.material-product-icons` extension, and define custom folder-icon overrides for the Material file/folder theme (`material-icon-theme.folders.associations`): `common → app`, `analog → functions`, `digital → core`, `qilisdk → src`, `functionals → organism`, `optimizers → target`, and `speqtrum → cloudflare`. These settings ensure everyone sees consistent UI and repo-specific icons when opening the project in VS Code.
