### PR TITLE
[SDK-155] Removing ``kwargs`` from ``schedule`` and ``interpolator``.

### DIFF
--- a/changes/122.removal.md
+++ b/changes/122.removal.md
@@ -1,0 +1,1 @@
+Removed `kwargs` from the constructors of the ``Schedule`` and ``Interpolator`` classes.

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from copy import copy
 from itertools import chain
-from typing import Any, Mapping, overload
+from typing import Mapping, overload
 
 from qilisdk.analog.hamiltonian import Hamiltonian
 from qilisdk.core.interpolator import Interpolation, Interpolator, TimeDict

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -71,7 +71,6 @@ class Schedule(Parameterizable):
         dt: float = 0.1,
         total_time: PARAMETERIZED_NUMBER | None = None,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None:
         """Create a Schedule that assigns time-dependent coefficients to Hamiltonians.
 
@@ -81,7 +80,6 @@ class Schedule(Parameterizable):
             dt (float): Time resolution used for sampling callable/interval definitions and plotting. Must be positive.
             total_time (float | Parameter | Term | None): Optional maximum time that rescales all defined time points proportionally.
             interpolation (Interpolation): How to interpolate between provided time points (``LINEAR`` or ``STEP``).
-            **kwargs: Passed to :class:`Interpolator` construction when coefficients are provided as dictionaries.
 
         Raises:
             ValueError: if the coefficients reference an undefined hamiltonian.
@@ -118,7 +116,7 @@ class Schedule(Parameterizable):
             if isinstance(coeff, Interpolator):
                 self._coefficients[ham] = coeff
             elif isinstance(coeff, dict):
-                self._coefficients[ham] = Interpolator(coeff, interpolation, nsamples=int(1 / dt), **kwargs)
+                self._coefficients[ham] = Interpolator(coeff, interpolation, nsamples=int(1 / dt))
 
             for p_name, p_value in self._coefficients[ham].parameters.items():
                 self._parameters[p_name] = p_value

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -280,12 +280,11 @@ class Schedule(Parameterizable):
         hamiltonian: Hamiltonian,
         coefficients: TimeDict,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None:
         if label in self._hamiltonians:
             raise ValueError(f"Can't add Hamiltonian because label {label} is already associated with a Hamiltonian.")
         self._hamiltonians[label] = hamiltonian
-        self._coefficients[label] = Interpolator(coefficients, interpolation, nsamples=int(1 / self.dt), **kwargs)
+        self._coefficients[label] = Interpolator(coefficients, interpolation, nsamples=int(1 / self.dt))
 
         for p_name, p_value in self._coefficients[label].parameters.items():
             self._parameters[p_name] = p_value
@@ -307,7 +306,6 @@ class Schedule(Parameterizable):
         label: str,
         hamiltonian: Hamiltonian,
         coefficients: TimeDict,
-        **kwargs: Any,
     ) -> None: ...
 
     @overload
@@ -316,7 +314,6 @@ class Schedule(Parameterizable):
         label: str,
         hamiltonian: Hamiltonian,
         coefficients: Interpolator,
-        **kwargs: Any,
     ) -> None: ...
 
     def add_hamiltonian(
@@ -325,7 +322,6 @@ class Schedule(Parameterizable):
         hamiltonian: Hamiltonian,
         coefficients: Interpolator | TimeDict,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None:
         if not isinstance(hamiltonian, Hamiltonian):
             raise ValueError(f"Expecting a Hamiltonian object but received {type(hamiltonian)} instead.")
@@ -333,7 +329,7 @@ class Schedule(Parameterizable):
         if isinstance(coefficients, Interpolator):
             self._add_hamiltonian_from_interpolator(label, hamiltonian, coefficients)
         elif isinstance(coefficients, dict):
-            self._add_hamiltonian_from_dict(label, hamiltonian, coefficients, interpolation, **kwargs)
+            self._add_hamiltonian_from_dict(label, hamiltonian, coefficients, interpolation)
         else:
             raise ValueError("Unsupported type of coefficient.")
         if self._max_time is not None:
@@ -344,11 +340,10 @@ class Schedule(Parameterizable):
         label: str,
         new_coefficients: TimeDict | None = None,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None:
         if new_coefficients is not None:
             self._coefficients[label] = Interpolator(
-                new_coefficients, interpolation, nsamples=int(1 / self.dt), **kwargs
+                new_coefficients, interpolation, nsamples=int(1 / self.dt)
             )  # TODO (ameer): allow for partial updates of the coefficients
 
             for p_name, p_value in self._coefficients[label].parameters.items():
@@ -368,7 +363,6 @@ class Schedule(Parameterizable):
         new_hamiltonian: Hamiltonian | None = None,
         new_coefficients: TimeDict | None = None,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None: ...
 
     @overload
@@ -377,7 +371,6 @@ class Schedule(Parameterizable):
         label: str,
         new_hamiltonian: Hamiltonian | None = None,
         new_coefficients: Interpolator | None = None,
-        **kwargs: Any,
     ) -> None: ...
 
     def update_hamiltonian(
@@ -386,7 +379,6 @@ class Schedule(Parameterizable):
         new_hamiltonian: Hamiltonian | None = None,
         new_coefficients: Interpolator | TimeDict | None = None,
         interpolation: Interpolation = Interpolation.LINEAR,
-        **kwargs: Any,
     ) -> None:
         if label not in self._hamiltonians:
             raise ValueError(f"Can't update unknown hamiltonian {label}. Did you mean `add_hamiltonian`?")
@@ -398,7 +390,7 @@ class Schedule(Parameterizable):
             if isinstance(new_coefficients, Interpolator):
                 self._update_hamiltonian_from_interpolator(label, new_coefficients)
             elif isinstance(new_coefficients, dict):
-                self._update_hamiltonian_from_dict(label, new_coefficients, interpolation, **kwargs)
+                self._update_hamiltonian_from_dict(label, new_coefficients, interpolation)
             else:
                 raise ValueError("Unsupported type of coefficient.")
 

--- a/src/qilisdk/utils/visualization/style.py
+++ b/src/qilisdk/utils/visualization/style.py
@@ -116,7 +116,7 @@ class ScheduleStyle(Style):
 
     # Title and labels
     title_fontsize: int = Field(default=16, description="Font size for the plot title.")
-    xlabel: str = Field(default="time (dt)", description="Label for the x-axis.")
+    xlabel: str = Field(default="time", description="Label for the x-axis.")
     ylabel: str = Field(default="coefficient value", description="Label for the y-axis.")
     label_fontsize: int = Field(default=14, description="Font size for axis labels.")
 

--- a/tests/analog/test_schedule.py
+++ b/tests/analog/test_schedule.py
@@ -30,7 +30,7 @@ def test_schedule_parameters():
     H0 = p[0] * X(1) + X(0)
     H1 = p[1] * Z(1) + Z(0)
 
-    schedule = Schedule(total_time=10, hamiltonians={"H0": H0, "H1": H1}, schedule={})
+    schedule = Schedule(total_time=10, hamiltonians={"H0": H0, "H1": H1}, coefficients={})
 
     assert p[0] in list(schedule._parameters.values())
     assert p[1] in list(schedule._parameters.values())
@@ -157,11 +157,11 @@ def test_add_hamiltonian_new():
     sched = Schedule(dt=1)
     # Define a coefficient function: coefficient = factor * t.
 
-    def coeff_func(t, factor=1):
+    def coeff_func(t, factor=2):
         return t * factor
 
     H1 = PauliZ(0).to_hamiltonian()
-    sched.add_hamiltonian("H1", H1, coefficients={(0, 4): coeff_func}, factor=2)
+    sched.add_hamiltonian("H1", H1, coefficients={(0, 4): coeff_func})
     # For T=4, dt=1, time steps are 0,1,2,3,4; expect coefficient = 2*t.
     for t in range(int(sched.T / sched.dt)):
         assert sched.coefficients["H1"][t] == 2 * t
@@ -303,7 +303,7 @@ def test_update_hamiltonian_coefficient_term_basevariable_errors():
 
 def test_draw_method_runs(monkeypatch):
     H1 = PauliZ(0).to_hamiltonian()
-    sched = Schedule(total_time=4, dt=1, hamiltonians={"H1": H1}, schedule={0: {"H1": 0.5}})
+    sched = Schedule(total_time=4, dt=1, hamiltonians={"H1": H1}, coefficients={"H1": {0: 0.5}})
 
     # Monkeypatch renderer to avoid actual plotting
     class DummyRenderer:

--- a/tests/backends/test_qutip_backend.py
+++ b/tests/backends/test_qutip_backend.py
@@ -182,7 +182,7 @@ def test_constant_hamiltonian():
         hamiltonians={"hz": x * pauli_z(0)},
         dt=1,
         total_time=10,
-        schedule={i: {"hz": 1.0} for i in range(int(1.0 / 0.1))},
+        coefficients={"hz": dict.fromkeys(range(int(1.0 / 0.1)), 1.0)},
     )
     psi0 = ket(0)
     obs = [pauli_z(0)]


### PR DESCRIPTION
Removed `kwargs` from the constructors of the ``Schedule`` and ``Interpolator`` classes.