### PR TITLE
[SDK-220] Fix Serialization issues with hash_cache

### DIFF
--- a/changes/158.bugfix.md
+++ b/changes/158.bugfix.md
@@ -1,0 +1,1 @@
+Fixed YAML serialization for `@yaml.register_class` objects so transient hash cache fields (`_hash_cache` and `_hash_chache`) are always dumped as `null` (`None`) without mutating the in-memory object state.

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -24,6 +24,23 @@ from pydantic import BaseModel
 from ruamel.yaml import YAML
 from scipy import sparse
 
+_HASH_CACHE_STATE_KEYS = "_hash_cache"
+_HASH_CACHE_PATCH_FLAG = "_qili_yaml_hash_cache_patched"
+
+
+def _reset_hash_cache_state(state):
+    if not isinstance(state, dict):
+        return state
+
+    if not any(key in state for key in _HASH_CACHE_STATE_KEYS):
+        return state
+
+    serialized_state = dict(state)
+    for key in _HASH_CACHE_STATE_KEYS:
+        if key in serialized_state:
+            serialized_state[key] = None
+    return serialized_state
+
 
 def csr_representer(representer, data: sparse.csr_matrix):
     """Representer for CSR matrix."""
@@ -203,6 +220,19 @@ def deque_constructor(constructor, node):
 
 # Create YAML handler and register all custom types
 class QiliYAML(YAML):
+    @staticmethod
+    def _patch_class_hash_cache_serialization(cls) -> None:
+        if getattr(cls, _HASH_CACHE_PATCH_FLAG, False):
+            return
+
+        original_getstate = cls.__getstate__
+
+        def __getstate__(instance):
+            return _reset_hash_cache_state(original_getstate(instance))
+
+        cls.__getstate__ = __getstate__
+        setattr(cls, _HASH_CACHE_PATCH_FLAG, True)
+
     def register_class(self, cls=None, *, shared: bool = False):
         if cls is None:
 
@@ -212,6 +242,7 @@ class QiliYAML(YAML):
             return decorator
         if not cls.__dict__.get("yaml_tag", None):
             cls.yaml_tag = f"!{cls.__module__.split('.')[0]}.{cls.__name__}" if shared else f"!{cls.__name__}"
+        self._patch_class_hash_cache_serialization(cls)
         return super().register_class(cls)
 
 

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -17,7 +17,6 @@
 import base64
 import types
 from collections import defaultdict, deque
-from collections.abc import Callable
 from typing import Final
 
 import numpy as np
@@ -233,9 +232,7 @@ class QiliYAML(YAML):
         setattr(class_type, "__getstate__", __getstate__)
         setattr(class_type, _HASH_CACHE_PATCH_FLAG, True)
 
-    def register_class(
-        self, cls=None, *, shared: bool = False
-    ) -> type[object] | Callable[[type[object]], type[object]]:
+    def register_class(self, cls=None, *, shared: bool = False):
         if cls is None:
 
             def decorator(target_cls):  # noqa: ANN202

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -17,6 +17,8 @@
 import base64
 import types
 from collections import defaultdict, deque
+from collections.abc import Callable
+from typing import Final
 
 import numpy as np
 from dill import dumps, loads
@@ -24,19 +26,19 @@ from pydantic import BaseModel
 from ruamel.yaml import YAML
 from scipy import sparse
 
-_HASH_CACHE_STATE_KEYS = "_hash_cache"
-_HASH_CACHE_PATCH_FLAG = "_qili_yaml_hash_cache_patched"
+_IGNORED_ATTRIBUTES: Final[tuple[str, ...]] = ("_hash_cache",)
+_HASH_CACHE_PATCH_FLAG: Final[str] = "_qili_yaml_hash_cache_patched"
 
 
-def _reset_hash_cache_state(state):
+def _reset_hash_cache_state(state: object) -> object:
     if not isinstance(state, dict):
         return state
 
-    if not any(key in state for key in _HASH_CACHE_STATE_KEYS):
+    if not any(key in state for key in _IGNORED_ATTRIBUTES):
         return state
 
     serialized_state = dict(state)
-    for key in _HASH_CACHE_STATE_KEYS:
+    for key in _IGNORED_ATTRIBUTES:
         if key in serialized_state:
             serialized_state[key] = None
     return serialized_state
@@ -221,22 +223,24 @@ def deque_constructor(constructor, node):
 # Create YAML handler and register all custom types
 class QiliYAML(YAML):
     @staticmethod
-    def _patch_class_hash_cache_serialization(cls) -> None:
-        if getattr(cls, _HASH_CACHE_PATCH_FLAG, False):
+    def _patch_class_hash_cache_serialization(class_type: type[object]) -> None:
+        if getattr(class_type, _HASH_CACHE_PATCH_FLAG, False):
             return
 
-        original_getstate = cls.__getstate__
+        original_getstate = class_type.__getstate__
 
-        def __getstate__(instance):
+        def __getstate__(instance: object) -> object:
             return _reset_hash_cache_state(original_getstate(instance))
 
-        cls.__getstate__ = __getstate__
-        setattr(cls, _HASH_CACHE_PATCH_FLAG, True)
+        class_type.__getstate__ = __getstate__
+        setattr(class_type, _HASH_CACHE_PATCH_FLAG, True)
 
-    def register_class(self, cls=None, *, shared: bool = False):
+    def register_class(
+        self, cls: type[object] | None = None, *, shared: bool = False
+    ) -> type[object] | Callable[[type[object]], type[object]]:
         if cls is None:
 
-            def decorator(target_cls):  # noqa: ANN202
+            def decorator(target_cls: type[object]) -> type[object]:
                 return self.register_class(target_cls, shared=shared)
 
             return decorator

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -227,20 +227,18 @@ class QiliYAML(YAML):
         if getattr(class_type, _HASH_CACHE_PATCH_FLAG, False):
             return
 
-        original_getstate = class_type.__getstate__
-
         def __getstate__(instance: object) -> object:
-            return _reset_hash_cache_state(original_getstate(instance))
+            return _reset_hash_cache_state(getattr(instance, "__dict__", None))
 
-        class_type.__getstate__ = __getstate__
+        setattr(class_type, "__getstate__", __getstate__)
         setattr(class_type, _HASH_CACHE_PATCH_FLAG, True)
 
     def register_class(
-        self, cls: type[object] | None = None, *, shared: bool = False
+        self, cls=None, *, shared: bool = False
     ) -> type[object] | Callable[[type[object]], type[object]]:
         if cls is None:
 
-            def decorator(target_cls: type[object]) -> type[object]:
+            def decorator(target_cls):  # noqa: ANN202
                 return self.register_class(target_cls, shared=shared)
 
             return decorator

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -260,6 +260,27 @@ def test_register_class_shared():
     assert "." in Bar.yaml_tag
 
 
+def test_register_class_hash_cache_serialized_as_none():
+    y = QiliYAML(typ="unsafe")
+
+    @y.register_class()
+    class Foo:
+        def __init__(self):
+            self.value = 7
+            self._hash_cache = 123
+
+    obj = Foo()
+    buffer = StringIO()
+    y.dump(obj, buffer)
+    content = buffer.getvalue()
+
+    assert obj._hash_cache == 123
+    assert "_hash_cache: null" in content
+    loaded = y.load(content)
+    assert loaded.value == 7
+    assert loaded._hash_cache is None
+
+
 def test_function_representer_direct():
     def f(x):
         return x + 1


### PR DESCRIPTION
Fixed YAML serialization for `@yaml.register_class` objects so transient hash cache fields (`_hash_cache`) is  always dumped as `null` (`None`) without mutating the in-memory object state.
