### PR TITLE
[SDK-156] Update TimeEvolution code blocks in the documentation to use the new schedule structure

### DIFF
--- a/changes/119.doc.md
+++ b/changes/119.doc.md
@@ -1,0 +1,1 @@
+Updated TimeEvolution documentation examples (backends, functionals, cost_functions) to use the new Schedule signature with explicit driver/problem Hamiltonians, coefficient mappings, and linear interpolation import.

--- a/docs/fundamentals/backends.rst
+++ b/docs/fundamentals/backends.rst
@@ -184,6 +184,7 @@ It is the most lightweight option, ideal for local development or environments w
     import numpy as np
     from qilisdk.analog import Schedule, X, Z, Y
     from qilisdk.core import ket, tensor_prod
+    from qilisdk.core.interpolator import Interpolation
     from qilisdk.backends import QutipBackend, CudaBackend
     from qilisdk.functionals import TimeEvolution
 
@@ -198,14 +199,16 @@ It is the most lightweight option, ideal for local development or environments w
     Hz = sum(Z(i) for i in range(nqubits))
 
     # Build a time‑dependent schedule
-    schedule = Schedule(T, dt)
-
-    # Add hx with a time‐dependent coefficient function
-    schedule.add_hamiltonian(label="hx", hamiltonian=Hx, schedule=lambda t: 1 - steps[t] / T)
-
-    # Add hz similarly
-    schedule.add_hamiltonian(label="hz", hamiltonian=Hz, schedule=lambda t: steps[t] / T)
-
+    schedule = Schedule(
+        hamiltonians={"driver": Hx, "problem": Hz},
+        coefficients={
+            "driver": {(0.0, T): lambda t: 1 - t / T},
+            "problem": {(0.0, T): lambda t: t / T},
+        },
+        dt=0.5,
+        interpolation=Interpolation.LINEAR,
+    )
+    
     # Prepare an equal superposition initial state
     initial_state = tensor_prod([(ket(0) - ket(1)).unit() for _ in range(nqubits)]).unit()
 

--- a/docs/fundamentals/backends.rst
+++ b/docs/fundamentals/backends.rst
@@ -190,8 +190,7 @@ It is the most lightweight option, ideal for local development or environments w
 
     # Define total time and timestep
     T = 10.0
-    dt = 0.1
-    steps = np.linspace(0, T + dt, int(T / dt))
+    dt = 0.5
     nqubits = 1
 
     # Define Hamiltonians
@@ -205,7 +204,7 @@ It is the most lightweight option, ideal for local development or environments w
             "driver": {(0.0, T): lambda t: 1 - t / T},
             "problem": {(0.0, T): lambda t: t / T},
         },
-        dt=0.5,
+        dt=dt,
         interpolation=Interpolation.LINEAR,
     )
     

--- a/docs/fundamentals/cost_functions.rst
+++ b/docs/fundamentals/cost_functions.rst
@@ -55,8 +55,7 @@ Example: expectation value from time evolution
 
     # Define total time and timestep
     T = 10.0
-    dt = 0.1
-    steps = np.linspace(0, T + dt, int(T / dt))
+    dt = 0.5
     nqubits = 1
 
     # Define Hamiltonians
@@ -70,9 +69,10 @@ Example: expectation value from time evolution
             "driver": {(0.0, T): lambda t: 1 - t / T},
             "problem": {(0.0, T): lambda t: t / T},
         },
-        dt=0.5,
+        dt=dt,
         interpolation=Interpolation.LINEAR,
     )
+    
     schedule.draw()
 
     functional = TimeEvolution(

--- a/docs/fundamentals/functionals.rst
+++ b/docs/fundamentals/functionals.rst
@@ -148,8 +148,7 @@ classical optimizers.
 
     # Define total time and timestep
     T = 10.0
-    dt = 0.1
-    steps = np.linspace(0, T + dt, int(T / dt))
+    dt = 0.5
     nqubits = 1
 
     # Define Hamiltonians
@@ -163,7 +162,7 @@ classical optimizers.
             "driver": {(0.0, T): lambda t: 1 - t / T},
             "problem": {(0.0, T): lambda t: t / T},
         },
-        dt=0.5,
+        dt=dt,
         interpolation=Interpolation.LINEAR,
     )
     

--- a/docs/fundamentals/functionals.rst
+++ b/docs/fundamentals/functionals.rst
@@ -142,6 +142,7 @@ classical optimizers.
     import numpy as np
     from qilisdk.analog import Schedule, X, Z, Y
     from qilisdk.core import ket, tensor_prod
+    from qilisdk.core.interpolator import Interpolation
     from qilisdk.backends import QutipBackend, CudaBackend
     from qilisdk.functionals import TimeEvolution
 
@@ -156,14 +157,16 @@ classical optimizers.
     Hz = sum(Z(i) for i in range(nqubits))
 
     # Build a time‑dependent schedule
-    schedule = Schedule(T, dt)
-
-    # Add hx with a time‐dependent coefficient function
-    schedule.add_hamiltonian(label="hx", hamiltonian=Hx, schedule=lambda t: 1 - steps[t] / T)
-
-    # Add hz similarly
-    schedule.add_hamiltonian(label="hz", hamiltonian=Hz, schedule=lambda t: steps[t] / T)
-
+    schedule = Schedule(
+        hamiltonians={"driver": Hx, "problem": Hz},
+        coefficients={
+            "driver": {(0.0, T): lambda t: 1 - t / T},
+            "problem": {(0.0, T): lambda t: t / T},
+        },
+        dt=0.5,
+        interpolation=Interpolation.LINEAR,
+    )
+    
     # Prepare an equal superposition initial state
     initial_state = tensor_prod([(ket(0) - ket(1)).unit() for _ in range(nqubits)]).unit()
 


### PR DESCRIPTION
Updated TimeEvolution documentation examples (backends, functionals, cost_functions) to use the new Schedule signature with explicit driver/problem Hamiltonians, coefficient mappings, and linear interpolation import.