### PR TITLE
[SDK-60] fixing the hardware efficient ansatz

### DIFF
--- a/changes/90.bugfix.md
+++ b/changes/90.bugfix.md
@@ -1,1 +1,1 @@
-Fixing the repeated first layer issue with the hardware efficient ansatz.
+Fixed the `HardwareEfficientAnsatz` so the first layer of single-qubit gates is not duplicated, restoring the expected gate and parameter counts.

--- a/changes/90.bugfix.md
+++ b/changes/90.bugfix.md
@@ -1,0 +1,1 @@
+Fixing the repeated first layer issue with the hardware efficient ansatz.

--- a/src/qilisdk/digital/ansatz.py
+++ b/src/qilisdk/digital/ansatz.py
@@ -188,9 +188,6 @@ class HardwareEfficientAnsatz(Ansatz):
         # Parameter iterator covering all single-qubit blocks, in order
         parameter_iterator = iter(self._parameter_blocks())
 
-        # U(0)
-        self._apply_single_qubit_block(parameter_iterator)
-
         # For each remaining layer: U -> E
         if self.structure == "grouped":
             for _ in range(self.layers):

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -924,7 +924,7 @@ class U2(BasicGate):
         ``U2(phi, gamma) = U2_qiskit/pennylane(phi, gamma) = exp(i*(phi+gamma)/2) U2_qibo(phi, gamma)``
 
     Other unitaries you can get from this one are:
-        - ``U2(phi=0, gamma=np.pi) = H``
+        - ``U2(phi=0, gamma=pi) = H``
         - ``U2(phi=0, gamma=0) = RY(theta=pi/2)``
         - ``U2(phi=-pi/2, gamma=pi/2) = RX(theta=pi/2)``
     """

--- a/tests/digital/test_ansatz.py
+++ b/tests/digital/test_ansatz.py
@@ -43,7 +43,7 @@ def test_nparameters_property():
     n_qubits = 3
     layers = 2
     ansatz = HardwareEfficientAnsatz(nqubits=n_qubits, layers=layers, connectivity="Linear", structure="grouped")
-    expected = n_qubits * (layers + 1) * len(U1.PARAMETER_NAMES)
+    expected = n_qubits * (layers) * len(U1.PARAMETER_NAMES)
     assert ansatz.nparameters == expected
 
 
@@ -59,7 +59,7 @@ def test_construct_circuit_grouped_structure_gate_count():
     E = len(list(ansatz.connectivity))
     one_q, two_q = _gate_counts(ansatz)
 
-    assert one_q == (layers + 1) * n_qubits
+    assert one_q == (layers) * n_qubits
     assert two_q == layers * E
     assert len(ansatz.gates) == one_q + two_q  # total gates
 
@@ -76,7 +76,7 @@ def test_construct_circuit_interposed_structure_gate_count():
     E = len(list(ansatz.connectivity))
     one_q, two_q = _gate_counts(ansatz)
 
-    assert one_q == (layers + 1) * n_qubits
+    assert one_q == (layers) * n_qubits
     assert two_q == layers * n_qubits * E
     assert len(ansatz.gates) == one_q + two_q
 
@@ -88,9 +88,9 @@ def test_layers_zero_only_initial_block():
     for structure in ("grouped", "interposed"):
         ans = HardwareEfficientAnsatz(nqubits=n_qubits, layers=layers, connectivity="Linear", structure=structure)
         one_q, two_q = _gate_counts(ans)
-        assert one_q == (layers + 1) * n_qubits == n_qubits
+        assert one_q == (layers) * n_qubits
         assert two_q == 0
-        assert len(ans.gates) == n_qubits
+        assert len(ans.gates) == 0
 
 
 def test_invalid_connectivity_string_raises():


### PR DESCRIPTION
Fixed the `HardwareEfficientAnsatz` so the first layer of single-qubit gates is not duplicated, restoring the expected gate and parameter counts.