### PR TITLE
[SDK-148] Improve Versioning Navbar

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -40,9 +40,22 @@ jobs:
         working-directory: docs
         run: uv run make multiversion
 
-      - name: Redirect root to main
+      - name: Redirect root to latest release tag
         run: |
-          echo '<!doctype html><meta http-equiv="refresh" content="0; url=main/">' > docs/_build/html/index.html
+          latest_tag="${{ github.event.release.tag_name }}"
+          if [ -z "$latest_tag" ]; then
+            latest_tag="$(git tag --sort=-version:refname | head -n 1)"
+          fi
+          if [ -z "$latest_tag" ]; then
+            echo "No tag found to redirect to" >&2
+            exit 1
+          fi
+          if [ ! -d "docs/_build/html/${latest_tag}" ]; then
+            echo "Built docs for tag ${latest_tag} not found" >&2
+            ls docs/_build/html
+            exit 1
+          fi
+          printf '<!doctype html><meta http-equiv="refresh" content="0; url=%s/">' "$latest_tag" > docs/_build/html/index.html
 
       - name: Deploy to GitHub Pages
         env:

--- a/changes/109.doc.md
+++ b/changes/109.doc.md
@@ -1,0 +1,1 @@
+Docs publishing now points the root of the site to the latest release docs and keeps "main" as a clearly labeled development build, with the version picker reorganized into separate Releases and Development sections so visitors land on the most current tag while still finding the dev docs easily.

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,8 +1,32 @@
 {% if versions %}
-<h3>{{ _('Versions') }}</h3>
-<ul>
-  {%- for item in versions|reverse %}
-  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
-  {%- endfor %}
-</ul>
+  {% set dev_versions = versions | selectattr("name", "equalto", "main") | list %}
+  {% set release_versions = versions | rejectattr("name", "equalto", "main") | list %}
+
+  <nav class="table w-full min-w-full my-6 lg:my-8 border-t pt-6">
+    {% if release_versions %}
+    <p class="caption" role="heading">
+      <span class="caption_text">{{ _('Releases') }}</span>
+    </p>
+    <ul>
+      {%- for item in release_versions|reverse %}
+      <li class="toctree-l1">
+        <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {% endif %}
+
+    {% if dev_versions %}
+    <p class="caption" role="heading">
+      <span class="caption_text">{{ _('Development') }}</span>
+    </p>
+    <ul>
+      {%- for item in dev_versions %}
+      <li class="toctree-l1">
+        <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+      </li>
+      {%- endfor %}
+    </ul>
+    {% endif %}
+  </nav>
 {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ autoapi_keep_files = False
 smv_tag_whitelist = r"^\d+\.\d+(\.\d+)?$"
 
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = None
+smv_branch_whitelist = r"^main$"
 
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"


### PR DESCRIPTION
Docs publishing now points the root of the site to the latest release docs and keeps "main" as a clearly labeled development build, with the version picker reorganized into separate Releases and Development sections so visitors land on the most current tag while still finding the dev docs easily.