### PR TITLE
[SDK-98] updated docs / tests for HardwareEfficientAnsatz with explict connectivity

### DIFF
--- a/changes/98.feature.md
+++ b/changes/98.feature.md
@@ -1,0 +1,1 @@
+HardwareEfficientAnsatz now supports explicit specification of connectivity via a list of tuples.

--- a/docs/fundamentals/digital.rst
+++ b/docs/fundamentals/digital.rst
@@ -306,6 +306,7 @@ HardwareEfficientAnsatz
   - ``circular``: Qubits form a ring.
   - ``linear``: Qubits are connected linearly.
   - ``full``: All-to-all connectivity.
+  - Or a list of tuples explicitly specifying the connectivity.
 - **one_qubit_gate**: Choose the parameterized single-qubit gate (e.g., :class:`~qilisdk.digital.gates.U1`, :class:`~qilisdk.digital.gates.U2`, :class:`~qilisdk.digital.gates.U3`).
 - **two_qubit_gate**: Choose the two-qubit interaction type (e.g., :class:`~qilisdk.digital.gates.CNOT`, :class:`~qilisdk.digital.gates.CZ`).
 - **structure**:

--- a/src/qilisdk/digital/ansatz.py
+++ b/src/qilisdk/digital/ansatz.py
@@ -75,7 +75,7 @@ class HardwareEfficientAnsatz(Ansatz):
             nqubits (int): Number of qubits in the circuit.
             layers (int, optional): Number of entangling layers. Defaults to 1.
             connectivity (Connectivity, optional): Topology used for two-qubit gates.
-                Accepts ``"linear"``, ``"circular"``, ``"full"``, or an explicit list of edges.
+                Accepts ``"linear"``, ``"circular"``, ``"full"``, or an explicit list of tuples defining the edges.
                 Defaults to ``"linear"``.
             structure (Structure, optional): Layout of single- and two-qubit gates within each layer.
                 ``"grouped"`` applies all single-qubit gates before the entangler block; ``"interposed"``

--- a/tests/digital/test_ansatz.py
+++ b/tests/digital/test_ansatz.py
@@ -121,6 +121,20 @@ def test_connectivity_full_option_pairs():
     assert set(map(tuple, ansatz.connectivity)) == expected
 
 
+def test_connectivity_given_edges():
+    n_qubits = 3
+    given = [(0, 1), (0, 2)]
+    ansatz = HardwareEfficientAnsatz(nqubits=n_qubits, connectivity=given, structure="grouped")
+    expected = {(0, 1), (0, 2)}
+    assert set(map(tuple, ansatz.connectivity)) == expected
+
+    # check that all gates use only given edges
+    for gate in ansatz.gates:
+        if gate.nqubits == 2:
+            edge = (gate.qubits[0], gate.qubits[1])
+            assert edge in expected or (edge[1], edge[0]) in expected
+
+
 def test_connectivity_circular_option_pairs():
     n_qubits = 3
     ansatz = HardwareEfficientAnsatz(nqubits=n_qubits, connectivity="Circular", structure="grouped")


### PR DESCRIPTION
HardwareEfficientAnsatz now supports explicit specification of connectivity via a list of tuples.

Note: this was already present in the code, it's just now tested and mentioned in the docs.