### PR TITLE
[SDK-224] Docs Highlight Bug

### DIFF
--- a/changes/160.doc.md
+++ b/changes/160.doc.md
@@ -1,0 +1,1 @@
+Fixed a bug in the documentation whereby titles could be hidden by a highlight after searching.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -14,6 +14,11 @@
   src: url("PlusJakartaSans-Italic-VariableFont_wght.ttf") format("truetype-variations");
 }
 
+/* No search term highlighting of the titles */
+h1 span.highlighted, h2 span.highlighted, h3 span.highlighted, h4 span.highlighted, h5 span.highlighted, h6 span.highlighted {
+    background-color: transparent;
+}
+
 html, body {
   font-family: "Plus Jakarta Sans", sans-serif !important;
 }

--- a/src/qilisdk/noise/readout_assignment.py
+++ b/src/qilisdk/noise/readout_assignment.py
@@ -23,8 +23,8 @@ class ReadoutAssignment(Noise, HasAllowedScopes):
 
     def __init__(self, *, p01: float, p10: float) -> None:
         """Args:
-            p01 (float): Probability to report "1" when the state is |0>.
-            p10 (float): Probability to report "0" when the state is |1>.
+            p01 (float): Probability to report "1" when the state is "0".
+            p10 (float): Probability to report "0" when the state is "1".
 
         Raises:
             ValueError: If any probability is outside [0, 1].
@@ -34,7 +34,7 @@ class ReadoutAssignment(Noise, HasAllowedScopes):
 
     @property
     def p01(self) -> float:
-        """Return the probability of reporting "1" for a |0> state.
+        """Return the probability of reporting "1" for a "0" state.
 
         Returns:
             The p01 probability.
@@ -43,7 +43,7 @@ class ReadoutAssignment(Noise, HasAllowedScopes):
 
     @property
     def p10(self) -> float:
-        """Return the probability of reporting "0" for a |1> state.
+        """Return the probability of reporting "0" for a "1" state.
 
         Returns:
             The p10 probability.


### PR DESCRIPTION
Fixed a bug in the documentation whereby titles could be hidden by a highlight after searching.

https://github.com/qilimanjaro-tech/qilisdk/issues/156

