### PR TITLE
adding basic state tomography

### DIFF
--- a/changes/70.feature.md
+++ b/changes/70.feature.md
@@ -1,0 +1,15 @@
+Adding ``StateTomography``functional. This functional can be used to retrieve the full reconstructed state vector at the end of the quantum circuit. 
+
+Example usage: 
+```python
+from qilisdk.digital import *
+from qilisdk.functionals import StateTomography
+from qilisdk.backends import CudaBackend
+
+circuit = Circuit(2)
+circuit.add(H(0))
+circuit.add(CNOT(0, 1))
+
+backend = CudaBackend()
+backend.execute(StateTomography(circuit))
+```

--- a/src/qilisdk/backends/backend.py
+++ b/src/qilisdk/backends/backend.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar, cast, overload
 
 from qilisdk.functionals.functional_result import FunctionalResult
 from qilisdk.functionals.sampling import Sampling
+from qilisdk.functionals.state_tomography import StateTomography
 from qilisdk.functionals.time_evolution import TimeEvolution
 from qilisdk.functionals.variational_program import VariationalProgram
 from qilisdk.functionals.variational_program_result import VariationalProgramResult
@@ -25,6 +26,7 @@ from qilisdk.functionals.variational_program_result import VariationalProgramRes
 if TYPE_CHECKING:
     from qilisdk.functionals.functional import Functional, PrimitiveFunctional
     from qilisdk.functionals.sampling_result import SamplingResult
+    from qilisdk.functionals.state_tomography_result import StateTomographyResult
     from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 
 TResult = TypeVar("TResult", bound=FunctionalResult)
@@ -36,6 +38,7 @@ class Backend(ABC):
             Sampling: lambda f: self._execute_sampling(cast("Sampling", f)),
             TimeEvolution: lambda f: self._execute_time_evolution(cast("TimeEvolution", f)),
             VariationalProgram: lambda f: self._execute_variational_program(cast("VariationalProgram", f)),
+            StateTomography: lambda f: self._execute_state_tomography(cast("StateTomography", f)),
         }
 
     @overload
@@ -43,6 +46,9 @@ class Backend(ABC):
 
     @overload
     def execute(self, functional: TimeEvolution) -> TimeEvolutionResult: ...
+
+    @overload
+    def execute(self, functional: StateTomography) -> StateTomographyResult: ...
 
     @overload
     def execute(self, functional: VariationalProgram[Sampling]) -> VariationalProgramResult[SamplingResult]: ...
@@ -69,6 +75,9 @@ class Backend(ABC):
         raise NotImplementedError(f"{type(self).__qualname__} has no Sampling implementation")
 
     def _execute_time_evolution(self, functional: TimeEvolution) -> TimeEvolutionResult:
+        raise NotImplementedError(f"{type(self).__qualname__} has no TimeEvolution implementation")
+
+    def _execute_state_tomography(self, functional: StateTomography) -> StateTomographyResult:
         raise NotImplementedError(f"{type(self).__qualname__} has no TimeEvolution implementation")
 
     def _execute_variational_program(

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -29,13 +29,13 @@ from qilisdk.common.qtensor import QTensor, ket, tensor_prod
 from qilisdk.digital.exceptions import UnsupportedGateError
 from qilisdk.digital.gates import RX, RY, RZ, U1, U2, U3, Adjoint, BasicGate, Controlled, H, M, S, T, X, Y, Z
 from qilisdk.functionals.sampling_result import SamplingResult
-from qilisdk.functionals.state_tomography import StateTomography
 from qilisdk.functionals.state_tomography_result import StateTomographyResult
 from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 
 if TYPE_CHECKING:
     from qilisdk.digital.circuit import Circuit
     from qilisdk.functionals.sampling import Sampling
+    from qilisdk.functionals.state_tomography import StateTomography
     from qilisdk.functionals.time_evolution import TimeEvolution
 
 

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -210,6 +210,18 @@ class CudaBackend(Backend):
     def _execute_state_tomography(
         self, functional: StateTomography, initial_state: QTensor | None = None, tol: float = -1e12
     ) -> StateTomographyResult:
+        """execute a state tomography protocol.
+
+        Args:
+            functional (StateTomography): the state tomography functional.
+            initial_state (QTensor | None, optional): the initial state of the circuit. Defaults to None.
+                NOTE: this is only used for the quantum reservoir and is not a public attribute.
+            tol (float, optional): the tolerance when computing if the state is positive semi-definite. Defaults to -1e12.
+                TODO (ameer): Move this somewhere else -> will do that in the reservoir pr.
+
+        Returns:
+            StateTomographyResult: the final results of the state tomography
+        """
         logger.info("Executing state tomography")
         self._apply_digital_simulation_method()
         kernel = self._get_cuda_kernel(functional.circuit, initial_state, ignore_measurement=True)

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from itertools import product
 from typing import TYPE_CHECKING, Callable, Type, TypeVar
 
 import cudaq
@@ -24,10 +25,12 @@ from loguru import logger
 
 from qilisdk.analog.hamiltonian import Hamiltonian, PauliI, PauliOperator, PauliX, PauliY, PauliZ
 from qilisdk.backends.backend import Backend
-from qilisdk.common.qtensor import QTensor
+from qilisdk.common.qtensor import QTensor, ket, tensor_prod
 from qilisdk.digital.exceptions import UnsupportedGateError
 from qilisdk.digital.gates import RX, RY, RZ, U1, U2, U3, Adjoint, BasicGate, Controlled, H, M, S, T, X, Y, Z
 from qilisdk.functionals.sampling_result import SamplingResult
+from qilisdk.functionals.state_tomography import StateTomography
+from qilisdk.functionals.state_tomography_result import StateTomographyResult
 from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 
 if TYPE_CHECKING:
@@ -131,21 +134,7 @@ class CudaBackend(Backend):
     def _execute_sampling(self, functional: Sampling) -> SamplingResult:
         logger.info("Executing Sampling (shots={})", functional.nshots)
         self._apply_digital_simulation_method()
-        kernel = cudaq.make_kernel()
-        qubits = kernel.qalloc(functional.circuit.nqubits)
-
-        for gate in functional.circuit.gates:
-            if isinstance(gate, Controlled):
-                self._handle_controlled(kernel, gate, qubits[gate.control_qubits[0]], qubits[gate.target_qubits[0]])
-            elif isinstance(gate, Adjoint):
-                self._handle_adjoint(kernel, gate, qubits[gate.target_qubits[0]])
-            elif isinstance(gate, M):
-                self._handle_M(kernel, gate, functional.circuit, qubits)
-            else:
-                handler = self._basic_gate_handlers.get(type(gate), None)
-                if handler is None:
-                    raise UnsupportedGateError
-                handler(kernel, gate, qubits[gate.target_qubits[0]])
+        kernel = self._get_cuda_kernel(functional.circuit)
 
         cudaq_result = cudaq.sample(kernel, shots_count=functional.nshots)
         logger.success("Sampling finished; {} distinct bitstrings", len(cudaq_result))
@@ -163,8 +152,11 @@ class CudaBackend(Backend):
             return lambda t: (functional.schedule.get_coefficient(t.real, key))
 
         cuda_hamiltonian = sum(
-            ScalarOperator(get_schedule(key)) * self._hamiltonian_to_cuda(ham)
-            for key, ham in functional.schedule.hamiltonians.items()
+            (
+                ScalarOperator(get_schedule(key)) * self._hamiltonian_to_cuda(ham)
+                for key, ham in functional.schedule.hamiltonians.items()
+            ),
+            cudaq.SpinOperator.empty(),
         )
 
         logger.trace("Hamiltonian compiled for evolution")
@@ -181,7 +173,6 @@ class CudaBackend(Backend):
                 logger.error("Unsupported observable type {}", observable.__class__.__name__)
                 raise ValueError(f"unsupported observable type of {observable.__class__}")
         logger.trace("Observables compiled for evolution")
-
         evolution_result = evolve(
             hamiltonian=cuda_hamiltonian,
             dimensions=dict.fromkeys(range(functional.schedule.nqubits), 2),
@@ -215,6 +206,90 @@ class CudaBackend(Backend):
                 else None
             ),
         )
+
+    def _execute_state_tomography(
+        self, functional: StateTomography, initial_state: QTensor | None = None, tol: float = -1e12
+    ) -> StateTomographyResult:
+        logger.info("Executing state tomography")
+        self._apply_digital_simulation_method()
+        kernel = self._get_cuda_kernel(functional.circuit, initial_state, ignore_measurement=True)
+
+        operators: list[tuple[type[PauliOperator], ...]] = list(
+            product([PauliI, PauliZ, PauliX, PauliY], repeat=functional.circuit.nqubits)
+        )
+        _identity_tuple: tuple[type[PauliOperator], ...] = tuple(PauliI for _ in range(functional.circuit.nqubits))
+        operators.remove(_identity_tuple)
+
+        def pauli_spin_operator(label: tuple[type[PauliOperator], ...]) -> cudaq.SpinOperatorTerm:
+            # Build a cudaq spin operator like X(0)*Y(1)*Z(2)...
+            ops = {PauliI: spin.i, PauliX: spin.x, PauliY: spin.y, PauliZ: spin.z}
+
+            term = ops[label[0]](0)
+            for idx, ch in enumerate(label[1:], start=1):
+                term *= ops[ch](idx)
+            return term
+
+        # Build list of spin operators once
+        spin_ops = [pauli_spin_operator(op) for op in operators]
+        # 2) Get expectations in one call (broadcasting list of SpinOperators)
+        res_list = cudaq.observe(kernel, spin_ops)
+        # res_list is a list of ObserveResult; pull expectations
+        exps = np.array([r.expectation() for r in res_list], dtype=float)
+
+        # 3) Assemble rho = (1/2^n) sum_P <P> P
+        def pauli_string_matrix(label: tuple[type[PauliOperator], ...]) -> np.ndarray:
+            mats = [ch._MATRIX for ch in label]  # noqa: SLF001
+            out = mats[0]
+            for m in mats[1:]:
+                out = np.kron(out, m)
+            return out
+
+        dim = 2**functional.circuit.nqubits
+        rho = np.identity(dim, dtype=complex)
+        for op, val in zip(operators, exps):
+            aux = val * pauli_string_matrix(op)
+            rho += aux
+        rho /= dim
+
+        # Hermitize & renormalize
+        rho = 0.5 * (rho + rho.conj().T)
+        rho /= np.trace(rho)
+        rho = 0.5 * (rho + rho.conj().T)
+        rho /= np.trace(rho)
+
+        eigvals, eigvecs = np.linalg.eigh(rho)
+        if any(e < tol for e in eigvals):
+            eigvals_clipped = np.clip(eigvals, 0, None)
+            rho = eigvecs @ np.diag(eigvals_clipped) @ eigvecs.conj().T
+            rho /= np.trace(rho)
+
+        logger.success("Sampling finished; ")
+        return StateTomographyResult(state=QTensor(rho))
+
+    def _get_cuda_kernel(
+        self, circuit: Circuit, initial_state: QTensor | None = None, ignore_measurement: bool = False
+    ) -> cudaq.Kernel:
+        kernel = cudaq.make_kernel()
+
+        if initial_state is None:
+            initial_state = tensor_prod([ket(0)] * circuit.nqubits)
+        state = State.from_data(np.array(initial_state.dense, dtype=cudaq.complex()))
+        qubits = kernel.qalloc(state)
+
+        for gate in circuit.gates:
+            if isinstance(gate, Controlled):
+                self._handle_controlled(kernel, gate, qubits[gate.control_qubits[0]], qubits[gate.target_qubits[0]])
+            elif isinstance(gate, Adjoint):
+                self._handle_adjoint(kernel, gate, qubits[gate.target_qubits[0]])
+            elif isinstance(gate, M):
+                if not ignore_measurement:
+                    self._handle_M(kernel, gate, circuit, qubits)
+            else:
+                handler = self._basic_gate_handlers.get(type(gate), None)
+                if handler is None:
+                    raise UnsupportedGateError
+                handler(kernel, gate, qubits[gate.target_qubits[0]])
+        return kernel
 
     def _handle_controlled(
         self, kernel: cudaq.Kernel, gate: Controlled, control_qubit: cudaq.QuakeValue, target_qubit: cudaq.QuakeValue

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -264,6 +264,19 @@ class QutipBackend(Backend):
     def _execute_state_tomography(
         self, functional: StateTomography, initial_state: QTensor | None = None
     ) -> StateTomographyResult:
+        """execute a state tomography protocol.
+
+        Args:
+            functional (StateTomography): the state tomography functional.
+            initial_state (QTensor | None, optional): the initial state of the circuit. Defaults to None.
+                NOTE: this is only used for the quantum reservoir and is not a public attribute.
+
+        Raises:
+            ValueError: if the final initial state is invalid.
+
+        Returns:
+            StateTomographyResult: the final results of the state tomography
+        """
         qutip_circuit = self._get_qutip_circuit(functional.circuit)
         U = gate_sequence_product(qutip_circuit.propagators(ignore_measurement=True))
 

--- a/src/qilisdk/functionals/__init__.py
+++ b/src/qilisdk/functionals/__init__.py
@@ -14,6 +14,8 @@
 
 from .sampling import Sampling
 from .sampling_result import SamplingResult
+from .state_tomography import StateTomography
+from .state_tomography_result import StateTomographyResult
 from .time_evolution import TimeEvolution
 from .time_evolution_result import TimeEvolutionResult
 from .variational_program import VariationalProgram
@@ -22,6 +24,8 @@ from .variational_program_result import VariationalProgramResult
 __all__ = [
     "Sampling",
     "SamplingResult",
+    "StateTomography",
+    "StateTomographyResult",
     "TimeEvolution",
     "TimeEvolutionResult",
     "VariationalProgram",

--- a/src/qilisdk/functionals/state_tomography.py
+++ b/src/qilisdk/functionals/state_tomography.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import ClassVar
+
+from qilisdk.common.variables import RealNumber
+from qilisdk.digital.circuit import Circuit
+from qilisdk.functionals import SamplingResult
+from qilisdk.functionals.functional import PrimitiveFunctional
+from qilisdk.yaml import yaml
+
+
+@yaml.register_class
+class StateTomography(PrimitiveFunctional[SamplingResult]):
+    result_type: ClassVar[type[SamplingResult]] = SamplingResult
+
+    def __init__(self, circuit: Circuit) -> None:
+        self.circuit = circuit
+
+    @property
+    def nparameters(self) -> int:
+        return self.circuit.nparameters
+
+    def set_parameters(self, parameters: dict[str, RealNumber]) -> None:
+        self.circuit.set_parameters(parameters)
+
+    def get_parameters(self) -> dict[str, RealNumber]:
+        return self.circuit.get_parameters()
+
+    def get_parameter_names(self) -> list[str]:
+        return list(self.circuit.get_parameters().keys())
+
+    def get_parameter_values(self) -> list[RealNumber]:
+        return list(self.circuit.get_parameters().values())
+
+    def set_parameter_values(self, values: list[float]) -> None:
+        self.circuit.set_parameter_values(values)
+
+    def get_parameter_bounds(self) -> dict[str, tuple[float, float]]:
+        return self.circuit.get_parameter_bounds()
+
+    def set_parameter_bounds(self, ranges: dict[str, tuple[float, float]]) -> None:
+        self.circuit.set_parameter_bounds(ranges)

--- a/src/qilisdk/functionals/state_tomography.py
+++ b/src/qilisdk/functionals/state_tomography.py
@@ -22,9 +22,15 @@ from qilisdk.yaml import yaml
 
 @yaml.register_class
 class StateTomography(PrimitiveFunctional[SamplingResult]):
+    """State Tomography functional reconstructs the state at the end of the circuit execution."""
+
     result_type: ClassVar[type[SamplingResult]] = SamplingResult
 
     def __init__(self, circuit: Circuit) -> None:
+        """
+        Args:
+            circuit (Circuit): The circuit to be executed.
+        """
         self.circuit = circuit
 
     @property

--- a/src/qilisdk/functionals/state_tomography_result.py
+++ b/src/qilisdk/functionals/state_tomography_result.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import heapq
+import operator
+from pprint import pformat
+
+import numpy as np
+
+from qilisdk.common.qtensor import QTensor
+from qilisdk.functionals.functional_result import FunctionalResult
+from qilisdk.yaml import yaml
+
+
+@yaml.register_class
+class StateTomographyResult(FunctionalResult):
+    """
+    Class representing the result of a quantum circuit measurement.
+
+    DigitalResult encapsulates the outcome of a digital measurement performed on a quantum circuit.
+    It includes the total number of measurement shots, the measurement samples and measurement probabilities.
+    """
+
+    def __init__(self, state: QTensor) -> None:
+        """
+        Initializes a DigitalResult instance.
+
+        Args:
+            nshots (int): The total number of measurement shots performed.
+            samples (dict[str, int]): A dictionary mapping bitstring outcomes to their occurrence counts.
+                All keys (bitstrings) must have the same length, which determines the number of qubits.
+        Raises:
+            ValueError: if the final state is not a ket of a density matrix
+        """
+        self._final_state = state
+
+        # Assign nqubits to attribute
+        self._nqubits = self._final_state.nqubits
+
+        # Calculate probabilities
+
+        probs = np.abs(state.dense) ** 2
+        if state.is_ket():
+            probs = np.abs(state.dense.flatten()) ** 2
+        elif state.is_density_matrix():
+            probs = np.real(np.diag(state.dense))
+        else:
+            raise ValueError("State must be a ket or density matrix")
+
+        bitstrings = [format(i, f"0{self._nqubits}b") for i in range(len(state.dense))]
+
+        self._probabilities = dict(zip(bitstrings, probs))
+
+    @property
+    def nqubits(self) -> int:
+        """
+        Gets the number of qubits involved in the measurement.
+
+        Returns:
+            int: The number of qubits measured.
+        """
+        return self._nqubits
+
+    @property
+    def final_state(self) -> QTensor:
+        """
+        Get the state vector at the end of the circuit.
+
+        Returns:
+            QTensor: The final state after evolution.
+        """
+        return self._final_state
+
+    @property
+    def probabilities(self) -> dict[str, float]:
+        """
+        Gets the probabilities for each measurement outcome.
+
+        Returns:
+            dict[str, float]: A dictionary mapping each bitstring outcome to its corresponding probability.
+        """
+        return dict(self._probabilities)
+
+    def get_probability(self, bitstring: str) -> float:
+        """
+        Computes the probability of a specific measurement outcome.
+
+        Args:
+            bitstring (str): The bitstring representing the measurement outcome of interest.
+
+        Returns:
+            float: The probability of the specified bitstring occurring.
+        """
+        return self._probabilities.get(bitstring, 0.0)
+
+    def get_probabilities(self, n: int | None = None) -> list[tuple[str, float]]:
+        """
+        Returns the n most probable bitstrings along with their probabilities.
+
+        Parameters:
+            n (int): The number of most probable bitstrings to return.
+
+        Returns:
+            list[tuple[str, float]]: A list of tuples (bitstring, probability) sorted in descending order by probability.
+        """
+        if n is None:
+            n = len(self._probabilities)
+        return heapq.nlargest(n, self._probabilities.items(), key=operator.itemgetter(1))
+
+    def __repr__(self) -> str:
+        """
+        Returns a string representation of the DigitalResult instance for debugging purposes.
+
+        The representation includes the class name, the number of measurement shots, and a formatted
+        display of the measurement samples.
+
+        Returns:
+            str: A string representation of the DigitalResult instance for debugging.
+        """
+        class_name = self.__class__.__name__
+        return f"{class_name}(\n  state=\n{self.final_state},\n  probabilities={pformat(self.probabilities)}\n)"

--- a/src/qilisdk/functionals/state_tomography_result.py
+++ b/src/qilisdk/functionals/state_tomography_result.py
@@ -25,20 +25,17 @@ from qilisdk.yaml import yaml
 @yaml.register_class
 class StateTomographyResult(FunctionalResult):
     """
-    Class representing the result of a quantum circuit measurement.
+    Class representing the result of the state after a  quantum circuit execution.
 
-    DigitalResult encapsulates the outcome of a digital measurement performed on a quantum circuit.
-    It includes the total number of measurement shots, the measurement samples and measurement probabilities.
+    StateTomographyResult encapsulates the outcome of a quantum circuit.
+    This includes the final state and the probabilities of the various states.
     """
 
     def __init__(self, state: QTensor) -> None:
         """
-        Initializes a DigitalResult instance.
-
         Args:
-            nshots (int): The total number of measurement shots performed.
-            samples (dict[str, int]): A dictionary mapping bitstring outcomes to their occurrence counts.
-                All keys (bitstrings) must have the same length, which determines the number of qubits.
+            state (QTensor): the state at the end of the execution.
+
         Raises:
             ValueError: if the final state is not a ket of a density matrix
         """

--- a/tests/backends/test_cuda_backend.py
+++ b/tests/backends/test_cuda_backend.py
@@ -29,7 +29,7 @@ class DummyKernel:
         self.qubits = []
 
     def qalloc(self, n):
-        self.qubits = [f"q{i}" for i in range(n)]
+        self.qubits = [f"q{i}" for i in range(len(n))]
         return self.qubits
 
     def x(self, qubit):


### PR DESCRIPTION
Adding ``StateTomography``functional. This functional can be used to retrieve the full reconstructed state vector at the end of the quantum circuit. 

Example usage: 
```python
from qilisdk.digital import *
from qilisdk.functionals import StateTomography
from qilisdk.backends import CudaBackend

circuit = Circuit(2)
circuit.add(H(0))
circuit.add(CNOT(0, 1))

backend = CudaBackend()
backend.execute(StateTomography(circuit))
```