### PR TITLE
[ALGP-309] Add Observable Cost Function

### DIFF
--- a/changes/68.feature.md
+++ b/changes/68.feature.md
@@ -2,6 +2,9 @@ Adding Observable cost function that now could be used with VariationalPrograms.
 
 You can construct an Observable cost function by using ``Hamiltonian``, ``PauliOperators``, or ``QuantumObjects``.
 
+The cost is the expected value of the observable given the final state after the simulation. 
+
+
 ```python
 from qilisdk.analog import Z, PauliZ
 from qilisdk.common import QuantumObject
@@ -19,4 +22,27 @@ cost_function = ObservableCostFunction(PauliZ(0))
 ## or
 
 cost_function = ObservableCostFunction(QuantumObject(np.array([[1, 0], [0, -1]])))
+```
+
+Usage: 
+```python
+from qilisdk.analog import Z
+from qilisdk.common import ket, tensor_prod
+from qilisdk.cost_functions import ObservableCostFunction
+from qilisdk.functionals import TimeEvolutionResult
+
+n = 2
+
+H = sum(Z(i) for i in range(n))
+
+ocf = ObservableCostFunction(H)
+
+te_results = TimeEvolutionResult(
+    final_expected_values=np.array([[-0.9, 0]]),
+    expected_values=None,
+    final_state=tensor_prod([ket(1), ket(1)]),
+    intermediate_states=None,
+)
+cost = ocf.compute_cost(te_results)
+# Output: -2
 ```

--- a/changes/68.feature.md
+++ b/changes/68.feature.md
@@ -1,0 +1,22 @@
+Adding Observable cost function that now could be used with VariationalPrograms. 
+
+You can construct an Observable cost function by using ``Hamiltonian``, ``PauliOperators``, or ``QuantumObjects``.
+
+```python
+from qilisdk.analog import Z, PauliZ
+from qilisdk.common import QuantumObject
+from qilisdk.cost_functions import ObservableCostFunction
+import numpy as np
+
+
+h = Z(0) + 2 * Z(1)
+cost_function = ObservableCostFunction(h)
+
+## or
+
+cost_function = ObservableCostFunction(PauliZ(0))
+
+## or
+
+cost_function = ObservableCostFunction(QuantumObject(np.array([[1, 0], [0, -1]])))
+```

--- a/src/qilisdk/analog/__init__.py
+++ b/src/qilisdk/analog/__init__.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .hamiltonian import Hamiltonian, I, X, Y, Z
+from .hamiltonian import Hamiltonian, I, PauliI, PauliX, PauliY, PauliZ, X, Y, Z
 from .schedule import Schedule
 
-__all__ = [
-    "Hamiltonian",
-    "I",
-    "Schedule",
-    "X",
-    "Y",
-    "Z",
-]
+__all__ = ["Hamiltonian", "I", "PauliI", "PauliX", "PauliY", "PauliZ", "Schedule", "X", "Y", "Z"]

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -112,7 +112,6 @@ class QutipBackend(Backend):
         measurements = sorted(measurements_set)
 
         sim = CircuitSimulator(qutip_circuit)
-        # sim.initialize(init_state)
 
         res = sim.run_statistics(init_state)  # runs the full circuit for one shot
         _bits = res.cbits  # classical measurement bits

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Callable, Type, TypeVar
 
 import numpy as np
 from loguru import logger
-from qutip import Qobj, basis, ket2dm, mesolve, tensor
+from qutip import Qobj, basis, mesolve, tensor
 from qutip_qip.circuit import CircuitSimulator, QubitCircuit
 from qutip_qip.operations import RX as q_RX
 from qutip_qip.operations import RY as q_RY

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Callable, Type, TypeVar
 
 import numpy as np
 from loguru import logger
-from qutip import Qobj, basis, mesolve, tensor
+from qutip import Qobj, basis, ket2dm, mesolve, tensor
 from qutip_qip.circuit import CircuitSimulator, QubitCircuit
 from qutip_qip.operations import RX as q_RX
 from qutip_qip.operations import RY as q_RY
@@ -96,6 +96,7 @@ class QutipBackend(Backend):
 
         Returns:
             DigitalResult: A result object containing the measurement samples and computed probabilities.
+
         """
         logger.info("Executing Sampling (shots={})", functional.nshots)
         qutip_circuit = self._get_qutip_circuit(functional.circuit)
@@ -111,12 +112,15 @@ class QutipBackend(Backend):
         measurements = sorted(measurements_set)
 
         sim = CircuitSimulator(qutip_circuit)
-        sim.initialize(init_state)
+        # sim.initialize(init_state)
 
         res = sim.run_statistics(init_state)  # runs the full circuit for one shot
         _bits = res.cbits  # classical measurement bits
         bits = []
         probs = res.probabilities
+
+        if sum(probs) != 1:
+            probs /= sum(probs)
 
         if len(measurements) > 0:
             for b in _bits:

--- a/src/qilisdk/cost_functions/__init__.py
+++ b/src/qilisdk/cost_functions/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from .model_cost_function import ModelCostFunction
+from .observable_cost_function import ObservableCostFunction
 
-__all__ = [
-    "ModelCostFunction",
-]
+__all__ = ["ModelCostFunction", "ObservableCostFunction"]

--- a/src/qilisdk/cost_functions/model_cost_function.py
+++ b/src/qilisdk/cost_functions/model_cost_function.py
@@ -30,7 +30,11 @@ if TYPE_CHECKING:
 class ModelCostFunction(CostFunction):
     def __init__(self, model: Model) -> None:
         super().__init__()
-        self.model = model
+        self._model = model
+
+    @property
+    def model(self) -> Model:
+        return self._model
 
     def _compute_cost_time_evolution(self, results: TimeEvolutionResult) -> Number:
         if results.final_state is None:

--- a/src/qilisdk/cost_functions/observable_cost_function.py
+++ b/src/qilisdk/cost_functions/observable_cost_function.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from qilisdk.common.quantum_objects import QuantumObject, expect_val, ket, tensor_prod
+from qilisdk.cost_functions.cost_function import CostFunction
+
+if TYPE_CHECKING:
+    from qilisdk.common.variables import Number
+    from qilisdk.functionals.sampling_result import SamplingResult
+    from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
+
+
+class ObservableCostFunction(CostFunction):
+    def __init__(self, observable: QuantumObject) -> None:
+        super().__init__()
+        self._observable = observable
+
+    @property
+    def observable(self) -> QuantumObject:
+        return self._observable
+
+    def _compute_cost_time_evolution(self, results: TimeEvolutionResult) -> Number:
+        if results.final_state is None:
+            raise ValueError(
+                "can't compute cost using Observables from time evolution results when the state is not provided."
+            )
+        total_cost = complex(np.real_if_close(expect_val(self._observable, results.final_state)))
+        if total_cost.imag == 0:
+            return total_cost.real
+        return total_cost
+
+    def _compute_cost_sampling(self, results: SamplingResult) -> Number:
+        total_cost = complex(0.0)
+        nqubits = self._observable.nqubits
+        for sample, prob in results.get_probabilities():
+            state = tensor_prod([ket(int(i)) for i in sample])
+            if nqubits != state.nqubits:
+                raise ValueError(
+                    f"The samples provided have {state.nqubits} qubits but the observable has {nqubits} qubits"
+                )
+            evaluate_results = complex(np.real_if_close(expect_val(self._observable, state)))
+            total_cost += evaluate_results * prob
+
+        if total_cost.imag == 0:
+            return total_cost.real
+        return total_cost

--- a/src/qilisdk/cost_functions/observable_cost_function.py
+++ b/src/qilisdk/cost_functions/observable_cost_function.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-from os import name
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/src/qilisdk/cost_functions/observable_cost_function.py
+++ b/src/qilisdk/cost_functions/observable_cost_function.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 from __future__ import annotations
 
+from os import name
 from typing import TYPE_CHECKING
 
 import numpy as np
 
+from qilisdk.analog.hamiltonian import Hamiltonian, PauliOperator
 from qilisdk.common.quantum_objects import QuantumObject, expect_val, ket, tensor_prod
 from qilisdk.cost_functions.cost_function import CostFunction
 
@@ -27,9 +29,18 @@ if TYPE_CHECKING:
 
 
 class ObservableCostFunction(CostFunction):
-    def __init__(self, observable: QuantumObject) -> None:
+    def __init__(self, observable: QuantumObject | Hamiltonian | PauliOperator) -> None:
         super().__init__()
-        self._observable = observable
+        if isinstance(observable, QuantumObject):
+            self._observable = observable
+        elif isinstance(observable, Hamiltonian):
+            self._observable = QuantumObject(observable.to_matrix())
+        elif isinstance(observable, PauliOperator):
+            self._observable = QuantumObject(observable.matrix)
+        else:
+            raise ValueError(
+                f"Observable needs to be of type QuantumObject, Hamiltonian, or PauliOperator but {type(observable)} was provided"
+            )
 
     @property
     def observable(self) -> QuantumObject:

--- a/tests/cost_functions/test_observable_cost_function.py
+++ b/tests/cost_functions/test_observable_cost_function.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pytest
+
+from qilisdk.analog.hamiltonian import Z
+from qilisdk.common import Model
+from qilisdk.common.model import ObjectiveSense
+from qilisdk.common.quantum_objects import QuantumObject, bra, ket, tensor_prod
+from qilisdk.common.variables import EQ, BinaryVariable
+from qilisdk.cost_functions.observable_cost_function import ObservableCostFunction
+from qilisdk.functionals.sampling_result import SamplingResult
+from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
+
+
+def test_compute_cost_time_evolution():
+    n = 2
+
+    H = sum(Z(i) for i in range(n))
+
+    ocf = ObservableCostFunction(H)
+
+    te_results = TimeEvolutionResult(
+        final_expected_values=np.array([[-0.9, 0]]),
+        expected_values=None,
+        final_state=tensor_prod([ket(1), ket(1)]),
+        intermediate_states=None,
+    )
+    cost = ocf.compute_cost(te_results)
+
+    assert cost == -2
+
+    te_results = TimeEvolutionResult(
+        final_expected_values=np.array([[-0.9, 0]]),
+        expected_values=None,
+        final_state=tensor_prod([ket(1), ket(1)]).to_density_matrix(),
+        intermediate_states=None,
+    )
+    cost = ocf.compute_cost(te_results)
+
+    assert cost == -2
+
+    te_results = TimeEvolutionResult(
+        final_expected_values=np.array([[-0.9, 0]]),
+        expected_values=None,
+        final_state=None,
+        intermediate_states=None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"can't compute cost using Observables from time evolution results when the state is not provided.",
+    ):
+        cost = ocf.compute_cost(te_results)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Observable needs to be of type QuantumObject, Hamiltonian, or PauliOperator but <class 'qilisdk.functionals.time_evolution_result.TimeEvolutionResult'> was provided",
+    ):
+        ObservableCostFunction(te_results)
+
+
+def test_compute_cost_sampling():
+    n = 2
+
+    H = sum(Z(i) for i in range(n))
+
+    ocf = ObservableCostFunction(H)
+
+    te_results = SamplingResult(nshots=100, samples={"11": 100})
+    cost = ocf.compute_cost(te_results)
+
+    assert cost == -2
+
+    te_results = SamplingResult(nshots=100, samples={"0": 100})
+
+    with pytest.raises(ValueError, match=r"The samples provided have 1 qubits but the observable has 2 qubits"):
+        cost = ocf.compute_cost(te_results)
+
+    te_results = SamplingResult(nshots=100, samples={"11": 50, "00": 50})
+    cost = ocf.compute_cost(te_results)
+
+    assert cost == 0

--- a/tests/cost_functions/test_observable_cost_function.py
+++ b/tests/cost_functions/test_observable_cost_function.py
@@ -15,10 +15,7 @@ import numpy as np
 import pytest
 
 from qilisdk.analog.hamiltonian import Z
-from qilisdk.common import Model
-from qilisdk.common.model import ObjectiveSense
-from qilisdk.common.quantum_objects import QuantumObject, bra, ket, tensor_prod
-from qilisdk.common.variables import EQ, BinaryVariable
+from qilisdk.common.quantum_objects import ket, tensor_prod
 from qilisdk.cost_functions.observable_cost_function import ObservableCostFunction
 from qilisdk.functionals.sampling_result import SamplingResult
 from qilisdk.functionals.time_evolution_result import TimeEvolutionResult


### PR DESCRIPTION
Adding Observable cost function that now could be used with VariationalPrograms. 

You can construct an Observable cost function by using ``Hamiltonian``, ``PauliOperators``, or ``QuantumObjects``.

The cost is the expected value of the observable given the final state after the simulation. 


```python
from qilisdk.analog import Z, PauliZ
from qilisdk.common import QuantumObject
from qilisdk.cost_functions import ObservableCostFunction
import numpy as np


h = Z(0) + 2 * Z(1)
cost_function = ObservableCostFunction(h)

## or

cost_function = ObservableCostFunction(PauliZ(0))

## or

cost_function = ObservableCostFunction(QuantumObject(np.array([[1, 0], [0, -1]])))
```

Usage: 
```python
from qilisdk.analog import Z
from qilisdk.common import ket, tensor_prod
from qilisdk.cost_functions import ObservableCostFunction
from qilisdk.functionals import TimeEvolutionResult

n = 2

H = sum(Z(i) for i in range(n))

ocf = ObservableCostFunction(H)

te_results = TimeEvolutionResult(
    final_expected_values=np.array([[-0.9, 0]]),
    expected_values=None,
    final_state=tensor_prod([ket(1), ket(1)]),
    intermediate_states=None,
)
cost = ocf.compute_cost(te_results)
# Output: -2
```