### PR TITLE
[SDK-107] Fix Optional Dependencies

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -48,5 +48,8 @@ jobs:
       - name: Ruff
         run: uv run ruff check --output-format=github .
 
+      - name: Format
+        run: uv run ruff format --diff --output-format=github .
+
       - name: Mypy
         run: uv run mypy src --ignore-missing-imports

--- a/changes/125.bugfix.1.md
+++ b/changes/125.bugfix.1.md
@@ -1,0 +1,1 @@
+The test suite no longer errors during collection when optional extras aren’t installed; optional-feature tests (CUDA, QuTiP, SpeQtrum, OpenFermion) are skipped via `pytest.importorskip(..., exc_type=ImportError)` unless their dependencies can be imported.

--- a/changes/125.bugfix.md
+++ b/changes/125.bugfix.md
@@ -1,0 +1,1 @@
+Optional dependency handling is now more robust: missing optional symbols are exported as attribute-aware stubs so both calling them and accessing members (e.g. `SpeQtrum.login()`) raises an informative `OptionalDependencyError` with the correct `pip install qilisdk[extra]` hint, and optional imports fall back to stubs even when a dependency is installed but fails during import.

--- a/src/qilisdk/_optionals.py
+++ b/src/qilisdk/_optionals.py
@@ -78,9 +78,7 @@ class _OptionalDependencyStub:
         self.__qualname__ = symbol_name
 
     def _raise(self) -> NoReturn:
-        message = (
-            f"Using {self._symbol_name} requires installing the '{self._feature_name}' optional feature: `pip install qilisdk[{self._feature_name}]`\n"
-        )
+        message = f"Using {self._symbol_name} requires installing the '{self._feature_name}' optional feature: `pip install qilisdk[{self._feature_name}]`\n"
         if self._import_error is None:
             raise OptionalDependencyError(message)
         detail = f"{type(self._import_error).__name__}: {self._import_error}"

--- a/src/qilisdk/_optionals.py
+++ b/src/qilisdk/_optionals.py
@@ -15,7 +15,7 @@
 import importlib
 import importlib.metadata
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 
 
 class OptionalDependencyError(ImportError):
@@ -63,6 +63,36 @@ class ImportedFeature:
     symbols: dict[str, Any | Callable]
 
 
+class _OptionalDependencyStub:
+    """Callable proxy that raises OptionalDependencyError for missing extras.
+
+    It also intercepts attribute access so expressions like ``SpeQtrum.login()``
+    raise an informative OptionalDependencyError rather than AttributeError.
+    """
+
+    def __init__(self, *, symbol_name: str, feature_name: str) -> None:
+        self._symbol_name = symbol_name
+        self._feature_name = feature_name
+        self.__name__ = symbol_name
+        self.__qualname__ = symbol_name
+
+    def _raise(self) -> NoReturn:
+        raise OptionalDependencyError(
+            f"Using {self._symbol_name} requires installing the '{self._feature_name}' optional feature: `pip install qilisdk[{self._feature_name}]`\n"
+        )
+
+    def __call__(self, *_: Any, **__: Any) -> NoReturn:
+        self._raise()
+
+    def __getattr__(self, name: str) -> "_OptionalDependencyStub":
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return _OptionalDependencyStub(symbol_name=f"{self._symbol_name}.{name}", feature_name=self._feature_name)
+
+    def __repr__(self) -> str:
+        return f"<missing optional dependency: {self._symbol_name} (extra '{self._feature_name}')>"
+
+
 def import_optional_dependencies(feature: OptionalFeature) -> ImportedFeature:
     """Tries to import a submodule at `feature.import_path` along with the required
     distributions. If successful, returns a dict mapping each symbol to the
@@ -83,16 +113,10 @@ def import_optional_dependencies(feature: OptionalFeature) -> ImportedFeature:
 
     if missing:
         # Build stubs that raise a helpful error
-        def make_stub(symbol_name: str) -> Callable:
-            def _stub(*args: Any, **kwargs: Any) -> None:
-                raise OptionalDependencyError(
-                    f"Using {symbol_name} requires installing the '{feature.name}' optional feature: `pip install qilisdk[{feature.name}]`\n"
-                )
+        def make_stub(symbol_name: str) -> _OptionalDependencyStub:
+            return _OptionalDependencyStub(symbol_name=symbol_name, feature_name=feature.name)
 
-            _stub.__name__ = symbol_name
-            return _stub
-
-        stubs = {symbol.name: make_stub(symbol.name) for symbol in feature.symbols}
+        stubs: dict[str, Any] = {symbol.name: make_stub(symbol.name) for symbol in feature.symbols}
         return ImportedFeature(name=feature.name, symbols=stubs)
 
     # All dependencies are present => import the real module

--- a/src/qilisdk/cost_functions/model_cost_function.py
+++ b/src/qilisdk/cost_functions/model_cost_function.py
@@ -77,7 +77,9 @@ class ModelCostFunction(CostFunction):
 
         if isinstance(self.model, QUBO):
             ham = self.model.to_hamiltonian()
-            total_cost = complex(np.real_if_close(expect_val(QTensor(ham.to_matrix()), results.final_state), tol=get_settings().atol))
+            total_cost = complex(
+                np.real_if_close(expect_val(QTensor(ham.to_matrix()), results.final_state), tol=get_settings().atol)
+            )
             if abs(total_cost.imag) < get_settings().atol:
                 return total_cost.real
             return total_cost
@@ -90,7 +92,11 @@ class ModelCostFunction(CostFunction):
             for i in range(rho.shape[0]):
                 state = [int(b) for b in f"{i:0{n}b}"]
                 _ket_state = ket(*state)
-                _prob = complex(np.real_if_close(np.trace((_ket_state @ _ket_state.adjoint()).dense() @ rho), tol=get_settings().atol))
+                _prob = complex(
+                    np.real_if_close(
+                        np.trace((_ket_state @ _ket_state.adjoint()).dense() @ rho), tol=get_settings().atol
+                    )
+                )
                 variable_map = {v: int(state[i]) for i, v in enumerate(self.model.variables())}
                 evaluate_results = self.model.evaluate(variable_map)
                 total_cost += sum(v for v in evaluate_results.values()) * _prob

--- a/src/qilisdk/cost_functions/observable_cost_function.py
+++ b/src/qilisdk/cost_functions/observable_cost_function.py
@@ -79,7 +79,9 @@ class ObservableCostFunction(CostFunction):
             raise ValueError(
                 "can't compute cost using Observables from time evolution results when the state is not provided."
             )
-        total_cost = complex(np.real_if_close(expect_val(self._observable, results.final_state), tol=get_settings().atol))
+        total_cost = complex(
+            np.real_if_close(expect_val(self._observable, results.final_state), tol=get_settings().atol)
+        )
         if abs(total_cost.imag) < get_settings().atol:
             return total_cost.real
         return total_cost

--- a/src/qilisdk/digital/ansatz.py
+++ b/src/qilisdk/digital/ansatz.py
@@ -318,84 +318,84 @@ class QAOA(Ansatz):
 
     @staticmethod
     def _pauli_evolution(
-            term: tuple[PauliOperator, ...],
-            coeff: complex | Term | Parameter,
-            time: complex | Term | Parameter,
-            ) -> Iterator[BasicGate | CNOT]:
-            """
-            An iterator of parameterized gates performing the evolution of a given Pauli string.
+        term: tuple[PauliOperator, ...],
+        coeff: complex | Term | Parameter,
+        time: complex | Term | Parameter,
+    ) -> Iterator[BasicGate | CNOT]:
+        """
+        An iterator of parameterized gates performing the evolution of a given Pauli string.
 
-            Args:
-                term (tuple[PauliOperator, ...]): The Pauli string to evolve under.
-                coeff (complex | Term | Parameter): The coefficient of the Pauli string.
-                time (complex | Term | Parameter): The evolution time parameter (gamma or alpha).
+        Args:
+            term (tuple[PauliOperator, ...]): The Pauli string to evolve under.
+            coeff (complex | Term | Parameter): The coefficient of the Pauli string.
+            time (complex | Term | Parameter): The evolution time parameter (gamma or alpha).
 
-            Yields:
-                Iterator[BasicGate]: Gates implementing the evolution under the Pauli string.
-            """
+        Yields:
+            Iterator[BasicGate]: Gates implementing the evolution under the Pauli string.
+        """
 
-            qubit_indices = [pauli.qubit for pauli in term if pauli.name != "I"]
-            if len(qubit_indices) == 0:
-                return
+        qubit_indices = [pauli.qubit for pauli in term if pauli.name != "I"]
+        if len(qubit_indices) == 0:
+            return
 
-            # Move everything to Z basis
-            for pauli in term:
-                q = pauli.qubit
-                name = pauli.name
-                if name == "X":
-                    yield H(q)
-                elif name == "Y":
-                    gate_val = pi / 2
-                    yield RX(q, theta=Parameter("fixed_" + str(gate_val), gate_val, Domain.REAL, (gate_val, gate_val)))
+        # Move everything to Z basis
+        for pauli in term:
+            q = pauli.qubit
+            name = pauli.name
+            if name == "X":
+                yield H(q)
+            elif name == "Y":
+                gate_val = pi / 2
+                yield RX(q, theta=Parameter("fixed_" + str(gate_val), gate_val, Domain.REAL, (gate_val, gate_val)))
 
-            # Apply CNOT ladder
-            for i in range(len(qubit_indices) - 1):
-                yield CNOT(qubit_indices[i], qubit_indices[i + 1])
+        # Apply CNOT ladder
+        for i in range(len(qubit_indices) - 1):
+            yield CNOT(qubit_indices[i], qubit_indices[i + 1])
 
-            # Apply RZ rotation on last qubit
-            last_qubit = qubit_indices[-1]
-            if isinstance(coeff, complex):
-                coeff = coeff.real
-            if isinstance(time, complex):
-                time = time.real
-            yield RZ(last_qubit, phi=(2 * coeff * time))
+        # Apply RZ rotation on last qubit
+        last_qubit = qubit_indices[-1]
+        if isinstance(coeff, complex):
+            coeff = coeff.real
+        if isinstance(time, complex):
+            time = time.real
+        yield RZ(last_qubit, phi=(2 * coeff * time))
 
-            # Undo CNOT ladder
-            for i in reversed(range(len(qubit_indices) - 1)):
-                yield CNOT(qubit_indices[i], qubit_indices[i + 1])
+        # Undo CNOT ladder
+        for i in reversed(range(len(qubit_indices) - 1)):
+            yield CNOT(qubit_indices[i], qubit_indices[i + 1])
 
-            # Move back from Z basis
-            for pauli in term:
-                q = pauli.qubit
-                name = pauli.name
-                if name == "X":
-                    yield H(q)
-                elif name == "Y":
-                    gate_val = -pi / 2
-                    yield RX(q, theta=Parameter("fixed_" + str(gate_val), gate_val, Domain.REAL, (gate_val, gate_val)))
+        # Move back from Z basis
+        for pauli in term:
+            q = pauli.qubit
+            name = pauli.name
+            if name == "X":
+                yield H(q)
+            elif name == "Y":
+                gate_val = -pi / 2
+                yield RX(q, theta=Parameter("fixed_" + str(gate_val), gate_val, Domain.REAL, (gate_val, gate_val)))
 
     def _trotter_evolution(
-            self,
-            commuting_parts: list[dict[tuple[PauliOperator, ...], complex | Term | Parameter]],
-            time: complex | Term | Parameter,
-            trotter_steps: int,
-        ) -> Iterator[BasicGate | CNOT]:
-            """
-            An iterator of parameterized gates performing Trotterized evolution of a commuting Hamiltonian part.
+        self,
+        commuting_parts: list[dict[tuple[PauliOperator, ...], complex | Term | Parameter]],
+        time: complex | Term | Parameter,
+        trotter_steps: int,
+    ) -> Iterator[BasicGate | CNOT]:
+        """
+        An iterator of parameterized gates performing Trotterized evolution of a commuting Hamiltonian part.
 
-            Args:
-                commuting_parts (list[dict[tuple[PauliOperator, ...], complex | Term | Parameter]]): List of commuting Hamiltonian parts.
-                time (complex | Term | Parameter): The evolution time parameter.
-                trotter_steps (int): Number of Trotter steps.
+        Args:
+            commuting_parts (list[dict[tuple[PauliOperator, ...], complex | Term | Parameter]]): List of commuting Hamiltonian parts.
+            time (complex | Term | Parameter): The evolution time parameter.
+            trotter_steps (int): Number of Trotter steps.
 
-            Yields:
-                Iterator[BasicGate]: Gates implementing the Trotterized evolution.
-            """
-            for _ in range(trotter_steps):
-                for part in commuting_parts:
-                    for term, coeff in part.items():
-                        for gate in self._pauli_evolution(term, coeff / trotter_steps, time):
-                            yield gate
+        Yields:
+            Iterator[BasicGate]: Gates implementing the Trotterized evolution.
+        """
+        for _ in range(trotter_steps):
+            for part in commuting_parts:
+                for term, coeff in part.items():
+                    for gate in self._pauli_evolution(term, coeff / trotter_steps, time):
+                        yield gate
 
     def _build_circuit(self) -> None:
         """Populate the circuit according to the Hamiltonian and mixer settings."""
@@ -414,7 +414,6 @@ class QAOA(Ansatz):
 
         # Build the layers
         for i in range(self.layers):
-
             # Initial parameter values
             initial_val_problem = self._problem_params[i]
             initial_val_mixer = self._mixer_params[i]

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -746,32 +746,32 @@ class T(BasicGate):
 
 
 def _process_param(
-                name: str,
-                value: float | Parameter | Term,
-                params_to_init: dict[str, Parameter],
-                terms_to_init: dict[str, Term],
-                ) -> None:
-            """
-            Process a parameter value and update the params_to_init and terms_to_init dictionaries.
-            Args:
-                name (str): The name of the parameter.
-                value (float | Parameter | Term): The value of the parameter.
-                params_to_init (dict[str, Parameter]): The dictionary to initialize parameters.
-                terms_to_init (dict[str, Term]): The dictionary to initialize terms.
-            Raises:
-                ValueError: If a Term is provided that contains Variables instead of Parameters.
-            """
-            if isinstance(value, Parameter):
-                params_to_init[name] = value
-            elif isinstance(value, Term):
-                if not value.is_parameterized_term() and len(value.variables()) > 0:
-                    raise ValueError(f"RX gate Term '{name}' must contain a Parameter and not Variables.")
-                for param in value.variables():
-                    if isinstance(param, Parameter):
-                        params_to_init[param.label] = param
-                terms_to_init[name] = value
-            else:
-                params_to_init[name] = Parameter(name, value)
+    name: str,
+    value: float | Parameter | Term,
+    params_to_init: dict[str, Parameter],
+    terms_to_init: dict[str, Term],
+) -> None:
+    """
+    Process a parameter value and update the params_to_init and terms_to_init dictionaries.
+    Args:
+        name (str): The name of the parameter.
+        value (float | Parameter | Term): The value of the parameter.
+        params_to_init (dict[str, Parameter]): The dictionary to initialize parameters.
+        terms_to_init (dict[str, Term]): The dictionary to initialize terms.
+    Raises:
+        ValueError: If a Term is provided that contains Variables instead of Parameters.
+    """
+    if isinstance(value, Parameter):
+        params_to_init[name] = value
+    elif isinstance(value, Term):
+        if not value.is_parameterized_term() and len(value.variables()) > 0:
+            raise ValueError(f"RX gate Term '{name}' must contain a Parameter and not Variables.")
+        for param in value.variables():
+            if isinstance(param, Parameter):
+                params_to_init[param.label] = param
+        terms_to_init[name] = value
+    else:
+        params_to_init[name] = Parameter(name, value)
 
 
 @yaml.register_class

--- a/tests/backends/test_cuda_backend.py
+++ b/tests/backends/test_cuda_backend.py
@@ -3,6 +3,12 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+pytest.importorskip(
+    "cudaq",
+    reason="CUDA backend tests require the 'cuda' optional dependency",
+    exc_type=ImportError,
+)
+
 from qilisdk.analog.hamiltonian import PauliI, PauliX, PauliY, PauliZ
 from qilisdk.backends.cuda_backend import CudaBackend, CudaSamplingMethod
 from qilisdk.core.model import Model

--- a/tests/backends/test_qutip_backend.py
+++ b/tests/backends/test_qutip_backend.py
@@ -4,6 +4,13 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+pytest.importorskip("qutip", reason="QuTiP backend tests require the 'qutip' optional dependency", exc_type=ImportError)
+pytest.importorskip(
+    "qutip_qip",
+    reason="QuTiP backend tests require the 'qutip' optional dependency",
+    exc_type=ImportError,
+)
+
 from qilisdk.analog.hamiltonian import X as pauli_x
 from qilisdk.analog.hamiltonian import Z as pauli_z
 from qilisdk.analog.schedule import Schedule

--- a/tests/speqtrum/test_keyring.py
+++ b/tests/speqtrum/test_keyring.py
@@ -1,4 +1,12 @@
 # replace these with the real import paths in your project:
+import pytest
+
+pytest.importorskip(
+    "keyring",
+    reason="SpeQtrum tests require the 'speqtrum' optional dependency",
+    exc_type=ImportError,
+)
+
 import keyring
 from pydantic import ValidationError
 

--- a/tests/speqtrum/test_speqtrum.py
+++ b/tests/speqtrum/test_speqtrum.py
@@ -13,8 +13,16 @@ from enum import Enum
 from types import SimpleNamespace
 from typing import Any
 
-import httpx
 import pytest
+
+pytest.importorskip("httpx", reason="SpeQtrum tests require the 'speqtrum' optional dependency", exc_type=ImportError)
+pytest.importorskip(
+    "keyring",
+    reason="SpeQtrum tests require the 'speqtrum' optional dependency",
+    exc_type=ImportError,
+)
+
+import httpx
 
 import qilisdk.speqtrum.speqtrum as speqtrum
 from qilisdk.functionals.sampling_result import SamplingResult

--- a/tests/test_optionals.py
+++ b/tests/test_optionals.py
@@ -7,7 +7,9 @@ from qilisdk._optionals import OptionalDependencyError, OptionalFeature, Symbol,
 
 def test_optional_stub_raises_on_call() -> None:
     feature = OptionalFeature(
-        name="speqtrum", dependencies=["definitely-not-installed-dist-xyz"], symbols=[Symbol(path="unused", name="SpeQtrum")],
+        name="speqtrum",
+        dependencies=["definitely-not-installed-dist-xyz"],
+        symbols=[Symbol(path="unused", name="SpeQtrum")],
     )
 
     imported = import_optional_dependencies(feature)

--- a/tests/test_optionals.py
+++ b/tests/test_optionals.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from qilisdk._optionals import OptionalDependencyError, OptionalFeature, Symbol, import_optional_dependencies
+
+
+def test_optional_stub_raises_on_call() -> None:
+    feature = OptionalFeature(
+        name="speqtrum",
+        dependencies=["definitely-not-installed-dist-xyz"],
+        symbols=[Symbol(path="unused", name="SpeQtrum")],
+    )
+
+    imported = import_optional_dependencies(feature)
+    SpeQtrum = imported.symbols["SpeQtrum"]
+
+    with pytest.raises(OptionalDependencyError) as excinfo:
+        SpeQtrum()
+
+    assert "Using SpeQtrum requires installing the 'speqtrum' optional feature" in str(excinfo.value)
+    assert "pip install qilisdk[speqtrum]" in str(excinfo.value)
+
+
+def test_optional_stub_raises_on_attribute_call() -> None:
+    feature = OptionalFeature(
+        name="speqtrum",
+        dependencies=["definitely-not-installed-dist-xyz"],
+        symbols=[Symbol(path="unused", name="SpeQtrum")],
+    )
+
+    imported = import_optional_dependencies(feature)
+    SpeQtrum = imported.symbols["SpeQtrum"]
+
+    with pytest.raises(OptionalDependencyError) as excinfo:
+        SpeQtrum.login()
+
+    assert "Using SpeQtrum.login requires installing the 'speqtrum' optional feature" in str(excinfo.value)
+    assert "pip install qilisdk[speqtrum]" in str(excinfo.value)

--- a/tests/test_optionals.py
+++ b/tests/test_optionals.py
@@ -7,9 +7,7 @@ from qilisdk._optionals import OptionalDependencyError, OptionalFeature, Symbol,
 
 def test_optional_stub_raises_on_call() -> None:
     feature = OptionalFeature(
-        name="speqtrum",
-        dependencies=["definitely-not-installed-dist-xyz"],
-        symbols=[Symbol(path="unused", name="SpeQtrum")],
+        name="speqtrum", dependencies=["definitely-not-installed-dist-xyz"], symbols=[Symbol(path="unused", name="SpeQtrum")],
     )
 
     imported = import_optional_dependencies(feature)

--- a/tests/test_optionals.py
+++ b/tests/test_optionals.py
@@ -13,10 +13,10 @@ def test_optional_stub_raises_on_call() -> None:
     )
 
     imported = import_optional_dependencies(feature)
-    SpeQtrum = imported.symbols["SpeQtrum"]
+    symbol = imported.symbols["SpeQtrum"]
 
     with pytest.raises(OptionalDependencyError) as excinfo:
-        SpeQtrum()
+        symbol()
 
     assert "Using SpeQtrum requires installing the 'speqtrum' optional feature" in str(excinfo.value)
     assert "pip install qilisdk[speqtrum]" in str(excinfo.value)
@@ -30,10 +30,10 @@ def test_optional_stub_raises_on_attribute_call() -> None:
     )
 
     imported = import_optional_dependencies(feature)
-    SpeQtrum = imported.symbols["SpeQtrum"]
+    symbol = imported.symbols["SpeQtrum"]
 
     with pytest.raises(OptionalDependencyError) as excinfo:
-        SpeQtrum.login()
+        symbol.login()
 
     assert "Using SpeQtrum.login requires installing the 'speqtrum' optional feature" in str(excinfo.value)
     assert "pip install qilisdk[speqtrum]" in str(excinfo.value)

--- a/tests/utils/openfermion/test_openfermion.py
+++ b/tests/utils/openfermion/test_openfermion.py
@@ -1,4 +1,12 @@
 import numpy as np
+import pytest
+
+pytest.importorskip(
+    "openfermion",
+    reason="OpenFermion integration tests require the 'openfermion' optional dependency",
+    exc_type=ImportError,
+)
+
 from openfermion.hamiltonians import jellium_model
 from openfermion.transforms import fourier_transform, jordan_wigner
 from openfermion.utils import Grid


### PR DESCRIPTION
Optional dependency handling is now more robust: missing optional symbols are exported as attribute-aware stubs so both calling them and accessing members (e.g. `SpeQtrum.login()`) raises an informative `OptionalDependencyError` with the correct `pip install qilisdk[extra]` hint, and optional imports fall back to stubs even when a dependency is installed but fails during import.

The test suite no longer errors during collection when optional extras aren’t installed; optional-feature tests (CUDA, QuTiP, SpeQtrum, OpenFermion) are skipped via `pytest.importorskip(..., exc_type=ImportError)` unless their dependencies can be imported.