### PR TITLE
[SDK-122] dense to dense()

### DIFF
--- a/changes/122.misc.md
+++ b/changes/122.misc.md
@@ -1,0 +1,1 @@
+The property "dense" of QTensor has been changed to a method (i.e. now "QTensor.dense()"), since it could be expensive in the case of a large sparse object, and it being a property would make it seem like it's just accessing a cached dense object.

--- a/docs/examples/quantum_objects.ipynb
+++ b/docs/examples/quantum_objects.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b98626ac",
    "metadata": {},
    "outputs": [
@@ -47,27 +47,27 @@
    "source": [
     "# 1‑qubit |0> ket\n",
     "psi_ket = QTensor(np.array([[1], [0]]))\n",
-    "print(\"Ket:\", psi_ket.dense, \"is_ket?\", psi_ket.is_ket())\n",
+    "print(\"Ket:\", psi_ket.dense(), \"is_ket?\", psi_ket.is_ket())\n",
     "print(\"-\" * 20)\n",
     "\n",
     "# 1‑qubit <0| bra\n",
     "psi_bra = QTensor(np.array([[1, 0]]))\n",
-    "print(\"Bra:\", psi_bra.dense, \"is_bra?\", psi_bra.is_bra())\n",
+    "print(\"Bra:\", psi_bra.dense(), \"is_bra?\", psi_bra.is_bra())\n",
     "print(\"-\" * 20)\n",
     "\n",
     "# Density matrix |0><0|\n",
     "rho = QTensor(np.array([[1, 0], [0, 0]]))\n",
-    "print(\"Density matrix:\\n\", rho.dense, \"is_density_matrix?\", rho.is_density_matrix())\n",
+    "print(\"Density matrix:\\n\", rho.dense(), \"is_density_matrix?\", rho.is_density_matrix())\n",
     "print(\"-\" * 20)\n",
     "\n",
     "# Scalar 0.5\n",
     "scalar = QTensor(np.array([[0.5]]))\n",
-    "print(\"Scalar:\", scalar.dense, \"is_scalar?\", scalar.is_scalar())"
+    "print(\"Scalar:\", scalar.dense(), \"is_scalar?\", scalar.is_scalar())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0f06dcdc",
    "metadata": {},
    "outputs": [
@@ -87,16 +87,16 @@
    ],
    "source": [
     "# Single‑qubit\n",
-    "print(\"ket(0):\", ket(0).dense, \"is_ket?\", ket(0).is_ket())\n",
-    "print(\"bra(1):\", bra(1).dense, \"is_bra?\", bra(1).is_bra())\n",
+    "print(\"ket(0):\", ket(0).dense(), \"is_ket?\", ket(0).is_ket())\n",
+    "print(\"bra(1):\", bra(1).dense(), \"is_bra?\", bra(1).is_bra())\n",
     "\n",
     "# Fock basis in N=4 Hilbert space\n",
-    "print(\"basis_state(2,4):\", basis_state(2, 4).dense, \"shape:\", basis_state(2, 4).shape)"
+    "print(\"basis_state(2,4):\", basis_state(2, 4).dense(), \"shape:\", basis_state(2, 4).shape)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9e8782d7",
    "metadata": {},
    "outputs": [
@@ -131,13 +131,13 @@
     "# Adjoint of a non-Hermitian operator\n",
     "A = QTensor(np.array([[1 + 1j, 2], [3, 4]]))\n",
     "A_dag = A.adjoint()\n",
-    "print(\"A:\\n\", A.dense)\n",
-    "print(\"A†:\\n\", A_dag.dense)\n",
+    "print(\"A:\\n\", A.dense())\n",
+    "print(\"A†:\\n\", A_dag.dense())\n",
     "\n",
     "# Matrix exponential of Pauli-X\n",
     "X = QTensor(np.array([[0, 1], [1, 0]]))\n",
     "expX = X.expm()\n",
-    "print(\"exp(X):\\n\", np.round(expX.dense, 3))\n",
+    "print(\"exp(X):\\n\", np.round(expX.dense(), 3))\n",
     "\n",
     "# Norm of a ket and a density matrix\n",
     "ket0 = QTensor(np.array([[1], [0]]))\n",
@@ -152,12 +152,12 @@
     "rho_bell = bell.to_density_matrix()\n",
     "print(\"rho_bell:\\n\", rho_bell)\n",
     "rhoA = rho_bell.ptrace([0])\n",
-    "print(\"rho_A:\\n\", rhoA.dense)"
+    "print(\"rho_A:\\n\", rhoA.dense())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "a1e04662",
    "metadata": {},
    "outputs": [
@@ -178,7 +178,7 @@
     "# Two‑qubit Hadamard tensor\n",
     "H = QTensor(np.array([[1, 1], [1, -1]]) / np.sqrt(2))\n",
     "H2 = tensor_prod([H, H])\n",
-    "print(\"H ⊗ H:\\n\", np.round(H2.dense, 3))\n",
+    "print(\"H ⊗ H:\\n\", np.round(H2.dense(), 3))\n",
     "\n",
     "# Expectation of Z⊗Z on |00>\n",
     "Z = QTensor(np.array([[1, 0], [0, -1]]))\n",

--- a/docs/fundamentals/core.rst
+++ b/docs/fundamentals/core.rst
@@ -600,22 +600,22 @@ Examples of creating various quantum objects:
 
     # 1‑qubit |0> ket
     psi_ket = QTensor(np.array([[1], [0]]))
-    print("Ket:", psi_ket.dense, "is_ket?", psi_ket.is_ket())
+    print("Ket:", psi_ket.dense(), "is_ket?", psi_ket.is_ket())
     print("-" * 20)
 
     # 1‑qubit <0| bra
     psi_bra = QTensor(np.array([[1, 0]]))
-    print("Bra:", psi_bra.dense, "is_bra?", psi_bra.is_bra())
+    print("Bra:", psi_bra.dense(), "is_bra?", psi_bra.is_bra())
     print("-" * 20)
 
     # Density matrix |0><0|
     rho = QTensor(np.array([[1, 0], [0, 0]]))
-    print("Density matrix:\n", rho.dense, "is_density_matrix?", rho.is_density_matrix())
+    print("Density matrix:\n", rho.dense(), "is_density_matrix?", rho.is_density_matrix())
     print("-" * 20)
 
     # Scalar 0.5
     scalar = QTensor(np.array([[0.5]]))
-    print("Scalar:", scalar.dense, "is_scalar?", scalar.is_scalar())
+    print("Scalar:", scalar.dense(), "is_scalar?", scalar.is_scalar())
 
 **Output**
 
@@ -640,11 +640,11 @@ Helper constructors
     from qilisdk.core.qtensor import ket, bra, basis_state
 
     # Single‑qubit
-    print("ket(0):\n", ket(0).dense, "\nis_ket?", ket(0).is_ket())
-    print("bra(1):\n", bra(1).dense, "\nis_bra?", bra(1).is_bra())
+    print("ket(0):\n", ket(0).dense(), "\nis_ket?", ket(0).is_ket())
+    print("bra(1):\n", bra(1).dense(), "\nis_bra?", bra(1).is_bra())
 
     # Fock basis in N=4 Hilbert space
-    print("basis_state(2,4):\n", basis_state(2, 4).dense, "\nshape:", basis_state(2, 4).shape)
+    print("basis_state(2,4):\n", basis_state(2, 4).dense(), "\nshape:", basis_state(2, 4).shape)
 
 **Output**
 
@@ -670,7 +670,7 @@ Quantum Object Properties & Operations
 All data are stored sparsely, but you can retrieve dense or sparse views:
 
 - ``.data``: sparse :class:`scipy.sparse.csr_matrix`  
-- ``.dense``: full NumPy array
+- ``.dense()``: get a full NumPy array (note: could be expensive for large sparse objects)
 
 Key methods:
 
@@ -690,13 +690,13 @@ Examples:
     # Adjoint of a non-Hermitian operator
     A = QTensor(np.array([[1+1j, 2], [3, 4]]))
     A_dag = A.adjoint()
-    print("A:\n", A.dense)
-    print("A†:\n", A_dag.dense)
+    print("A:\n", A.dense())
+    print("A†:\n", A_dag.dense())
 
     # Matrix exponential of Pauli-X
     X = QTensor(np.array([[0, 1], [1, 0]]))
     expX = X.expm()
-    print("exp(X):\n", np.round(expX.dense, 3))
+    print("exp(X):\n", np.round(expX.dense(), 3))
 
     # Norm of a ket and a density matrix
     ket0 = QTensor(np.array([[1], [0]]))
@@ -710,7 +710,7 @@ Examples:
     rho_bell = bell.to_density_matrix()
     print("rho_bell:\n", rho_bell)
     rhoA = rho_bell.ptrace([0])
-    print("rho_A:\n", rhoA.dense)
+    print("rho_A:\n", rhoA.dense())
 
 **Output**
 
@@ -752,7 +752,7 @@ Extra Utilities
     # Two‑qubit Hadamard tensor
     H = QTensor(np.array([[1, 1], [1, -1]]) / np.sqrt(2))
     H2 = tensor_prod([H, H])
-    print("H ⊗ H:\n", np.round(H2.dense, 3))
+    print("H ⊗ H:\n", np.round(H2.dense(), 3))
 
     # Expectation of Z⊗Z on |00>
     Z = QTensor(np.array([[1, 0], [0, -1]]))

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -521,7 +521,7 @@ class Hamiltonian(Parameterizable):
         Raises
             ValueError: If the input is not square, not a power-of-two dimension, or not Hermitian w.r.t. `tol`.
         """
-        A = np.asarray(tensor.dense)
+        A = np.asarray(tensor.dense())
 
         dim = tensor.shape[0]
         n = round(np.log2(dim))
@@ -549,7 +549,7 @@ class Hamiltonian(Parameterizable):
                 op = op * pauli_for[letter](q) if op != 0 else pauli_for[letter](q)
 
             # Convert to dense once; no padding needed because it spans all n qubits
-            P_dense = op.to_qtensor(n).dense
+            P_dense = op.to_qtensor(n).dense()
 
             # Coefficient c_P = Tr(A P) / 2^n  (P is Hermitian)
             c = norm * np.trace(A @ P_dense)
@@ -562,7 +562,7 @@ class Hamiltonian(Parameterizable):
                 H += c * op
 
         # Optional: verify round-trip (use a slightly looser atol to tolerate pruning)
-        if not np.allclose(H.to_qtensor(n).dense, A, atol=max(10 * prune, 1e-9)):
+        if not np.allclose(H.to_qtensor(n).dense(), A, atol=max(10 * prune, 1e-9)):
             # If this triggers, consider lowering `prune` or raising `tol`.
             raise ValueError("Pauli expansion failed round-trip check; try adjusting tolerances.")
 

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -191,7 +191,7 @@ class CudaBackend(Backend):
             hamiltonian=cuda_hamiltonian,
             dimensions=dict.fromkeys(range(functional.schedule.nqubits), 2),
             schedule=cuda_schedule,
-            initial_state=State.from_data(np.array(functional.initial_state.unit().dense, dtype=np.complex128)),
+            initial_state=State.from_data(np.array(functional.initial_state.unit().dense(), dtype=np.complex128)),
             observables=cuda_observables,
             collapse_operators=[],
             store_intermediate_results=functional.store_intermediate_results,

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -202,7 +202,7 @@ class QutipBackend(Backend):
             logger.error("Invalid initial state provided")
             raise ValueError("invalid initial state provided.")
 
-        qutip_init_state = Qobj(functional.initial_state.dense, dims=state_dim)
+        qutip_init_state = Qobj(functional.initial_state.dense(), dims=state_dim)
 
         qutip_obs: list[Qobj] = []
 
@@ -231,7 +231,7 @@ class QutipBackend(Backend):
                 raise ValueError(f"unsupported observable type of {obs.__class__}")
             if aux_obs is not None:
                 qutip_obs.append(
-                    Qobj(aux_obs.dense, dims=[[2 for _ in range(functional.schedule.nqubits)] for _ in range(2)])
+                    Qobj(aux_obs.dense(), dims=[[2 for _ in range(functional.schedule.nqubits)] for _ in range(2)])
                 )
 
         results = mesolve(

--- a/src/qilisdk/core/qtensor.py
+++ b/src/qilisdk/core/qtensor.py
@@ -143,7 +143,6 @@ class QTensor:
         """
         return self._data.shape
 
-    @property
     def dense(self) -> np.ndarray:
         """
         Get the dense (NumPy array) representation of the QTensor.

--- a/src/qilisdk/cost_functions/model_cost_function.py
+++ b/src/qilisdk/cost_functions/model_cost_function.py
@@ -84,12 +84,12 @@ class ModelCostFunction(CostFunction):
         total_cost = complex(0.0)
 
         if results.final_state.is_density_matrix(tol=1e-5):
-            rho = results.final_state.dense
+            rho = results.final_state.dense()
             n = results.final_state.nqubits
             for i in range(rho.shape[0]):
                 state = [int(b) for b in f"{i:0{n}b}"]
                 _ket_state = ket(*state)
-                _prob = complex(np.real_if_close(np.trace((_ket_state @ _ket_state.adjoint()).dense @ rho)))
+                _prob = complex(np.real_if_close(np.trace((_ket_state @ _ket_state.adjoint()).dense() @ rho)))
                 variable_map = {v: int(state[i]) for i, v in enumerate(self.model.variables())}
                 evaluate_results = self.model.evaluate(variable_map)
                 total_cost += sum(v for v in evaluate_results.values()) * _prob
@@ -99,9 +99,9 @@ class ModelCostFunction(CostFunction):
 
         dense_state = None
         if results.final_state.is_ket():
-            dense_state = results.final_state.dense.T[0]
+            dense_state = results.final_state.dense().T[0]
         elif results.final_state.is_bra():
-            dense_state = results.final_state.dense[0]
+            dense_state = results.final_state.dense()[0]
 
         if dense_state is None:
             raise ValueError("The final state is invalid.")

--- a/tests/backends/test_qutip_backend.py
+++ b/tests/backends/test_qutip_backend.py
@@ -170,7 +170,7 @@ def test_constant_hamiltonian():
     # Intermediate states should replicate constant behavior
     assert res.intermediate_states is not None
     for state in res.intermediate_states:
-        psi = state.dense.flatten()
+        psi = state.dense().flatten()
         assert pytest.approx(abs(psi[0]) ** 2, rel=1e-6) == 1.0
 
 

--- a/tests/common/test_qtensor.py
+++ b/tests/common/test_qtensor.py
@@ -66,11 +66,11 @@ def test_nqubits(array, expected_nqubits):
     assert qobj.nqubits == expected_nqubits
 
 
-def test_dense_property():
-    """The dense property should return a NumPy array equivalent to the original data."""
+def test_dense_method():
+    """The dense method should return a NumPy array equivalent to the original data."""
     arr = np.array([[1, 2], [3, 4]])
     qobj = QTensor(arr)
-    np.testing.assert_array_equal(qobj.dense, arr)
+    np.testing.assert_array_equal(qobj.dense(), arr)
 
 
 # --- Method Tests ---
@@ -81,7 +81,7 @@ def test_dag():
     arr = np.array([[1 + 2j, 2], [3, 4 + 5j]])
     qobj = QTensor(arr)
     dagger_qobj = qobj.adjoint()
-    np.testing.assert_array_equal(dagger_qobj.dense, arr.conj().T)
+    np.testing.assert_array_equal(dagger_qobj.dense(), arr.conj().T)
 
 
 def test_ptrace_valid():
@@ -113,24 +113,24 @@ def test_ptrace_valid():
     expected_double_qubit = ket(1, 0).to_density_matrix()
 
     # Checks:
-    np.testing.assert_allclose(reduced_single_qubit_ground.dense, expected_single_qubit_ground.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_single_qubit_excited.dense, expected_single_qubit_excited.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_double_qubit_1.dense, expected_double_qubit.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_double_qubit_2.dense, expected_double_qubit.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_double_qubit_3.dense, expected_double_qubit.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_1.dense, expected_single_qubit_excited.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_0.dense, expected_single_qubit_ground.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_1_big.dense, expected_single_qubit_excited.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_0_big.dense, expected_single_qubit_ground.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_1_big_bra.dense, expected_single_qubit_excited.dense, atol=1e-8)
-    np.testing.assert_allclose(reduced_ket_qubit_0_big_bra.dense, expected_single_qubit_ground.dense, atol=1e-8)
+    np.testing.assert_allclose(reduced_single_qubit_ground.dense(), expected_single_qubit_ground.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_single_qubit_excited.dense(), expected_single_qubit_excited.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_double_qubit_1.dense(), expected_double_qubit.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_double_qubit_2.dense(), expected_double_qubit.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_double_qubit_3.dense(), expected_double_qubit.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_1.dense(), expected_single_qubit_excited.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_0.dense(), expected_single_qubit_ground.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_1_big.dense(), expected_single_qubit_excited.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_0_big.dense(), expected_single_qubit_ground.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_1_big_bra.dense(), expected_single_qubit_excited.dense(), atol=1e-8)
+    np.testing.assert_allclose(reduced_ket_qubit_0_big_bra.dense(), expected_single_qubit_ground.dense(), atol=1e-8)
 
 
 def test_ptrace_valid_keep_with_automatic_dims_and_density_matrix():
     qket = ket(0, 0, 1, 0)
     reduced_single_qubit = qket.ptrace(keep=[2, 3])
     expected_single_qubit = ket(1, 0).to_density_matrix()
-    np.testing.assert_allclose(reduced_single_qubit.dense, expected_single_qubit.dense, atol=1e-8)
+    np.testing.assert_allclose(reduced_single_qubit.dense(), expected_single_qubit.dense(), atol=1e-8)
 
 
 def test_ptrace_works_for_operators_which_are_not_density_matrices():
@@ -144,7 +144,7 @@ def test_ptrace_works_for_operators_which_are_not_density_matrices():
     # Pick an out of order keep list:
     keep = [0, 2]  # subspace 2 *then* subspace 0
     expected_result = np.array([[2, 0, 0, 0], [0, 4, 0, 0], [0, 0, 10, 0], [0, 0, 0, 12]])
-    np.testing.assert_allclose(q_obj.ptrace(keep, dims).dense, expected_result, atol=1e-8)
+    np.testing.assert_allclose(q_obj.ptrace(keep, dims).dense(), expected_result, atol=1e-8)
 
 
 # def test_ptrace_invalid_dims():
@@ -178,7 +178,7 @@ def test_add_scalar_zero(other):
     arr = np.array([[1, 0], [0, 1]])
     qobj = QTensor(arr)
     result = qobj + other
-    np.testing.assert_array_equal(result.dense, qobj.dense)
+    np.testing.assert_array_equal(result.dense(), qobj.dense())
 
 
 def test_add_QTensor():
@@ -187,7 +187,7 @@ def test_add_QTensor():
     q1 = QTensor(arr)
     q2 = QTensor(arr)
     result = q1 + q2
-    np.testing.assert_array_equal(result.dense, arr + arr)
+    np.testing.assert_array_equal(result.dense(), arr + arr)
 
 
 def test_add_invalid_type():
@@ -205,7 +205,7 @@ def test_sub_QTensor():
     q1 = QTensor(arr1)
     q2 = QTensor(arr2)
     result = q1 - q2
-    np.testing.assert_array_equal(result.dense, arr1 - arr2)
+    np.testing.assert_array_equal(result.dense(), arr1 - arr2)
 
 
 def test_sub_invalid_type():
@@ -222,7 +222,7 @@ def test_mul_scalar(scalar):
     arr = np.array([[1, 0], [0, 1]])
     qobj = QTensor(arr)
     result = qobj * scalar
-    np.testing.assert_array_equal(result.dense, arr * scalar)
+    np.testing.assert_array_equal(result.dense(), arr * scalar)
 
 
 def test_mul_QTensor():
@@ -232,7 +232,7 @@ def test_mul_QTensor():
     q1 = QTensor(arr1)
     q2 = QTensor(arr2)
     result = q1 * q2
-    np.testing.assert_array_equal(result.dense, arr1 * arr2)
+    np.testing.assert_array_equal(result.dense(), arr1 * arr2)
 
 
 def test_mul_invalid_type():
@@ -248,7 +248,7 @@ def test_rmul():
     arr = np.array([[1, 0], [0, 1]])
     qobj = QTensor(arr)
     result = 3 * qobj
-    np.testing.assert_array_equal(result.dense, arr * 3)
+    np.testing.assert_array_equal(result.dense(), arr * 3)
 
 
 def test_matmul():
@@ -257,7 +257,7 @@ def test_matmul():
     q1 = QTensor(arr)
     q2 = QTensor(np.eye(2))
     result = q1 @ q2
-    np.testing.assert_array_equal(result.dense, arr @ np.eye(2))
+    np.testing.assert_array_equal(result.dense(), arr @ np.eye(2))
 
 
 def test_matmul_invalid_type():
@@ -325,7 +325,7 @@ def test_expm():
     qobj = QTensor(arr)
     result = qobj.expm()
     expected = np.array([[1, 0], [0, 2]])
-    np.testing.assert_allclose(result.dense, expected, atol=1e-8)
+    np.testing.assert_allclose(result.dense(), expected, atol=1e-8)
 
 
 def test_is_ket():
@@ -374,7 +374,7 @@ def test_to_dm_from_dm():
     """to_dm() called on a density matrix should return a valid density matrix."""
     qdm = ket(0).to_density_matrix()
     dm2 = qdm.to_density_matrix()
-    np.testing.assert_allclose(dm2.dense, qdm.dense, atol=1e-8)
+    np.testing.assert_allclose(dm2.dense(), qdm.dense(), atol=1e-8)
 
 
 def test_to_dm_from_ket():
@@ -400,7 +400,7 @@ def test_basis():
     n = 2
     qbasis = basis_state(n, N)
     assert qbasis.shape == (N, 1)
-    dense = qbasis.dense.flatten()
+    dense = qbasis.dense().flatten()
     expected = np.zeros(N)
     expected[n] = 1
     np.testing.assert_array_equal(dense, expected)
@@ -441,7 +441,7 @@ def test_tensor():
     q1 = ket(0)
     q2 = ket(1)
     qt = tensor_prod([q1, q2])
-    np.testing.assert_array_equal(qt.dense.shape, (4, 1))
+    np.testing.assert_array_equal(qt.dense().shape, (4, 1))
 
 
 def test_expect_density():
@@ -471,8 +471,8 @@ def test_to_density_matrix():
 
     s = ket(0)
     qdm = s.to_density_matrix()
-    np.testing.assert_allclose(qdm.dense, np.array([[1, 0], [0, 0]]), atol=1e-8)
+    np.testing.assert_allclose(qdm.dense(), np.array([[1, 0], [0, 0]]), atol=1e-8)
 
     s = bra(0)
     qdm = s.to_density_matrix()
-    np.testing.assert_allclose(qdm.dense, np.array([[1, 0], [0, 0]]), atol=1e-8)
+    np.testing.assert_allclose(qdm.dense(), np.array([[1, 0], [0, 0]]), atol=1e-8)

--- a/tests/functionals/test_time_evolution_results.py
+++ b/tests/functionals/test_time_evolution_results.py
@@ -45,5 +45,5 @@ def test_time_evolution_results_initialization():
     )
 
     expected_list = [[0], [1]]
-    for i, l in enumerate(list(ter.final_state.dense)):
+    for i, l in enumerate(list(ter.final_state.dense())):
         assert list(l) == expected_list[i]


### PR DESCRIPTION
The property "dense" of QTensor has been changed to a method (i.e. now "QTensor.dense()"), since it could be expensive in the case of a large sparse object, and it being a property would make it seem like it's just accessing a cached dense object.