### PR TITLE
[SDK-136] Multi-Controlled Simulations

### DIFF
--- a/changes/136.feature.md
+++ b/changes/136.feature.md
@@ -1,0 +1,1 @@
+Added support for gates with multiple controls in QuTiP and CUDA backends.

--- a/docs/fundamentals/digital.rst
+++ b/docs/fundamentals/digital.rst
@@ -64,7 +64,7 @@ Any basic gate can be turned into a controlled gate using the :class:`~qilisdk.d
     controlled_y = Controlled(0, basic_gate=Y(1))
     multiple_controlled_y = Controlled(0, 1, basic_gate=Y(2))
 
-Or alternatively, you can use the ``.controlled()`` method on any gate instance:
+Or alternatively, you can use the :meth:`.controlled()<qilisdk.digital.gates.BasicGate.controlled>` method on any gate instance:
 
 .. code-block:: python
 

--- a/docs/fundamentals/digital.rst
+++ b/docs/fundamentals/digital.rst
@@ -62,6 +62,17 @@ Any basic gate can be turned into a controlled gate using the :class:`~qilisdk.d
     from qilisdk.digital.gates import Controlled, Y
 
     controlled_y = Controlled(0, basic_gate=Y(1))
+    multiple_controlled_y = Controlled(0, 1, basic_gate=Y(2))
+
+Or alternatively, you can use the ``.controlled()`` method on any gate instance:
+
+.. code-block:: python
+
+    from qilisdk.digital.gates import Y
+
+    controlled_y = Y(1).controlled(0)
+    multiple_controlled_y = Y(2).controlled(0, 1)
+
 
 Adjoint Gates
 ^^^^^^^^^^^^^

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -315,12 +315,7 @@ class QutipBackend(Backend):
         For non-native controlled gates we construct the block-matrix explicitly, mirroring
         the approach recommended in the QuTiP QIP documentation for custom controlled rotations.
 
-        Raises:
-            UnsupportedGateError: If the number of control qubits is not equal to one or if the basic gate is unsupported.
         """
-        if len(gate.control_qubits) != 1:
-            logger.error("Controlled gate with {} control qubits not supported", len(gate.control_qubits))
-            raise UnsupportedGateError
 
         if gate.name == "CNOT":
             circuit.add_gate("CNOT", targets=[*gate.target_qubits], controls=[*gate.control_qubits])

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -281,7 +281,7 @@ class BasicGate(Gate):
         on both the control and target qubits.
 
         Args:
-            *control_qubits (int | list[int]): One or more integer indices specifying the control qubits.
+            *control_qubits (int): One or more integer indices specifying the control qubits.
 
         Returns:
             Controlled: A new Controlled gate instance that wraps this unitary gate with the specified control qubits.
@@ -380,7 +380,6 @@ class Modified(Gate, Generic[TBasicGate]):
 @yaml.register_class
 class Controlled(Modified[TBasicGate]):
     def __init__(self, *control_qubits: int, basic_gate: TBasicGate) -> None:
-
         super().__init__(basic_gate=basic_gate)
 
         # Check for duplicate integers in control_qubits.

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -281,7 +281,7 @@ class BasicGate(Gate):
         on both the control and target qubits.
 
         Args:
-            *control_qubits (int): One or more integer indices specifying the control qubits.
+            *control_qubits (int | list[int]): One or more integer indices specifying the control qubits.
 
         Returns:
             Controlled: A new Controlled gate instance that wraps this unitary gate with the specified control qubits.
@@ -380,6 +380,7 @@ class Modified(Gate, Generic[TBasicGate]):
 @yaml.register_class
 class Controlled(Modified[TBasicGate]):
     def __init__(self, *control_qubits: int, basic_gate: TBasicGate) -> None:
+
         super().__init__(basic_gate=basic_gate)
 
         # Check for duplicate integers in control_qubits.

--- a/tests/backends/test_qutip_backend.py
+++ b/tests/backends/test_qutip_backend.py
@@ -139,6 +139,34 @@ def test_controlled_handler(gate_instance):
 
 
 @pytest.mark.parametrize("gate_instance", [case[0] for case in basic_gate_test_cases + swap_test_case])
+def test_multi_controlled_handler(gate_instance):
+    backend = QutipBackend()
+    circuit = Circuit(nqubits=10)
+    controlled_gate = Controlled(7, 8, 9, basic_gate=gate_instance)
+    circuit.add(controlled_gate)
+    qutip_circuit = backend._get_qutip_circuit(circuit)
+    expected_targets = set(controlled_gate.target_qubits).union(set(controlled_gate.control_qubits))
+
+    assert any(g.name.startswith(controlled_gate.name) for g in qutip_circuit.gates)
+    assert any(set(g.targets) == expected_targets for g in qutip_circuit.gates)
+
+
+def test_multi_controlled_execution():
+    # Create two Xs then a multi-controlled X (Toffoli) gate
+    # Expect roughly all shots to be '111'
+    backend = QutipBackend()
+    circuit = Circuit(nqubits=3)
+    circuit.add(X(0))
+    circuit.add(X(1))
+    circuit.add(Controlled(0, 1, basic_gate=X(2)))
+    result = backend.execute(Sampling(circuit=circuit, nshots=100))
+    assert isinstance(result, SamplingResult)
+    samples = result.samples
+    assert "111" in samples
+    assert samples["111"] == 100
+
+
+@pytest.mark.parametrize("gate_instance", [case[0] for case in basic_gate_test_cases + swap_test_case])
 def test_handlers(gate_instance):
     backend = QutipBackend()
     circuit = Circuit(nqubits=10)


### PR DESCRIPTION
Added support for gates with multiple controls in QuTiP and CUDA backends.

Note: the code for this (i.e. decomposing and handling) was already implemented, it just needed tests and documentation.