### PR TITLE
[SDK-55] Implement strong typing for SpeQtrum jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ client = SpeQtrum()
 # # Execute a pre-built circuit (see Digital Quantum Circuits section)
 job_id = client.submit(Sampling(circuit, 1000), device="cuda_state_vector")
 print("job id:", job_id)
-print("job status:", client.get_job_details(job_id).status)
-print("job result:", client.get_job_details(job_id).result)
+print("job status:", client.get_job(job_id).status)
+print("job result:", client.get_job(job_id).result)
 ```
 
 ### Sample a quantum Circuit Using a CUDA-Accelerated Simulator

--- a/changes/87.feature.md
+++ b/changes/87.feature.md
@@ -1,0 +1,15 @@
+SpeQtrum jobs now retain their concrete result types from submission through retrieval, so every handle produced by `submit` returns the right `FunctionalResult` whether you are sampling, evolving in time, or orchestrating a variational loop. Waiting for a fresh job still takes a single call, but the typed detail that comes back no longer needs manual casting:
+
+```python
+job_handle = speqtrum.submit(Sampling(circuit), device="cuda_state_vector")
+job = speqtrum.wait_for_job(job_handle)
+results = job.get_results()  # Your IDE will know this is a SamplingResult
+```
+
+The same strong typing applies when inspecting historical runs. Recreate a handle with the appropriate class method, pass it to `get_job`, and the returned `TypedJobDetail` exposes the precise payload you expect:
+
+```python
+job_handle = JobHandle.sampling(1200853)
+job = speqtrum.get_job(job_handle)
+results = job.get_results()  # Your IDE will know this is a SamplingResult
+```

--- a/changes/87.feature.md
+++ b/changes/87.feature.md
@@ -19,7 +19,8 @@ Variational programs are the only scenario that needs an extra hint: because the
 ```python
 job_handle = JobHandle.variational_program(1200853, result_type=SamplingResult)
 job = speqtrum.get_job(job_handle)
-optimal = job.get_results().optimal_execution_results  # Your IDE will now know this is a SamplingResult
+results = job.get_results()  # Your IDE will now know this is a VariationalProgramResult
+optimal = results.optimal_execution_results  # Your IDE will now know this is a SamplingResult
 ```
 
 Passing a bare integer job identifier to `wait_for_job` or `get_job` remains valid for quick checks and backwards-compatibility, but doing so skips the handle metadata and yields an untyped `JobDetail`, so you will need to inspect or cast the result manually.

--- a/changes/87.feature.md
+++ b/changes/87.feature.md
@@ -3,7 +3,7 @@ SpeQtrum jobs now retain their concrete result types from submission through ret
 ```python
 job_handle = speqtrum.submit(Sampling(circuit), device="cuda_state_vector")
 job = speqtrum.wait_for_job(job_handle)
-results = job.get_results()  # Your IDE will know this is a SamplingResult
+results = job.get_results()  # Your IDE will now know this is a SamplingResult
 ```
 
 The same strong typing applies when inspecting historical runs. Recreate a handle with the appropriate class method, pass it to `get_job`, and the returned `TypedJobDetail` exposes the precise payload you expect:
@@ -11,5 +11,15 @@ The same strong typing applies when inspecting historical runs. Recreate a handl
 ```python
 job_handle = JobHandle.sampling(1200853)
 job = speqtrum.get_job(job_handle)
-results = job.get_results()  # Your IDE will know this is a SamplingResult
+results = job.get_results()  # Your IDE will now know this is a SamplingResult
+```
+
+Note: Passing a bare integer job identifier to `wait_for_job` or `get_job` remains valid for quick checks and backwards-compatibility, but doing so skips the handle metadata and yields an untyped `JobDetail`, so you will need to inspect or cast the result manually. 
+
+Variational programs are the only scenario that needs an extra hint: because they wrap another functional, recreate the handle with the inner functional’s result type so the execution results can be validated against your expectations:
+
+```python
+job_handle = JobHandle.variational_program(1200853, result_type=SamplingResult)
+job = speqtrum.get_job(job_handle)
+optimal = job.get_results().optimal_execution_results  # Your IDE will now know this is a SamplingResult
 ```

--- a/changes/87.feature.md
+++ b/changes/87.feature.md
@@ -14,8 +14,6 @@ job = speqtrum.get_job(job_handle)
 results = job.get_results()  # Your IDE will now know this is a SamplingResult
 ```
 
-Note: Passing a bare integer job identifier to `wait_for_job` or `get_job` remains valid for quick checks and backwards-compatibility, but doing so skips the handle metadata and yields an untyped `JobDetail`, so you will need to inspect or cast the result manually. 
-
 Variational programs are the only scenario that needs an extra hint: because they wrap another functional, recreate the handle with the inner functional’s result type so the execution results can be validated against your expectations:
 
 ```python
@@ -23,3 +21,5 @@ job_handle = JobHandle.variational_program(1200853, result_type=SamplingResult)
 job = speqtrum.get_job(job_handle)
 optimal = job.get_results().optimal_execution_results  # Your IDE will now know this is a SamplingResult
 ```
+
+Passing a bare integer job identifier to `wait_for_job` or `get_job` remains valid for quick checks and backwards-compatibility, but doing so skips the handle metadata and yields an untyped `JobDetail`, so you will need to inspect or cast the result manually.

--- a/docs/fundamentals/speqtrum.rst
+++ b/docs/fundamentals/speqtrum.rst
@@ -82,7 +82,7 @@ Remote Jobs
         print(f"{job.id}: {job.status.value} on {job.device_id}")
 
 To inspect complete job metadata (payload, result, logs, decoded errors) call
-:meth:`SpeQtrum.get_job_details <qilisdk.speqtrum.speqtrum.SpeQtrum.get_job_details>`. Binary fields are returned as
+:meth:`SpeQtrum.get_job <qilisdk.speqtrum.speqtrum.SpeQtrum.get_job>`. Binary fields are returned as
 decoded strings or structured :class:`~qilisdk.speqtrum.speqtrum_models.ExecuteResult` objects.
 
 When you wait on a :class:`~qilisdk.speqtrum.speqtrum_models.JobHandle`, the returned object is a
@@ -94,7 +94,7 @@ When you wait on a :class:`~qilisdk.speqtrum.speqtrum_models.JobHandle`, the ret
     final_job = client.wait_for_job(job_handle)
     sampling_result = final_job.get_results()  # -> SamplingResult
 
-You can still call :meth:`~qilisdk.speqtrum.speqtrum.SpeQtrum.get_job_details` with a bare integer identifier. In that
+You can still call :meth:`~qilisdk.speqtrum.speqtrum.SpeQtrum.get_job` with a bare integer identifier. In that
 case a regular :class:`JobDetail <qilisdk.speqtrum.speqtrum_models.JobDetail>` object is returned and you can inspect the
 individual ``*.result`` fields manually when needed.
 

--- a/src/qilisdk/speqtrum/__init__.py
+++ b/src/qilisdk/speqtrum/__init__.py
@@ -25,6 +25,8 @@ OPTIONAL_FEATURES: list[OptionalFeature] = [
             Symbol(path="qilisdk.speqtrum.speqtrum", name="SpeQtrum"),
             Symbol(path="qilisdk.speqtrum.speqtrum_models", name="DeviceStatus"),
             Symbol(path="qilisdk.speqtrum.speqtrum_models", name="DeviceType"),
+            Symbol(path="qilisdk.speqtrum.speqtrum_models", name="JobHandle"),
+            Symbol(path="qilisdk.speqtrum.speqtrum_models", name="TypedJobDetail"),
         ],
     ),
 ]

--- a/src/qilisdk/speqtrum/speqtrum.py
+++ b/src/qilisdk/speqtrum/speqtrum.py
@@ -347,7 +347,11 @@ class SpeQtrum:
     def submit(self, functional: TimeEvolution, device: str) -> JobHandle[TimeEvolutionResult]: ...
 
     @overload
-    def submit(self, functional: VariationalProgram, device: str) -> JobHandle[VariationalProgramResult]: ...
+    def submit(
+        self,
+        functional: VariationalProgram[PrimitiveFunctional[ResultT]],
+        device: str,
+    ) -> JobHandle[VariationalProgramResult[ResultT]]: ...
 
     @overload
     def submit(self, functional: RabiExperiment, device: str) -> JobHandle[RabiExperimentResult]: ...
@@ -470,8 +474,8 @@ class SpeQtrum:
         return JobHandle.time_evolution(job.id)
 
     def _submit_variational_program(
-        self, variational_program: VariationalProgram, device: str
-    ) -> JobHandle[VariationalProgramResult]:
+        self, variational_program: VariationalProgram[PrimitiveFunctional[ResultT]], device: str
+    ) -> JobHandle[VariationalProgramResult[ResultT]]:
         payload = ExecutePayload(
             type=ExecuteType.VARIATIONAL_PROGRAM,
             variational_program_payload=VariationalProgramPayload(variational_program=variational_program),
@@ -487,4 +491,5 @@ class SpeQtrum:
             response.raise_for_status()
             job = JobId(**response.json())
         logger.info("Variational program job submitted: {}", job.id)
-        return JobHandle.variational_program(job.id)
+        result_type = cast("type[ResultT]", variational_program.functional.result_type)
+        return JobHandle.variational_program(job.id, result_type=result_type)

--- a/src/qilisdk/speqtrum/speqtrum.py
+++ b/src/qilisdk/speqtrum/speqtrum.py
@@ -35,7 +35,6 @@ from qilisdk.functionals import (
 from qilisdk.functionals.functional_result import FunctionalResult
 from qilisdk.settings import get_settings
 from qilisdk.speqtrum.experiments import (
-    ExperimentFunctional,
     RabiExperiment,
     RabiExperimentResult,
     T1Experiment,
@@ -47,18 +46,18 @@ from .speqtrum_models import (
     Device,
     ExecutePayload,
     ExecuteType,
-    JobHandle,
     JobDetail,
+    JobHandle,
     JobId,
     JobInfo,
     JobStatus,
     JobType,
-    TypedJobDetail,
     RabiExperimentPayload,
     SamplingPayload,
     T1ExperimentPayload,
     TimeEvolutionPayload,
     Token,
+    TypedJobDetail,
     VariationalProgramPayload,
 )
 
@@ -344,7 +343,9 @@ class SpeQtrum:
     def submit(self, functional: TimeEvolution, device: str) -> JobHandle[TimeEvolutionResult]: ...
 
     @overload
-    def submit(self, functional: VariationalProgram[Sampling], device: str) -> JobHandle[VariationalProgramResult[SamplingResult]]: ...
+    def submit(
+        self, functional: VariationalProgram[Sampling], device: str
+    ) -> JobHandle[VariationalProgramResult[SamplingResult]]: ...
 
     @overload
     def submit(
@@ -408,7 +409,7 @@ class SpeQtrum:
 
                 # Fallback to untyped handle for custom primitives.
                 job_handle = self._submit_variational_program(cast("VariationalProgram[Any]", functional), device)
-                return cast(JobHandle[FunctionalResult], job_handle)
+                return cast("JobHandle[FunctionalResult]", job_handle)
 
             handler = self._handlers[type(functional)]
         except KeyError as exc:
@@ -515,7 +516,12 @@ class SpeQtrum:
             type=ExecuteType.VARIATIONAL_PROGRAM,
             variational_program_payload=VariationalProgramPayload(variational_program=variational_program),
         )
-        json = {"device_code": device, "payload": payload.model_dump_json(), "job_type": JobType.VARIATIONAL, "meta": {}}
+        json = {
+            "device_code": device,
+            "payload": payload.model_dump_json(),
+            "job_type": JobType.VARIATIONAL,
+            "meta": {},
+        }
         logger.debug("Executing variational program on device {}", device)
         with httpx.Client() as client:
             response = client.post(

--- a/src/qilisdk/speqtrum/speqtrum.py
+++ b/src/qilisdk/speqtrum/speqtrum.py
@@ -80,9 +80,15 @@ class SpeQtrum:
         self._username, self._token = credentials
         self._handlers: dict[type[Functional], Callable[[Functional, str, str | None], JobHandle[Any]]] = {
             Sampling: lambda f, device, job_name: self._submit_sampling(cast("Sampling", f), device, job_name),
-            TimeEvolution: lambda f, device, job_name: self._submit_time_evolution(cast("TimeEvolution", f), device, job_name),
-            RabiExperiment: lambda f, device, job_name: self._submit_rabi_program(cast("RabiExperiment", f), device, job_name),
-            T1Experiment: lambda f, device, job_name: self._submit_t1_program(cast("T1Experiment", f), device, job_name),
+            TimeEvolution: lambda f, device, job_name: self._submit_time_evolution(
+                cast("TimeEvolution", f), device, job_name
+            ),
+            RabiExperiment: lambda f, device, job_name: self._submit_rabi_program(
+                cast("RabiExperiment", f), device, job_name
+            ),
+            T1Experiment: lambda f, device, job_name: self._submit_t1_program(
+                cast("T1Experiment", f), device, job_name
+            ),
         }
         self._settings = get_settings()
         logger.success("QaaS client initialised for user '{}'", self._username)
@@ -340,7 +346,9 @@ class SpeQtrum:
     def submit(self, functional: Sampling, device: str, job_name: str | None = None) -> JobHandle[SamplingResult]: ...
 
     @overload
-    def submit(self, functional: TimeEvolution, device: str, job_name: str | None = None) -> JobHandle[TimeEvolutionResult]: ...
+    def submit(
+        self, functional: TimeEvolution, device: str, job_name: str | None = None
+    ) -> JobHandle[TimeEvolutionResult]: ...
 
     @overload
     def submit(
@@ -349,25 +357,23 @@ class SpeQtrum:
 
     @overload
     def submit(
-        self,
-        functional: VariationalProgram[TimeEvolution],
-        device: str,
-        job_name: str | None = None
+        self, functional: VariationalProgram[TimeEvolution], device: str, job_name: str | None = None
     ) -> JobHandle[VariationalProgramResult[TimeEvolutionResult]]: ...
 
     @overload
     def submit(
-        self,
-        functional: VariationalProgram[PrimitiveFunctional[ResultT]],
-        device: str,
-        job_name: str | None = None
+        self, functional: VariationalProgram[PrimitiveFunctional[ResultT]], device: str, job_name: str | None = None
     ) -> JobHandle[VariationalProgramResult[ResultT]]: ...
 
     @overload
-    def submit(self, functional: RabiExperiment, device: str, job_name: str | None = None) -> JobHandle[RabiExperimentResult]: ...
+    def submit(
+        self, functional: RabiExperiment, device: str, job_name: str | None = None
+    ) -> JobHandle[RabiExperimentResult]: ...
 
     @overload
-    def submit(self, functional: T1Experiment, device: str, job_name: str | None = None) -> JobHandle[T1ExperimentResult]: ...
+    def submit(
+        self, functional: T1Experiment, device: str, job_name: str | None = None
+    ) -> JobHandle[T1ExperimentResult]: ...
 
     def submit(self, functional: Functional, device: str, job_name: str | None = None) -> JobHandle[FunctionalResult]:
         """
@@ -426,7 +432,9 @@ class SpeQtrum:
         logger.success("Submission complete - job {}", job_handle.id)
         return job_handle
 
-    def _submit_sampling(self, sampling: Sampling, device: str, job_name: str | None = None) -> JobHandle[SamplingResult]:
+    def _submit_sampling(
+        self, sampling: Sampling, device: str, job_name: str | None = None
+    ) -> JobHandle[SamplingResult]:
         payload = ExecutePayload(
             type=ExecuteType.SAMPLING,
             sampling_payload=SamplingPayload(sampling=sampling),
@@ -450,7 +458,9 @@ class SpeQtrum:
             job = JobId(**response.json())
         return JobHandle.sampling(job.id)
 
-    def _submit_rabi_program(self, rabi_experiment: RabiExperiment, device: str, job_name: str | None = None) -> JobHandle[RabiExperimentResult]:
+    def _submit_rabi_program(
+        self, rabi_experiment: RabiExperiment, device: str, job_name: str | None = None
+    ) -> JobHandle[RabiExperimentResult]:
         payload = ExecutePayload(
             type=ExecuteType.RABI_EXPERIMENT,
             rabi_experiment_payload=RabiExperimentPayload(rabi_experiment=rabi_experiment),
@@ -475,7 +485,9 @@ class SpeQtrum:
         logger.info("Rabi experiment job submitted: {}", job.id)
         return JobHandle.rabi_experiment(job.id)
 
-    def _submit_t1_program(self, t1_experiment: T1Experiment, device: str, job_name: str | None = None) -> JobHandle[T1ExperimentResult]:
+    def _submit_t1_program(
+        self, t1_experiment: T1Experiment, device: str, job_name: str | None = None
+    ) -> JobHandle[T1ExperimentResult]:
         payload = ExecutePayload(
             type=ExecuteType.T1_EXPERIMENT,
             t1_experiment_payload=T1ExperimentPayload(t1_experiment=t1_experiment),
@@ -500,7 +512,9 @@ class SpeQtrum:
         logger.info("T1 experiment job submitted: {}", job.id)
         return JobHandle.t1_experiment(job.id)
 
-    def _submit_time_evolution(self, time_evolution: TimeEvolution, device: str, job_name: str | None = None) -> JobHandle[TimeEvolutionResult]:
+    def _submit_time_evolution(
+        self, time_evolution: TimeEvolution, device: str, job_name: str | None = None
+    ) -> JobHandle[TimeEvolutionResult]:
         payload = ExecutePayload(
             type=ExecuteType.TIME_EVOLUTION,
             time_evolution_payload=TimeEvolutionPayload(time_evolution=time_evolution),

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -14,7 +14,7 @@
 # ruff: noqa: ANN001, ANN202, PLR6301
 from email.utils import parsedate_to_datetime
 from enum import Enum
-from typing import Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar, cast, overload
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_serializer, field_validator
 
@@ -229,36 +229,7 @@ class ExecuteResult(SpeQtrumModel):
 
 
 ResultT_co = TypeVar("ResultT_co", bound=FunctionalResult, covariant=True)
-
-
-def _require_sampling_result(result: ExecuteResult) -> SamplingResult:
-    if result.sampling_result is None:
-        raise RuntimeError("SpeQtrum did not return a sampling_result for a sampling execution.")
-    return result.sampling_result
-
-
-def _require_time_evolution_result(result: ExecuteResult) -> TimeEvolutionResult:
-    if result.time_evolution_result is None:
-        raise RuntimeError("SpeQtrum did not return a time_evolution_result for a time evolution execution.")
-    return result.time_evolution_result
-
-
-def _require_variational_program_result(result: ExecuteResult) -> VariationalProgramResult:
-    if result.variational_program_result is None:
-        raise RuntimeError("SpeQtrum did not return a variational_program_result for a variational program execution.")
-    return result.variational_program_result
-
-
-def _require_rabi_experiment_result(result: ExecuteResult) -> RabiExperimentResult:
-    if result.rabi_experiment_result is None:
-        raise RuntimeError("SpeQtrum did not return a rabi_experiment_result for a Rabi experiment execution.")
-    return result.rabi_experiment_result
-
-
-def _require_t1_experiment_result(result: ExecuteResult) -> T1ExperimentResult:
-    if result.t1_experiment_result is None:
-        raise RuntimeError("SpeQtrum did not return a t1_experiment_result for a T1 experiment execution.")
-    return result.t1_experiment_result
+VariationalInnerResultT = TypeVar("VariationalInnerResultT", bound=FunctionalResult)
 
 
 ResultExtractor = Callable[[ExecuteResult], ResultT_co]
@@ -293,6 +264,23 @@ def _require_t1_experiment_result(result: ExecuteResult) -> T1ExperimentResult:
         raise RuntimeError("SpeQtrum did not return a t1_experiment_result for a T1 experiment execution.")
     return result.t1_experiment_result
 
+
+def _require_variational_program_result_typed(
+    inner_result_type: type[VariationalInnerResultT],
+) -> ResultExtractor[VariationalProgramResult[VariationalInnerResultT]]:
+    def _extractor(result: ExecuteResult) -> VariationalProgramResult[VariationalInnerResultT]:
+        variational_result = _require_variational_program_result(result)
+        optimal_results = variational_result.optimal_execution_results
+        if not isinstance(optimal_results, inner_result_type):
+            raise RuntimeError(
+                "SpeQtrum returned a variational program result whose optimal execution result "
+                f"({type(optimal_results).__qualname__}) does not match the expected "
+                f"{inner_result_type.__qualname__}."
+            )
+        return cast("VariationalProgramResult[VariationalInnerResultT]", variational_result)
+
+    return _extractor
+
 class JobHandle(SpeQtrumModel, Generic[ResultT_co]):
     """Strongly typed reference to a submitted SpeQtrum job."""
 
@@ -308,9 +296,27 @@ class JobHandle(SpeQtrumModel, Generic[ResultT_co]):
     def time_evolution(cls, job_id: int) -> "JobHandle[TimeEvolutionResult]":
         return cls(id=job_id, execute_type=ExecuteType.TIME_EVOLUTION, extractor=_require_time_evolution_result)
 
+    @overload
     @classmethod
-    def variational_program(cls, job_id: int) -> "JobHandle[VariationalProgramResult]":
-        return cls(id=job_id, execute_type=ExecuteType.VARIATIONAL_PROGRAM, extractor=_require_variational_program_result)
+    def variational_program(cls, job_id: int) -> "JobHandle[VariationalProgramResult]": ...
+
+    @overload
+    @classmethod
+    def variational_program(
+        cls, job_id: int, *, result_type: type[VariationalInnerResultT]
+    ) -> "JobHandle[VariationalProgramResult[VariationalInnerResultT]]": ...
+
+    @classmethod
+    def variational_program(
+        cls, job_id: int, *, result_type: type[VariationalInnerResultT] | None = None
+    ) -> "JobHandle[Any]":
+        if result_type is None:
+            handle = cls(id=job_id, execute_type=ExecuteType.VARIATIONAL_PROGRAM, extractor=_require_variational_program_result)
+            return cast("JobHandle[VariationalProgramResult]", handle)
+
+        extractor = _require_variational_program_result_typed(result_type)
+        handle = cls(id=job_id, execute_type=ExecuteType.VARIATIONAL_PROGRAM, extractor=extractor)
+        return cast("JobHandle[VariationalProgramResult[VariationalInnerResultT]]", handle)
 
     @classmethod
     def rabi_experiment(cls, job_id: int) -> "JobHandle[RabiExperimentResult]":

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -14,6 +14,7 @@
 # ruff: noqa: ANN001, ANN202, PLR6301
 from email.utils import parsedate_to_datetime
 from enum import Enum
+from typing import Callable, Generic, TypeVar
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_serializer, field_validator
 
@@ -25,6 +26,7 @@ from qilisdk.functionals import (
     VariationalProgram,
     VariationalProgramResult,
 )
+from qilisdk.functionals.functional_result import FunctionalResult
 from qilisdk.speqtrum.experiments import RabiExperiment, RabiExperimentResult, T1Experiment, T1ExperimentResult
 from qilisdk.utils.serialization import deserialize, serialize
 
@@ -226,6 +228,109 @@ class ExecuteResult(SpeQtrumModel):
         return v
 
 
+ResultT_co = TypeVar("ResultT_co", bound=FunctionalResult, covariant=True)
+
+
+def _require_sampling_result(result: ExecuteResult) -> SamplingResult:
+    if result.sampling_result is None:
+        raise RuntimeError("SpeQtrum did not return a sampling_result for a sampling execution.")
+    return result.sampling_result
+
+
+def _require_time_evolution_result(result: ExecuteResult) -> TimeEvolutionResult:
+    if result.time_evolution_result is None:
+        raise RuntimeError("SpeQtrum did not return a time_evolution_result for a time evolution execution.")
+    return result.time_evolution_result
+
+
+def _require_variational_program_result(result: ExecuteResult) -> VariationalProgramResult:
+    if result.variational_program_result is None:
+        raise RuntimeError("SpeQtrum did not return a variational_program_result for a variational program execution.")
+    return result.variational_program_result
+
+
+def _require_rabi_experiment_result(result: ExecuteResult) -> RabiExperimentResult:
+    if result.rabi_experiment_result is None:
+        raise RuntimeError("SpeQtrum did not return a rabi_experiment_result for a Rabi experiment execution.")
+    return result.rabi_experiment_result
+
+
+def _require_t1_experiment_result(result: ExecuteResult) -> T1ExperimentResult:
+    if result.t1_experiment_result is None:
+        raise RuntimeError("SpeQtrum did not return a t1_experiment_result for a T1 experiment execution.")
+    return result.t1_experiment_result
+
+
+ResultExtractor = Callable[[ExecuteResult], ResultT_co]
+
+# these helpers live outside the models so they can be referenced by default values
+def _require_sampling_result(result: ExecuteResult) -> SamplingResult:
+    if result.sampling_result is None:
+        raise RuntimeError("SpeQtrum did not return a sampling_result for a sampling execution.")
+    return result.sampling_result
+
+
+def _require_time_evolution_result(result: ExecuteResult) -> TimeEvolutionResult:
+    if result.time_evolution_result is None:
+        raise RuntimeError("SpeQtrum did not return a time_evolution_result for a time evolution execution.")
+    return result.time_evolution_result
+
+
+def _require_variational_program_result(result: ExecuteResult) -> VariationalProgramResult:
+    if result.variational_program_result is None:
+        raise RuntimeError("SpeQtrum did not return a variational_program_result for a variational program execution.")
+    return result.variational_program_result
+
+
+def _require_rabi_experiment_result(result: ExecuteResult) -> RabiExperimentResult:
+    if result.rabi_experiment_result is None:
+        raise RuntimeError("SpeQtrum did not return a rabi_experiment_result for a Rabi experiment execution.")
+    return result.rabi_experiment_result
+
+
+def _require_t1_experiment_result(result: ExecuteResult) -> T1ExperimentResult:
+    if result.t1_experiment_result is None:
+        raise RuntimeError("SpeQtrum did not return a t1_experiment_result for a T1 experiment execution.")
+    return result.t1_experiment_result
+
+class JobHandle(SpeQtrumModel, Generic[ResultT_co]):
+    """Strongly typed reference to a submitted SpeQtrum job."""
+
+    id: int
+    execute_type: ExecuteType
+    extractor: ResultExtractor[ResultT_co] = Field(repr=False, exclude=True)
+
+    @classmethod
+    def sampling(cls, job_id: int) -> "JobHandle[SamplingResult]":
+        return cls(id=job_id, execute_type=ExecuteType.SAMPLING, extractor=_require_sampling_result)
+
+    @classmethod
+    def time_evolution(cls, job_id: int) -> "JobHandle[TimeEvolutionResult]":
+        return cls(id=job_id, execute_type=ExecuteType.TIME_EVOLUTION, extractor=_require_time_evolution_result)
+
+    @classmethod
+    def variational_program(cls, job_id: int) -> "JobHandle[VariationalProgramResult]":
+        return cls(id=job_id, execute_type=ExecuteType.VARIATIONAL_PROGRAM, extractor=_require_variational_program_result)
+
+    @classmethod
+    def rabi_experiment(cls, job_id: int) -> "JobHandle[RabiExperimentResult]":
+        return cls(id=job_id, execute_type=ExecuteType.RABI_EXPERIMENT, extractor=_require_rabi_experiment_result)
+
+    @classmethod
+    def t1_experiment(cls, job_id: int) -> "JobHandle[T1ExperimentResult]":
+        return cls(id=job_id, execute_type=ExecuteType.T1_EXPERIMENT, extractor=_require_t1_experiment_result)
+
+    def bind(self, detail: "JobDetail") -> "TypedJobDetail[ResultT_co]":
+        """Attach this handle's typing information to a concrete `JobDetail`."""
+        return TypedJobDetail.model_validate(
+            {
+                **detail.model_dump(),
+                "expected_type": self.execute_type,
+                "extractor": self.extractor,
+            }
+        )
+
+
 class JobStatus(str, Enum):
     "Job has not been submitted to the Lab api"
 
@@ -298,3 +403,25 @@ class JobDetail(JobInfo):
     logs: str | None = None
     error: str | None = None
     error_logs: str | None = None
+
+
+class TypedJobDetail(JobDetail, Generic[ResultT_co]):
+    """`JobDetail` subclass that exposes a strongly typed `get_results` method."""
+
+    expected_type: ExecuteType = Field(repr=False)
+    extractor: ResultExtractor[ResultT_co] = Field(repr=False, exclude=True)
+
+    def get_results(self) -> ResultT_co:
+        """
+        Return the strongly typed execution result.
+
+        Raises:
+            RuntimeError: If SpeQtrum has not populated the result payload or the type disagrees with the handle.
+        """
+        if self.result is None:
+            raise RuntimeError("The job completed without a result payload; inspect `error` or `logs` for details.")
+
+        if self.result.type != self.expected_type:
+            raise RuntimeError(f"Expected a result of type '{self.expected_type.value}' but received '{self.result.type.value}'.")
+
+        return self.extractor(self.result)

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -327,7 +327,9 @@ class JobHandle(SpeQtrumModel, Generic[ResultT_co]):
         """
         if result_type is None:
             handle = cls(
-                id=job_id, execute_type=ExecuteType.VARIATIONAL_PROGRAM, extractor=_require_variational_program_result  # type: ignore[arg-type]
+                id=job_id,
+                execute_type=ExecuteType.VARIATIONAL_PROGRAM,
+                extractor=_require_variational_program_result,  # type: ignore[arg-type]
             )
             return cast("JobHandle[VariationalProgramResult]", handle)
 

--- a/tests/speqtrum/test_speqtrum.py
+++ b/tests/speqtrum/test_speqtrum.py
@@ -151,11 +151,11 @@ def test_wait_for_job_completes(monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_get_job_details(self, _id):
+    def fake_get_job(self, _id):
         calls["n"] += 1
         return FakeJob(DummyStatus.RUNNING if calls["n"] == 1 else DummyStatus.COMPLETED)
 
-    monkeypatch.setattr(speqtrum.SpeQtrum, "get_job_details", fake_get_job_details, raising=True)
+    monkeypatch.setattr(speqtrum.SpeQtrum, "get_job", fake_get_job, raising=True)
     monkeypatch.setattr(speqtrum.time, "sleep", lambda *_: None)  # skip real sleeping
 
     # run - should finish on 2nd iteration
@@ -185,7 +185,7 @@ def test_wait_for_job_with_handle_returns_typed_detail(monkeypatch):
         result=ExecuteResult(type=speqtrum.ExecuteType.SAMPLING, sampling_result=sampling_result),
     )
 
-    monkeypatch.setattr(speqtrum.SpeQtrum, "get_job_details", lambda self, _: detail, raising=True)
+    monkeypatch.setattr(speqtrum.SpeQtrum, "get_job", lambda self, _: detail, raising=True)
 
     typed_detail = q.wait_for_job(handle, poll_interval=0.0)
     assert isinstance(typed_detail, speqtrum.TypedJobDetail)
@@ -212,7 +212,7 @@ def test_wait_for_job_times_out(monkeypatch):
     # always RUNNING → never terminal
     monkeypatch.setattr(
         speqtrum.SpeQtrum,
-        "get_job_details",
+        "get_job",
         lambda *_: types.SimpleNamespace(status=DummyStatus.RUNNING),
         raising=True,
     )


### PR DESCRIPTION
SpeQtrum jobs now retain their concrete result types from submission through retrieval, so every handle produced by `submit` returns the right `FunctionalResult` whether you are sampling, evolving in time, or orchestrating a variational loop. Waiting for a fresh job still takes a single call, but the typed detail that comes back no longer needs manual casting:

```python
job_handle = speqtrum.submit(Sampling(circuit), device="cuda_state_vector")
job = speqtrum.wait_for_job(job_handle)
results = job.get_results()  # Your IDE will now know this is a SamplingResult
```

The same strong typing applies when inspecting historical runs. Recreate a handle with the appropriate class method, pass it to `get_job`, and the returned `TypedJobDetail` exposes the precise payload you expect:

```python
job_handle = JobHandle.sampling(1200853)
job = speqtrum.get_job(job_handle)
results = job.get_results()  # Your IDE will now know this is a SamplingResult
```

Variational programs are the only scenario that needs an extra hint: because they wrap another functional, recreate the handle with the inner functional’s result type so the execution results can be validated against your expectations:

```python
job_handle = JobHandle.variational_program(1200853, result_type=SamplingResult)
job = speqtrum.get_job(job_handle)
results = job.get_results()  # Your IDE will now know this is a VariationalProgramResult
optimal = results.optimal_execution_results  # Your IDE will now know this is a SamplingResult
```

Passing a bare integer job identifier to `wait_for_job` or `get_job` remains valid for quick checks and backwards-compatibility, but doing so skips the handle metadata and yields an untyped `JobDetail`, so you will need to inspect or cast the result manually.