### PR TITLE
[SDK-69] fixing QuTiP time evolution bug

### DIFF
--- a/changes/91.bugfix.md
+++ b/changes/91.bugfix.md
@@ -1,5 +1,2 @@
-Fixing issues with schedule:
-- issues encountered when a numpy float is passed.
-
-Fixing issues with qutip backend:
-- updated the structure of mapping qilisdk schedule to qutip's.
+Fixed the scheduler so numpy floats are accepted without errors.
+Fixed the QuTiP backend by aligning the schedule-to-backend mapping structure.

--- a/changes/91.bugfix.md
+++ b/changes/91.bugfix.md
@@ -1,0 +1,5 @@
+Fixing issues with schedule:
+- issues encountered when a numpy float is passed.
+
+Fixing issues with qutip backend:
+- updated the structure of mapping qilisdk schedule to qutip's.

--- a/src/qilisdk/analog/linear_schedule.py
+++ b/src/qilisdk/analog/linear_schedule.py
@@ -100,7 +100,8 @@ class LinearSchedule(Schedule):
         Returns:
             Number: Evaluated coefficient value.
         """
-        val = self.get_coefficient_expression(time_step=float(time_step), hamiltonian_key=hamiltonian_key)
+        time_step = float(time_step)
+        val = self.get_coefficient_expression(time_step=time_step, hamiltonian_key=hamiltonian_key)
         return val.evaluate({}) if isinstance(val, Term) else (val.evaluate() if isinstance(val, Parameter) else val)
 
     def __getitem__(self, time_step: int) -> Hamiltonian:

--- a/src/qilisdk/analog/linear_schedule.py
+++ b/src/qilisdk/analog/linear_schedule.py
@@ -85,7 +85,9 @@ class LinearSchedule(Schedule):
         if next_idx is None or prev_idx is None or prev_expr is None or next_expr is None:
             raise ValueError("Something unexpected happened while retrieving the coefficient.")
         alpha: float = (t - prev_idx) / (next_idx - prev_idx)
-        return (1 - alpha) * prev_expr + alpha * next_expr
+        e1 = next_expr * alpha
+        e2 = prev_expr * (1 - alpha)
+        return e1 + e2
 
     def get_coefficient(self, time_step: float, hamiltonian_key: str) -> Number:
         """
@@ -98,7 +100,7 @@ class LinearSchedule(Schedule):
         Returns:
             Number: Evaluated coefficient value.
         """
-        val = self.get_coefficient_expression(time_step=time_step, hamiltonian_key=hamiltonian_key)
+        val = self.get_coefficient_expression(time_step=float(time_step), hamiltonian_key=hamiltonian_key)
         return val.evaluate({}) if isinstance(val, Term) else (val.evaluate() if isinstance(val, Parameter) else val)
 
     def __getitem__(self, time_step: int) -> Hamiltonian:

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from typing import Callable
 
-import numpy as np
 from loguru import logger
 
 from qilisdk.analog.hamiltonian import Hamiltonian

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -422,7 +422,8 @@ class Schedule(Parameterizable):
         Returns:
             Number: The coefficient of the Hamiltonian at the specified time, or 0 if not defined.
         """
-        val = self.get_coefficient_expression(time_step=float(time_step), hamiltonian_key=hamiltonian_key)
+        time_step = float(time_step)
+        val = self.get_coefficient_expression(time_step=time_step, hamiltonian_key=hamiltonian_key)
         return val.evaluate({}) if isinstance(val, Term) else (val.evaluate() if isinstance(val, Parameter) else val)
 
     def get_coefficient_expression(self, time_step: float, hamiltonian_key: str) -> Number | Term | Parameter:

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+import numpy as np
 from loguru import logger
 
 from qilisdk.analog.hamiltonian import Hamiltonian
@@ -110,7 +111,7 @@ class Schedule(Parameterizable):
                                 f"The schedule can only contain Parameters, but a generic variable was provided ({time_step})"
                             )
                         self._parameters[v.label] = v
-                if isinstance(coeff, BaseVariable):
+                elif isinstance(coeff, BaseVariable):
                     if not isinstance(coeff, Parameter):
                         raise ValueError(
                             f"The schedule can only contain Parameters, but a generic variable was provided ({time_step})"
@@ -256,12 +257,12 @@ class Schedule(Parameterizable):
         self._hamiltonians[label] = hamiltonian
         self._schedule[0][label] = 0
         self._nqubits = max(self._nqubits, hamiltonian.nqubits)
-        for l, param in hamiltonian.parameters.items():
+        for _, param in hamiltonian.parameters.items():
             self._parameters[param.label] = param
 
         if schedule is not None:
             for t in range(int(self.T / self.dt)):
-                time_step = schedule(t, **kwargs)
+                time_step = schedule(float(t), **kwargs)
                 if isinstance(time_step, Term):
                     for v in time_step.variables():
                         if not isinstance(v, Parameter):
@@ -422,7 +423,7 @@ class Schedule(Parameterizable):
         Returns:
             Number: The coefficient of the Hamiltonian at the specified time, or 0 if not defined.
         """
-        val = self.get_coefficient_expression(time_step=time_step, hamiltonian_key=hamiltonian_key)
+        val = self.get_coefficient_expression(time_step=float(time_step), hamiltonian_key=hamiltonian_key)
         return val.evaluate({}) if isinstance(val, Term) else (val.evaluate() if isinstance(val, Parameter) else val)
 
     def get_coefficient_expression(self, time_step: float, hamiltonian_key: str) -> Number | Term | Parameter:
@@ -502,3 +503,5 @@ class Schedule(Parameterizable):
         renderer.plot()
         if filepath:
             renderer.save(filepath)
+        else:
+            renderer.show()

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -24,7 +24,6 @@ from qutip_qip.circuit import CircuitSimulator, QubitCircuit
 from qutip_qip.operations.gateclass import SingleQubitGate, is_qutip5
 
 from qilisdk.analog.hamiltonian import Hamiltonian, PauliI, PauliOperator
-from qilisdk.analog.schedule import Schedule
 from qilisdk.backends.backend import Backend
 from qilisdk.common.qtensor import QTensor, tensor_prod
 from qilisdk.digital import RX, RY, RZ, SWAP, U1, U2, U3, Circuit, H, I, M, S, T, X, Y, Z
@@ -34,7 +33,6 @@ from qilisdk.functionals.sampling_result import SamplingResult
 from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 
 if TYPE_CHECKING:
-    from qilisdk.common.variables import Number
     from qilisdk.functionals.sampling import Sampling
     from qilisdk.functionals.time_evolution import TimeEvolution
 

--- a/src/qilisdk/common/qtensor.py
+++ b/src/qilisdk/common/qtensor.py
@@ -185,7 +185,7 @@ class QTensor:
         # diagonal() returns dense 1D array; summing it is cheap
         return complex(self._data.diagonal().sum())
 
-    def ptrace(self, keep: list[int], dims: list[int] | None = None) -> QTensor:
+    def k(self, keep: list[int], dims: list[int] | None = None) -> QTensor:
         """
         Compute the partial trace over subsystems not in 'keep'.
 

--- a/src/qilisdk/common/qtensor.py
+++ b/src/qilisdk/common/qtensor.py
@@ -185,7 +185,7 @@ class QTensor:
         # diagonal() returns dense 1D array; summing it is cheap
         return complex(self._data.diagonal().sum())
 
-    def k(self, keep: list[int], dims: list[int] | None = None) -> QTensor:
+    def ptrace(self, keep: list[int], dims: list[int] | None = None) -> QTensor:
         """
         Compute the partial trace over subsystems not in 'keep'.
 

--- a/src/qilisdk/common/variables.py
+++ b/src/qilisdk/common/variables.py
@@ -890,6 +890,9 @@ class BaseVariable(ABC):
         if isinstance(other, Term):
             return other + self
 
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return Term(elements=[self, other], operation=Operation.ADD)
 
     __radd__ = __add__
@@ -901,6 +904,9 @@ class BaseVariable(ABC):
         if isinstance(other, Term):
             return other * self
 
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return Term(elements=[self, other], operation=Operation.MUL)
 
     def __rmul__(self, other: Number | BaseVariable | Term) -> Term:
@@ -909,6 +915,9 @@ class BaseVariable(ABC):
         if isinstance(other, Term):
             return other * self
 
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return Term(elements=[other, self], operation=Operation.MUL)
 
     __imul__ = __mul__
@@ -916,11 +925,19 @@ class BaseVariable(ABC):
     def __sub__(self, other: Number | BaseVariable | Term) -> Term:
         if not isinstance(other, (Number, BaseVariable, Term)):
             return NotImplemented
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return self + -1 * other
 
     def __rsub__(self, other: Number | BaseVariable | Term) -> Term:
         if not isinstance(other, (Number, BaseVariable, Term)):
             return NotImplemented
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return -1 * self + other
 
     __isub__ = __sub__
@@ -935,6 +952,8 @@ class BaseVariable(ABC):
         if other == 0:
             raise ValueError("Division by zero is not allowed")
 
+        if isinstance(other, np.generic):
+            other = other.item()
         other = 1 / other
         return self * other
 
@@ -1665,6 +1684,10 @@ class Term:
         if not isinstance(other, (Number, BaseVariable, Term)):
             return NotImplemented
         out = self.to_list() if self.operation == Operation.ADD else [copy.copy(self)]
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         out.append(other)
         return Term(out, Operation.ADD)
 
@@ -1674,6 +1697,9 @@ class Term:
         if not isinstance(other, (Number, BaseVariable, Term)):
             return NotImplemented
         out = self.to_list() if self.operation == Operation.ADD else [copy.copy(self)]
+
+        if isinstance(other, np.generic):
+            other = other.item()
         out.insert(0, other)
         return Term(out, Operation.ADD)
 
@@ -1683,6 +1709,10 @@ class Term:
         out = self.to_list() if self.operation == Operation.MUL else [copy.copy(self)]
         if len(out) == 0:
             out = [0]
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         out.append(other)
         return Term(out, Operation.MUL)._unfold_parentheses()
 
@@ -1694,6 +1724,10 @@ class Term:
         out = self.to_list() if self.operation == Operation.MUL else [copy.copy(self)]
         if len(out) == 0:
             out = [0]
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         out.insert(0, other)
         return Term(out, Operation.MUL)._unfold_parentheses()
 
@@ -1703,6 +1737,10 @@ class Term:
     def __sub__(self, other: Number | BaseVariable | Term) -> Term:
         if not isinstance(other, (Number, BaseVariable, Term)):
             return NotImplemented
+
+        if isinstance(other, np.generic):
+            other = other.item()
+
         return self + -1 * other
 
     def __rsub__(self, other: Number | BaseVariable | Term) -> Term:

--- a/src/qilisdk/utils/visualization/schedule_renderers.py
+++ b/src/qilisdk/utils/visualization/schedule_renderers.py
@@ -146,6 +146,11 @@ class MatplotlibScheduleRenderer:
 
         self.ax.figure.savefig(filename, bbox_inches="tight")  # type: ignore[union-attr]
 
+    def show(self) -> None:  # noqa: PLR6301
+        """Show the current figure."""
+
+        plt.show()
+
     @staticmethod
     def _make_axes(dpi: int, style: ScheduleStyle) -> plt.Axes:
         """

--- a/tests/analog/test_schedule.py
+++ b/tests/analog/test_schedule.py
@@ -300,6 +300,9 @@ def test_draw_method_runs(monkeypatch):
         def save(self, *a, **kw):
             return None
 
+        def show(self):
+            pass
+
     monkeypatch.setattr("qilisdk.utils.visualization.schedule_renderers.MatplotlibScheduleRenderer", DummyRenderer)
     sched.draw()
 


### PR DESCRIPTION
- Fixed the scheduler so numpy floats are accepted without errors. 
- Fixed the QuTiP backend by aligning the schedule-to-backend mapping structure.