### PR TITLE
[SDK-222] Updating qilisdk object hashing to be deterministic

### DIFF
--- a/changes/159.bugfix.md
+++ b/changes/159.bugfix.md
@@ -1,0 +1,1 @@
+Reworked custom hashing to a deterministic `hashlib.blake2b`-based `qilisdk.utils.hashing.hash(...)` interface (no Python builtin hash dependency in the hashing pipeline), migrated Variable/Term/ComparisonTerm/QTensor/Hamiltonian/Pauli hashing to it, and added consistency tests for hashing behavior (stability, equality-consistency, and order-insensitive structures).

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -28,6 +28,7 @@ from qilisdk.core.qtensor import QTensor
 from qilisdk.core.types import Number
 from qilisdk.core.variables import BaseVariable, Parameter, Term
 from qilisdk.settings import get_settings
+from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.yaml import yaml
 
 from .exceptions import InvalidHamiltonianOperation
@@ -150,7 +151,7 @@ class PauliOperator(ABC):
         return Hamiltonian({(self,): 1})
 
     def __hash__(self) -> int:
-        return hash((self._NAME, self._qubit))
+        return qili_hash(self._NAME, self._qubit)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Hamiltonian):
@@ -480,8 +481,7 @@ class Hamiltonian(Parameterizable):
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        items_frozen = frozenset(self._elements.items())
-        return hash(items_frozen)
+        return qili_hash(self._elements)
 
     def __copy__(self) -> Hamiltonian:
         return Hamiltonian(elements=self._elements.copy())

--- a/src/qilisdk/core/qtensor.py
+++ b/src/qilisdk/core/qtensor.py
@@ -22,6 +22,7 @@ from scipy.sparse.linalg import ArpackNoConvergence, eigsh, expm
 from scipy.sparse.linalg import norm as scipy_norm
 
 from qilisdk.settings import get_settings
+from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.yaml import yaml
 
 if TYPE_CHECKING:
@@ -550,7 +551,11 @@ class QTensor:
 
     def __hash__(self) -> int:
         coo = self._data.tocoo()
-        return hash((self.shape, tuple(zip(coo.row, coo.col, coo.data))))
+        order = np.lexsort((coo.col, coo.row))
+        rows = np.asarray(coo.row[order], dtype=np.int64)
+        cols = np.asarray(coo.col[order], dtype=np.int64)
+        data = np.asarray(coo.data[order], dtype=np.complex128)
+        return qili_hash(self.shape, rows, cols, data)
 
 
 ###############################################################################

--- a/src/qilisdk/core/variables.py
+++ b/src/qilisdk/core/variables.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from qilisdk.core.exceptions import EvaluationError, InvalidBoundsError, NotSupportedOperation, OutOfBoundsException
 from qilisdk.settings import get_settings
+from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.yaml import yaml
 
 from .types import Number, QiliEnum, RealNumber
@@ -917,7 +918,7 @@ class BaseVariable(ABC):
 
     def __hash__(self) -> int:
         if self._hash_cache is None:
-            self._hash_cache = hash((self._label, self._domain.value, self._bounds))
+            self._hash_cache = qili_hash(self._label)  # , self._domain.value, self._bounds[0], self._bounds[1])
         return self._hash_cache
 
     def __eq__(self, other: object) -> bool:
@@ -1773,7 +1774,7 @@ class Term:
         )
 
     def __hash__(self) -> int:
-        return hash((frozenset(self._elements.items()), self.operation))
+        return qili_hash(self.operation.value, self._elements)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Term):
@@ -1950,7 +1951,7 @@ class ComparisonTerm:
         )
 
     def __hash__(self) -> int:
-        return hash((hash(self._lhs), self.operation, hash(self._rhs)))
+        return qili_hash(self._lhs, self.operation.value, self._rhs)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ComparisonTerm):

--- a/src/qilisdk/utils/hashing.py
+++ b/src/qilisdk/utils/hashing.py
@@ -1,0 +1,141 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
+from typing import Final
+
+import numpy as np
+
+_HASH_DIGEST_SIZE: Final[int] = 8
+_CHUNK_SIZE_BYTES: Final[int] = 8
+
+
+def _digest_to_hash_int(digest: bytes) -> int:
+    value = int.from_bytes(digest, byteorder="big", signed=True)
+    # -1 is reserved internally by Python's hashing C-API.
+    return -2 if value == -1 else value
+
+
+def _length_prefix(payload: bytes) -> bytes:
+    return len(payload).to_bytes(_CHUNK_SIZE_BYTES, byteorder="big", signed=False)
+
+
+def _encode_scalar(value: object) -> bytes:
+    if value is None:
+        return b"none"
+    if isinstance(value, str):
+        return b"str:" + value.encode("utf-8")
+    if isinstance(value, bytes):
+        return b"bytes:" + value
+    if isinstance(value, np.generic):
+        return _encode_scalar(value.item())
+    if isinstance(value, bool):
+        return b"real:" + _encode_real_number(int(value))
+    if isinstance(value, int):
+        return b"real:" + _encode_real_number(value)
+    if isinstance(value, float):
+        return b"real:" + _encode_real_number(value)
+    if isinstance(value, complex):
+        if value.imag == 0:
+            return b"real:" + _encode_real_number(value.real)
+        real_payload = _encode_real_number(value.real)
+        imag_payload = _encode_real_number(value.imag)
+        return (
+            b"complex:"
+            + _length_prefix(real_payload)
+            + real_payload
+            + _length_prefix(imag_payload)
+            + imag_payload
+        )
+    return b""
+
+
+def _encode_real_number(value: float) -> bytes:
+    if isinstance(value, int):
+        return f"{value}/1".encode("utf-8")
+
+    if math.isnan(value):
+        return b"nan"
+    if math.isinf(value):
+        return b"+inf" if value > 0 else b"-inf"
+
+    numerator, denominator = value.as_integer_ratio()
+    return f"{numerator}/{denominator}".encode("utf-8")
+
+
+def _encode_object_via_custom_hash(value: object) -> bytes:
+    object_hash_method = value.__class__.__hash__
+    if object_hash_method in {None, object.__hash__}:
+        return b""
+
+    class_name = f"{value.__class__.__module__}.{value.__class__.__qualname__}".encode("utf-8")
+    object_hash = object_hash_method(value)
+    return b"object-hash:" + class_name + b":" + str(object_hash).encode("utf-8")
+
+
+def _encode_object(value: object) -> bytes:
+    scalar_payload = _encode_scalar(value)
+    if scalar_payload:
+        return scalar_payload
+
+    if isinstance(value, np.ndarray):
+        dtype_payload = str(value.dtype).encode("utf-8")
+        shape_payload = ",".join(str(dim) for dim in value.shape).encode("utf-8")
+        data_payload = value.tobytes()
+        return b"ndarray:" + _length_prefix(dtype_payload) + dtype_payload + _length_prefix(shape_payload) + shape_payload + data_payload
+
+    if isinstance(value, Mapping):
+        encoded_items = [_encode_object(key) + _encode_object(item) for key, item in value.items()]
+        encoded_items.sort()
+        return b"mapping:" + b"".join(_length_prefix(item) + item for item in encoded_items)
+
+    if isinstance(value, AbstractSet):
+        encoded_items = [_encode_object(item) for item in value]
+        encoded_items.sort()
+        return b"set:" + b"".join(_length_prefix(item) + item for item in encoded_items)
+
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        encoded_items = [_encode_object(item) for item in value]
+        return b"sequence:" + b"".join(_length_prefix(item) + item for item in encoded_items)
+
+    custom_hash_payload = _encode_object_via_custom_hash(value)
+    if custom_hash_payload:
+        return custom_hash_payload
+
+    if hasattr(value, "__dict__"):
+        class_name = f"{value.__class__.__module__}.{value.__class__.__qualname__}".encode("utf-8")
+        state_payload = _encode_object(vars(value))
+        return b"object-state:" + class_name + b":" + state_payload
+
+    class_name = f"{value.__class__.__module__}.{value.__class__.__qualname__}".encode("utf-8")
+    return b"object-repr:" + class_name + b":" + repr(value).encode("utf-8")
+
+
+def hash(*objects: object) -> int:
+    """Stable blake2b-based hash for arbitrary Python objects used by qilisdk models.
+
+    Returns:
+        int: blake2b-based hash integer compatible with Python's ``__hash__``.
+    """
+    hasher = hashlib.blake2b(digest_size=_HASH_DIGEST_SIZE)
+    for value in objects:
+        payload = _encode_object(value)
+        hasher.update(_length_prefix(payload))
+        hasher.update(payload)
+    return _digest_to_hash_int(hasher.digest())

--- a/src/qilisdk/utils/hashing.py
+++ b/src/qilisdk/utils/hashing.py
@@ -45,28 +45,20 @@ def _encode_scalar(value: object) -> bytes:
         return b"bytes:" + value
     if isinstance(value, np.generic):
         return _encode_scalar(value.item())
-    if isinstance(value, bool):
-        return b"real:" + _encode_real_number(int(value))
-    if isinstance(value, int):
-        return b"real:" + _encode_real_number(value)
-    if isinstance(value, float):
+    if isinstance(value, (bool, float, int)):
         return b"real:" + _encode_real_number(value)
     if isinstance(value, complex):
         if value.imag == 0:
             return b"real:" + _encode_real_number(value.real)
         real_payload = _encode_real_number(value.real)
         imag_payload = _encode_real_number(value.imag)
-        return (
-            b"complex:"
-            + _length_prefix(real_payload)
-            + real_payload
-            + _length_prefix(imag_payload)
-            + imag_payload
-        )
+        return b"complex:" + _length_prefix(real_payload) + real_payload + _length_prefix(imag_payload) + imag_payload
     return b""
 
 
-def _encode_real_number(value: float) -> bytes:
+def _encode_real_number(value: float | bool) -> bytes:
+    if isinstance(value, bool):
+        value = int(value)
     if isinstance(value, int):
         return f"{value}/1".encode("utf-8")
 
@@ -98,7 +90,14 @@ def _encode_object(value: object) -> bytes:
         dtype_payload = str(value.dtype).encode("utf-8")
         shape_payload = ",".join(str(dim) for dim in value.shape).encode("utf-8")
         data_payload = value.tobytes()
-        return b"ndarray:" + _length_prefix(dtype_payload) + dtype_payload + _length_prefix(shape_payload) + shape_payload + data_payload
+        return (
+            b"ndarray:"
+            + _length_prefix(dtype_payload)
+            + dtype_payload
+            + _length_prefix(shape_payload)
+            + shape_payload
+            + data_payload
+        )
 
     if isinstance(value, Mapping):
         encoded_items = [_encode_object(key) + _encode_object(item) for key, item in value.items()]

--- a/src/qilisdk/yaml.py
+++ b/src/qilisdk/yaml.py
@@ -17,30 +17,12 @@
 import base64
 import types
 from collections import defaultdict, deque
-from typing import Final
 
 import numpy as np
 from dill import dumps, loads
 from pydantic import BaseModel
 from ruamel.yaml import YAML
 from scipy import sparse
-
-_IGNORED_ATTRIBUTES: Final[tuple[str, ...]] = ("_hash_cache",)
-_HASH_CACHE_PATCH_FLAG: Final[str] = "_qili_yaml_hash_cache_patched"
-
-
-def _reset_hash_cache_state(state: object) -> object:
-    if not isinstance(state, dict):
-        return state
-
-    if not any(key in state for key in _IGNORED_ATTRIBUTES):
-        return state
-
-    serialized_state = dict(state)
-    for key in _IGNORED_ATTRIBUTES:
-        if key in serialized_state:
-            serialized_state[key] = None
-    return serialized_state
 
 
 def csr_representer(representer, data: sparse.csr_matrix):
@@ -221,17 +203,6 @@ def deque_constructor(constructor, node):
 
 # Create YAML handler and register all custom types
 class QiliYAML(YAML):
-    @staticmethod
-    def _patch_class_hash_cache_serialization(class_type: type[object]) -> None:
-        if getattr(class_type, _HASH_CACHE_PATCH_FLAG, False):
-            return
-
-        def __getstate__(instance: object) -> object:
-            return _reset_hash_cache_state(getattr(instance, "__dict__", None))
-
-        setattr(class_type, "__getstate__", __getstate__)
-        setattr(class_type, _HASH_CACHE_PATCH_FLAG, True)
-
     def register_class(self, cls=None, *, shared: bool = False):
         if cls is None:
 
@@ -241,7 +212,6 @@ class QiliYAML(YAML):
             return decorator
         if not cls.__dict__.get("yaml_tag", None):
             cls.yaml_tag = f"!{cls.__module__.split('.')[0]}.{cls.__name__}" if shared else f"!{cls.__name__}"
-        self._patch_class_hash_cache_serialization(cls)
         return super().register_class(cls)
 
 

--- a/tests/unit/analog/test_hamiltionian.py
+++ b/tests/unit/analog/test_hamiltionian.py
@@ -254,6 +254,33 @@ def test_equality():
     assert pauli1 != 1
 
 
+def test_pauli_hash_consistency():
+    pauli1 = PauliZ(2)
+    pauli2 = PauliZ(2)
+    pauli3 = PauliX(2)
+
+    assert pauli1 == pauli2
+    assert hash(pauli1) == hash(pauli2)
+    assert pauli1 != pauli3
+    assert hash(pauli1) != hash(pauli3)
+
+
+def test_hamiltonian_hash_order_independent():
+    h1 = 2 * Z(0) + 3 * X(1) + 1j * Y(0)
+    h2 = 1j * Y(0) + 3 * X(1) + 2 * Z(0)
+
+    assert h1 == h2
+    assert hash(h1) == hash(h2)
+
+
+def test_hamiltonian_hash_changes_when_coefficients_change():
+    h1 = Z(0) + X(1)
+    h2 = Z(0) + 2 * X(1)
+
+    assert h1 != h2
+    assert hash(h1) != hash(h2)
+
+
 @pytest.mark.parametrize(
     ("pauli", "expected_output"),
     [

--- a/tests/unit/core/test_qtensor.py
+++ b/tests/unit/core/test_qtensor.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import pytest
-from scipy.sparse import csc_array, csr_matrix, issparse
+from scipy.sparse import coo_matrix, csc_array, csr_matrix, issparse
 from scipy.sparse.linalg import ArpackNoConvergence
 from scipy.sparse.linalg import norm as scipy_norm
 
@@ -668,3 +668,36 @@ def test_qtensor_hash():
 
     assert hash(q1) == hash(q2)
     assert hash(q1) != hash(q3)
+
+
+def test_qtensor_hash_stable_across_calls():
+    q = QTensor(np.array([[1, 0], [0, 1]]))
+    first = hash(q)
+    second = hash(q)
+    third = hash(q)
+
+    assert first == second == third
+
+
+def test_qtensor_hash_independent_of_sparse_input_order():
+    rows_a = np.array([1, 0, 1])
+    cols_a = np.array([0, 1, 1])
+    data_a = np.array([2.0, 3.0, 4.0], dtype=np.complex128)
+
+    rows_b = np.array([1, 1, 0])
+    cols_b = np.array([1, 0, 1])
+    data_b = np.array([4.0, 2.0, 3.0], dtype=np.complex128)
+
+    q1 = QTensor(coo_matrix((data_a, (rows_a, cols_a)), shape=(2, 2)))
+    q2 = QTensor(coo_matrix((data_b, (rows_b, cols_b)), shape=(2, 2)))
+
+    assert q1 == q2
+    assert hash(q1) == hash(q2)
+
+
+def test_qtensor_hash_changes_when_data_changes():
+    q1 = QTensor(np.array([[1, 0], [0, 1]]))
+    q2 = QTensor(np.array([[1, 0], [0, 2]]))
+
+    assert q1 != q2
+    assert hash(q1) != hash(q2)

--- a/tests/unit/core/test_variables.py
+++ b/tests/unit/core/test_variables.py
@@ -1469,6 +1469,44 @@ def test_comparison_term_equality():
     assert comp1 != other
 
 
+def test_variable_hash_consistency():
+    x1 = Variable("x", Domain.REAL)
+    x2 = Variable("x", Domain.REAL)
+    y = Variable("y", Domain.REAL)
+
+    assert x1 == x2
+    assert hash(x1) == hash(x2)
+    assert hash(x1) == hash(x1)
+    assert x1 != y
+    assert hash(x1) != hash(y)
+
+
+def test_term_hash_consistency():
+    x = Variable("x", Domain.REAL)
+    y = Variable("y", Domain.REAL)
+
+    term1 = x + y + 2
+    term2 = 2 + y + x
+    term3 = x + 2 * y + 2
+
+    assert term1 == term2
+    assert hash(term1) == hash(term2)
+    assert term1 != term3
+    assert hash(term1) != hash(term3)
+
+
+def test_comparison_term_hash_consistency():
+    x = Variable("x", Domain.REAL)
+    comp1 = EQ(x + 1, 2)
+    comp2 = EQ(x + 1, 2)
+    comp3 = EQ(x + 2, 2)
+
+    assert comp1 == comp2
+    assert hash(comp1) == hash(comp2)
+    assert comp1 != comp3
+    assert hash(comp1) != hash(comp3)
+
+
 def test_check_output():
     x = Variable("x", Domain.INTEGER, (0, 3))
     assert _check_output(x, 3) == 3

--- a/tests/unit/test_yaml.py
+++ b/tests/unit/test_yaml.py
@@ -260,27 +260,6 @@ def test_register_class_shared():
     assert "." in Bar.yaml_tag
 
 
-def test_register_class_hash_cache_serialized_as_none():
-    y = QiliYAML(typ="unsafe")
-
-    @y.register_class()
-    class Foo:
-        def __init__(self):
-            self.value = 7
-            self._hash_cache = 123
-
-    obj = Foo()
-    buffer = StringIO()
-    y.dump(obj, buffer)
-    content = buffer.getvalue()
-
-    assert obj._hash_cache == 123
-    assert "_hash_cache: null" in content
-    loaded = y.load(content)
-    assert loaded.value == 7
-    assert loaded._hash_cache is None
-
-
 def test_function_representer_direct():
     def f(x):
         return x + 1

--- a/tests/unit/utils/test_hashing.py
+++ b/tests/unit/utils/test_hashing.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from qilisdk.utils.hashing import hash as qili_hash
+
+
+def test_qili_hash_numeric_equivalence():
+    assert qili_hash(1) == qili_hash(1.0)
+
+
+def test_qili_hash_mapping_order_independent():
+    assert qili_hash({"a": 1, "b": 2}) == qili_hash({"b": 2, "a": 1})
+
+
+def test_qili_hash_set_order_independent():
+    assert qili_hash({1, "x", 2.0}) == qili_hash({"x", 2.0, 1})
+
+
+def test_qili_hash_sequence_order_dependent():
+    assert qili_hash([1, 2]) != qili_hash([2, 1])
+
+
+def test_qili_hash_ndarray_support():
+    a = np.array([[1, 2], [3, 4]], dtype=np.float64)
+    b = np.array([[1, 2], [3, 4]], dtype=np.float64)
+    c = np.array([[1, 2], [4, 3]], dtype=np.float64)
+
+    assert qili_hash(a) == qili_hash(b)
+    assert qili_hash(a) != qili_hash(c)

--- a/tests/unit/utils/test_hashing.py
+++ b/tests/unit/utils/test_hashing.py
@@ -17,8 +17,41 @@ import numpy as np
 from qilisdk.utils.hashing import hash as qili_hash
 
 
+class _CustomHash:
+    def __init__(self, value: int):
+        self.value = value
+
+    def __hash__(self) -> int:
+        return self.value
+
+
+class _StateObject:
+    __hash__ = None
+
+    def __init__(self, left: int, right: str):
+        self.left = left
+        self.right = right
+
+
 def test_qili_hash_numeric_equivalence():
     assert qili_hash(1) == qili_hash(1.0)
+
+
+def test_qili_hash_boolean_numeric_equivalence():
+    assert qili_hash(True) == qili_hash(1)
+    assert qili_hash(False) == qili_hash(0.0)
+
+
+def test_qili_hash_complex_real_equivalence():
+    assert qili_hash(3 + 0j) == qili_hash(3)
+    assert qili_hash(3 + 1j) != qili_hash(3 + 2j)
+
+
+def test_qili_hash_special_float_values():
+    assert qili_hash(float("nan")) == qili_hash(np.nan)
+    assert qili_hash(float("inf")) == qili_hash(np.inf)
+    assert qili_hash(float("-inf")) == qili_hash(-np.inf)
+    assert qili_hash(float("inf")) != qili_hash(float("-inf"))
 
 
 def test_qili_hash_mapping_order_independent():
@@ -33,10 +66,33 @@ def test_qili_hash_sequence_order_dependent():
     assert qili_hash([1, 2]) != qili_hash([2, 1])
 
 
+def test_qili_hash_multiple_arguments_order_dependent():
+    assert qili_hash("a", 1) == qili_hash("a", 1)
+    assert qili_hash("a", 1) != qili_hash(1, "a")
+
+
 def test_qili_hash_ndarray_support():
     a = np.array([[1, 2], [3, 4]], dtype=np.float64)
     b = np.array([[1, 2], [3, 4]], dtype=np.float64)
     c = np.array([[1, 2], [4, 3]], dtype=np.float64)
+
+    assert qili_hash(a) == qili_hash(b)
+    assert qili_hash(a) != qili_hash(c)
+
+
+def test_qili_hash_uses_custom_hash_method_for_objects():
+    a = _CustomHash(7)
+    b = _CustomHash(7)
+    c = _CustomHash(8)
+
+    assert qili_hash(a) == qili_hash(b)
+    assert qili_hash(a) != qili_hash(c)
+
+
+def test_qili_hash_uses_object_state_when_object_is_unhashable():
+    a = _StateObject(left=1, right="x")
+    b = _StateObject(left=1, right="x")
+    c = _StateObject(left=2, right="x")
 
     assert qili_hash(a) == qili_hash(b)
     assert qili_hash(a) != qili_hash(c)


### PR DESCRIPTION
Reworked custom hashing to a deterministic `hashlib.blake2b`-based `qilisdk.utils.hashing.hash(...)` interface (no Python builtin hash dependency in the hashing pipeline), migrated Variable/Term/ComparisonTerm/QTensor/Hamiltonian/Pauli hashing to it, and added consistency tests for hashing behavior (stability, equality-consistency, and order-insensitive structures).
