### PR TITLE
updating the qilisim interface

### DIFF
--- a/changes/165.feature.md
+++ b/changes/165.feature.md
@@ -1,0 +1,25 @@
+Refactored the QiliSim backend configuration API around typed Pydantic models and aligned docs/tests with the new usage.
+
+Main changes:
+
+* Introduced structured QiliSim configuration models:
+  * `AnalogMethod` (with `integrator`, `arnoldi`, and `direct` builders)
+  * `DigitalMethod` (with `state_vector` builder)
+  * `ExecutionConfig` (threading and RNG seed controls)
+  * `MonteCarloConfig` (trajectory control for Monte Carlo mode)
+* Updated `QiliSim` initialization to accept:
+  * `analog_simulation_method`
+  * `digital_simulation_method`
+  * `execution_config`
+  instead of many flat constructor parameters.
+* Added `QiliSim.get_config()` and kept `solver_params` as a backward-compatible alias.
+* Fixed solver configuration wiring so execution paths use the refactored internal config dictionary.
+* Expanded docstrings for new and affected methods/classes, including:
+  * per-field `Field(description=...)` metadata for Pydantic model fields
+  * top-level model parameter documentation for better IDE hover help
+  * classmethod argument documentation aligned with field descriptions.
+* Updated backend documentation (`docs/fundamentals/backends.rst`) to describe the new configuration objects and provide an updated configuration example.
+* Updated and expanded QiliSim unit/integration tests to validate:
+  * new configuration builders and validation behavior
+  * new backend construction patterns using `ExecutionConfig`/`AnalogMethod`/`DigitalMethod`/`MonteCarloConfig`
+  * compatibility of shared backend integration suites with the new API.

--- a/docs/fundamentals/backends.rst
+++ b/docs/fundamentals/backends.rst
@@ -123,25 +123,24 @@ There is no need to install QiliSim separately, as it is included with the core 
 **Parameters**
 
 - ``noise_model`` (:class:`~qilisdk.noise.noise_model.NoiseModel`, optional): Noise model applied during simulation.
-- ``analog_simulation_method`` (:class:`~qilisdk.backends.qilisim.AnalogMethod`, optional): Analog simulation method and method-specific options.
-- ``digital_simulation_method`` (:class:`~qilisdk.backends.qilisim.DigitalMethod`, optional): Digital simulation options.
-- ``execution_config`` (:class:`~qilisdk.backends.qilisim.ExecutionConfig`, optional): Runtime execution options such as thread count and random seed.
+- ``analog_simulation_method`` (:class:`~qilisdk.backends.backend_config.AnalogMethod`, optional): Analog simulation method and method-specific options.
+- ``digital_simulation_method`` (:class:`~qilisdk.backends.backend_config.DigitalMethod`, optional): Digital simulation options.
+- ``execution_config`` (:class:`~qilisdk.backends.backend_config.ExecutionConfig`, optional): Runtime execution options such as thread count and random seed.
 
 **Configuration example**
 
 .. code-block:: python
 
     from qilisdk.backends import QiliSim
-    from qilisdk.backends.qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
+    from qilisdk.backends.backend_config import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
 
     backend = QiliSim(
         analog_simulation_method=AnalogMethod.arnoldi(
             dim=16,
-            num_substeps=2,
-            monte_carlo=MonteCarloConfig(trajectories=200),
+            num_substeps=2
         ),
         digital_simulation_method=DigitalMethod.state_vector(max_cache_size=2_000),
-        execution_config=ExecutionConfig(num_threads=4, seed=42),
+        execution_config=ExecutionConfig(num_threads=4, seed=42, monte_carlo=MonteCarloConfig(trajectories=200)),
     )
 
 **Example**

--- a/docs/fundamentals/backends.rst
+++ b/docs/fundamentals/backends.rst
@@ -118,12 +118,27 @@ There is no need to install QiliSim separately, as it is included with the core 
 
 **Parameters**
 
-- ``evolution_method`` (str, optional): The method for simulating time evolution. Options include 'direct', 'arnoldi' and 'integrate'. Default is 'integrate'.
-- ``arnoldi_dim`` (int, optional): Dimension of the Krylov subspace for the Arnoldi method. Default is 10.
-- ``num_arnoldi_substeps`` (int, optional): Number of substeps for the Arnoldi method per timestep. Default is 1.
-- ``num_integration_substeps`` (int, optional): Number of integration steps for the integrate method per timestep. Default is 2.
-- ``monte_carlo`` (bool, optional): Whether to use the Monte Carlo wavefunction method. Default is False.
-- ``num_monte_carlo_trajectories`` (int, optional): Number of trajectories to simulate when using the Monte Carlo method. Default is 100.
+- ``noise_model`` (:class:`~qilisdk.noise.noise_model.NoiseModel`, optional): Noise model applied during simulation.
+- ``analog_simulation_method`` (:class:`~qilisdk.backends.qilisim.AnalogMethod`, optional): Analog simulation method and method-specific options.
+- ``digital_simulation_method`` (:class:`~qilisdk.backends.qilisim.DigitalMethod`, optional): Digital simulation options.
+- ``execution_config`` (:class:`~qilisdk.backends.qilisim.ExecutionConfig`, optional): Runtime execution options such as thread count and random seed.
+
+**Configuration example**
+
+.. code-block:: python
+
+    from qilisdk.backends import QiliSim
+    from qilisdk.backends.qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
+
+    backend = QiliSim(
+        analog_simulation_method=AnalogMethod.arnoldi(
+            dim=16,
+            num_substeps=2,
+            monte_carlo=MonteCarloConfig(trajectories=200),
+        ),
+        digital_simulation_method=DigitalMethod.state_vector(max_cache_size=2_000),
+        execution_config=ExecutionConfig(num_threads=4, seed=42),
+    )
 
 **Example**
 
@@ -297,4 +312,3 @@ It is the most lightweight option, ideal for local development or environments w
         [[0.05506547-0.00516502j]
         [0.3364973 -0.94005887j]]
     )
-

--- a/src/qilisdk/backends/__init__.pyi
+++ b/src/qilisdk/backends/__init__.pyi
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 from .cuda_backend import CudaBackend, CudaSamplingMethod
+from .qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, QiliSim
 from .qutip_backend import QutipBackend
 
-__all__ = ["CudaBackend", "CudaSamplingMethod", "QutipBackend"]
+__all__ = [
+    "AnalogMethod",
+    "CudaBackend",
+    "CudaSamplingMethod",
+    "DigitalMethod",
+    "ExecutionConfig",
+    "QiliSim",
+    "QutipBackend",
+]

--- a/src/qilisdk/backends/__init__.pyi
+++ b/src/qilisdk/backends/__init__.pyi
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .backend_config import AnalogMethod, DigitalMethod, ExecutionConfig
 from .cuda_backend import CudaBackend, CudaSamplingMethod
-from .qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, QiliSim
+from .qilisim import QiliSim
 from .qutip_backend import QutipBackend
 
 __all__ = [

--- a/src/qilisdk/backends/backend_config.py
+++ b/src/qilisdk/backends/backend_config.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+import secrets
+from abc import ABC, abstractmethod
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic import ConfigDict as PydanticConfigDict
+
+# ----------------------------
+# Base config interface
+# ----------------------------
+
+ConfigValue = bool | int | float | str
+SolverConfigDict = dict[str, ConfigValue]
+
+
+class BaseSimulatorConfig(BaseModel, ABC):
+    """Abstract base class for all QiliSim configuration sections."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Disallow positional arguments to keep configuration explicit.
+
+        Raises:
+            TypeError: If positional arguments are provided.
+        """
+        if args:
+            cls = self.__class__
+            field_names = ", ".join(cls.model_fields.keys())
+
+            raise TypeError(
+                f"{cls.__name__} does not accept positional arguments. "
+                f"Use keyword arguments instead. "
+                f"Valid fields: [{field_names}].\n"
+                f"Received positional arguments: {args!r}."
+            )
+        super().__init__(**kwargs)
+
+    @abstractmethod
+    def get_config(self) -> SolverConfigDict:
+        """Serialize the configuration to the flat dictionary consumed by the C++ backend."""
+
+
+# ----------------------------
+# Analog (time evolution) config
+# ----------------------------
+
+
+class MonteCarloConfig(BaseSimulatorConfig):
+    """Configuration for Monte Carlo trajectory sampling in open-system simulations.
+
+    Args:
+        trajectories: Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.
+    """
+
+    trajectories: int = Field(
+        default=100,
+        gt=0,
+        description="Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return Monte Carlo settings in backend-compatible key names."""
+        return {"num_monte_carlo_trajectories": self.trajectories}
+
+
+class AnalogMethod(BaseSimulatorConfig):
+    """Configuration for analog time-evolution method selection and its hyperparameters.
+
+    Preferred constructors:
+        - :meth:`integrator` for integrate-based evolution.
+        - :meth:`arnoldi` for Krylov/Arnoldi-based evolution.
+        - :meth:`direct` for direct evolution.
+
+    Args:
+        evolution_method: Analog time-evolution method to use: ``"direct"``, ``"arnoldi"``, or ``"integrate"``.
+        arnoldi_dim: Dimension of the Arnoldi Krylov subspace used when ``evolution_method="arnoldi"``.
+        num_arnoldi_substeps: Number of integration substeps per schedule step for the Arnoldi method.
+        num_integrate_substeps: Number of integration substeps per schedule step for the Integrate method.
+    """
+
+    evolution_method: Literal["direct", "arnoldi", "integrate"] = Field(
+        default="integrate",
+        description="Analog time-evolution method to use: 'direct', 'arnoldi', or 'integrate'.",
+    )
+    arnoldi_dim: int = Field(
+        default=10,
+        gt=0,
+        description="Dimension of the Arnoldi Krylov subspace used when `evolution_method='arnoldi'`.",
+    )
+    num_arnoldi_substeps: int = Field(
+        default=1,
+        gt=0,
+        description="Number of integration substeps per schedule step when using the Arnoldi method.",
+    )
+    num_integrate_substeps: int = Field(
+        default=2,
+        gt=0,
+        description="Number of integration substeps per schedule step when using the Integrate method.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return a complete analog solver configuration for the C++ backend."""
+        d: SolverConfigDict = {
+            "evolution_method": self.evolution_method,
+            "arnoldi_dim": self.arnoldi_dim,
+            "num_arnoldi_substeps": self.num_arnoldi_substeps,
+            "num_integrate_substeps": self.num_integrate_substeps,
+        }
+
+        return d
+
+    @classmethod
+    def integrator(cls, *, num_substeps: int = 2, monte_carlo: MonteCarloConfig | None = None) -> AnalogMethod:
+        """Build an ``integrate`` analog method configuration.
+
+        Args:
+            num_substeps: Number of integration substeps per schedule step when using the Integrate method.
+
+        Returns:
+            AnalogMethod: Configured integrate-method analog configuration.
+        """
+        return cls(evolution_method="integrate", num_integrate_substeps=num_substeps)
+
+    @classmethod
+    def arnoldi(
+        cls,
+        *,
+        num_substeps: int = 1,
+        dim: int = 10,
+        monte_carlo: MonteCarloConfig | None = None,
+    ) -> AnalogMethod:
+        """Build an ``arnoldi`` analog method configuration.
+
+        Args:
+            num_substeps: Number of integration substeps per schedule step when using the Arnoldi method.
+            dim: Dimension of the Arnoldi Krylov subspace.
+
+        Returns:
+            AnalogMethod: Configured arnoldi-method analog configuration.
+        """
+        return cls(
+            evolution_method="arnoldi",
+            arnoldi_dim=dim,
+            num_arnoldi_substeps=num_substeps,
+        )
+
+    @classmethod
+    def direct(cls) -> AnalogMethod:
+        """Build a ``direct`` analog method configuration.
+
+        Returns:
+            AnalogMethod: Configured direct-method analog configuration.
+        """
+        return cls(evolution_method="direct")
+
+
+# ----------------------------
+# Execution config
+# ----------------------------
+
+
+class ExecutionConfig(BaseSimulatorConfig):
+    """Configuration for execution-level controls (threading and randomness).
+
+    Args:
+        num_threads: Number of CPU threads used for simulation. If set to ``0``, all available cores are selected.
+        seed: Random seed used by the simulator. If ``None``, a random seed is generated.
+        monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled and deterministic evolution is
+            used.
+
+    """
+
+    model_config = PydanticConfigDict(validate_default=True)
+    num_threads: int = Field(
+        default=0,
+        ge=0,
+        description=("Number of CPU threads used for simulation. If set to 0, all available cores are selected."),
+    )  # 0 means "use all cores"
+    seed: int | None = Field(
+        default=None,
+        ge=0,
+        description="Random seed used by the simulator. If `None`, a random seed is generated.",
+    )
+    # None means Monte-Carlo disabled
+    monte_carlo: MonteCarloConfig | None = Field(
+        default=None,
+        description=(
+            "Monte Carlo configuration. If `None`, Monte Carlo is disabled and deterministic evolution is used."
+        ),
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return execution settings with resolved defaults."""
+        d = {
+            "num_threads": self.num_threads,
+            "seed": int(self.seed) if self.seed is not None else 0,  # defensive
+            "monte_carlo": self.monte_carlo is not None,
+        }
+        if self.monte_carlo is not None:
+            d.update(self.monte_carlo.get_config())
+        else:
+            d.update({"num_monte_carlo_trajectories": 100})
+        return d
+
+    @field_validator("num_threads", mode="after")
+    @classmethod
+    def _validate_num_threads(cls, num_threads: int) -> int:
+        if num_threads <= 0:
+            return os.cpu_count() or 1
+        return num_threads
+
+    @field_validator("seed", mode="after")
+    @classmethod
+    def _validate_seed(cls, seed: int | None) -> int:
+        if seed is None:
+            return secrets.randbelow(2**15)
+        return seed
+
+
+# ----------------------------
+# Digital config
+# ----------------------------
+
+
+class DigitalMethod(BaseSimulatorConfig):
+    """Configuration for digital-circuit simulation options.
+
+    Preferred constructors:
+        - :meth:`state_vector` for standard state-vector simulation settings.
+
+    Args:
+        max_cache_size: Maximum number of cached gate representations used by the digital simulator.
+    """
+
+    max_cache_size: int = Field(
+        default=1000,
+        ge=0,
+        description="Maximum number of cached gate representations used by the digital simulator.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return digital simulation settings in backend-compatible key names."""
+        return {
+            "max_cache_size": self.max_cache_size,
+        }
+
+    @classmethod
+    def state_vector(cls, *, max_cache_size: int = 1000) -> DigitalMethod:
+        """Build the standard state-vector simulation configuration.
+
+        Args:
+            max_cache_size: Maximum number of cached gate representations used by the digital simulator.
+
+        Returns:
+            DigitalMethod: Configured state-vector digital configuration.
+        """
+        return cls(max_cache_size=max_cache_size)

--- a/src/qilisdk/backends/qilisim.py
+++ b/src/qilisdk/backends/qilisim.py
@@ -13,18 +13,15 @@
 # limitations under the License.
 from __future__ import annotations
 
-import os
-import secrets
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING
 
 from loguru import logger
-from pydantic import BaseModel, Field, field_validator
-from pydantic import ConfigDict as PydanticConfigDict
 from qilisim_module import QiliSimCpp  # ty:ignore[unresolved-import]
 
-from qilisdk.backends.backend import Backend
 from qilisdk.settings import get_settings
+
+from .backend import Backend
+from .backend_config import AnalogMethod, DigitalMethod, ExecutionConfig, SolverConfigDict
 
 if TYPE_CHECKING:
     from qilisdk.core import QTensor
@@ -35,272 +32,24 @@ if TYPE_CHECKING:
     from qilisdk.noise.noise_model import NoiseModel
 
 
-# ----------------------------
-# Base config interface
-# ----------------------------
-
-ConfigValue = bool | int | float | str
-SolverConfigDict = dict[str, ConfigValue]
-
-
-class QiliSimConfig(BaseModel, ABC):
-    """Abstract base class for all QiliSim configuration sections."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Disallow positional arguments to keep configuration explicit.
-
-        Raises:
-            TypeError: If positional arguments are provided.
-        """
-        if args:
-            cls = self.__class__
-            field_names = ", ".join(cls.model_fields.keys())
-
-            raise TypeError(
-                f"{cls.__name__} does not accept positional arguments. "
-                f"Use keyword arguments instead. "
-                f"Valid fields: [{field_names}].\n"
-                f"Received positional arguments: {args!r}."
-            )
-        super().__init__(**kwargs)
-
-    @abstractmethod
-    def get_config(self) -> SolverConfigDict:
-        """Serialize the configuration to the flat dictionary consumed by the C++ backend."""
-
-
-# ----------------------------
-# Analog (time evolution) config
-# ----------------------------
-
-
-class MonteCarloConfig(QiliSimConfig):
-    """Configuration for Monte Carlo trajectory sampling in open-system simulations.
-
-    Args:
-        trajectories: Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.
-    """
-
-    trajectories: int = Field(
-        default=100,
-        gt=0,
-        description="Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.",
-    )
-
-    def get_config(self) -> SolverConfigDict:
-        """Return Monte Carlo settings in backend-compatible key names."""
-        return {"num_monte_carlo_trajectories": self.trajectories}
-
-
-class AnalogMethod(QiliSimConfig):
-    """Configuration for analog time-evolution method selection and its hyperparameters.
-
-    Preferred constructors:
-        - :meth:`integrator` for integrate-based evolution.
-        - :meth:`arnoldi` for Krylov/Arnoldi-based evolution.
-        - :meth:`direct` for direct evolution.
-
-    Args:
-        evolution_method: Analog time-evolution method to use: ``"direct"``, ``"arnoldi"``, or ``"integrate"``.
-        arnoldi_dim: Dimension of the Arnoldi Krylov subspace used when ``evolution_method="arnoldi"``.
-        num_arnoldi_substeps: Number of integration substeps per schedule step for the Arnoldi method.
-        num_integrate_substeps: Number of integration substeps per schedule step for the Integrate method.
-        monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled and deterministic evolution is
-            used.
-    """
-
-    evolution_method: Literal["direct", "arnoldi", "integrate"] = Field(
-        default="integrate",
-        description="Analog time-evolution method to use: 'direct', 'arnoldi', or 'integrate'.",
-    )
-    arnoldi_dim: int = Field(
-        default=10,
-        gt=0,
-        description="Dimension of the Arnoldi Krylov subspace used when `evolution_method='arnoldi'`.",
-    )
-    num_arnoldi_substeps: int = Field(
-        default=1,
-        gt=0,
-        description="Number of integration substeps per schedule step when using the Arnoldi method.",
-    )
-    num_integrate_substeps: int = Field(
-        default=2,
-        gt=0,
-        description="Number of integration substeps per schedule step when using the Integrate method.",
-    )
-
-    # None means Monte-Carlo disabled
-    monte_carlo: Annotated[
-        MonteCarloConfig | None,
-        Field(
-            default=None,
-            description=(
-                "Monte Carlo configuration. If `None`, Monte Carlo is disabled and deterministic evolution is used."
-            ),
-        ),
-    ]
-
-    def get_config(self) -> SolverConfigDict:
-        """Return a complete analog solver configuration for the C++ backend."""
-        d: SolverConfigDict = {
-            "evolution_method": self.evolution_method,
-            "arnoldi_dim": self.arnoldi_dim,
-            "num_arnoldi_substeps": self.num_arnoldi_substeps,
-            "num_integrate_substeps": self.num_integrate_substeps,
-            "monte_carlo": self.monte_carlo is not None,
-        }
-        if self.monte_carlo is not None:
-            d.update(self.monte_carlo.get_config())
-        else:
-            d.update({"num_monte_carlo_trajectories": 100})
-        return d
-
-    @classmethod
-    def integrator(cls, *, num_substeps: int = 2, monte_carlo: MonteCarloConfig | None = None) -> AnalogMethod:
-        """Build an ``integrate`` analog method configuration.
-
-        Args:
-            num_substeps: Number of integration substeps per schedule step when using the Integrate method.
-            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
-
-        Returns:
-            AnalogMethod: Configured integrate-method analog configuration.
-        """
-        return cls(
-            evolution_method="integrate",
-            num_integrate_substeps=num_substeps,
-            monte_carlo=monte_carlo,
-        )
-
-    @classmethod
-    def arnoldi(
-        cls,
-        *,
-        num_substeps: int = 1,
-        dim: int = 10,
-        monte_carlo: MonteCarloConfig | None = None,
-    ) -> AnalogMethod:
-        """Build an ``arnoldi`` analog method configuration.
-
-        Args:
-            num_substeps: Number of integration substeps per schedule step when using the Arnoldi method.
-            dim: Dimension of the Arnoldi Krylov subspace.
-            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
-
-        Returns:
-            AnalogMethod: Configured arnoldi-method analog configuration.
-        """
-        return cls(
-            evolution_method="arnoldi",
-            arnoldi_dim=dim,
-            num_arnoldi_substeps=num_substeps,
-            monte_carlo=monte_carlo,
-        )
-
-    @classmethod
-    def direct(cls, *, monte_carlo: MonteCarloConfig | None = None) -> AnalogMethod:
-        """Build a ``direct`` analog method configuration.
-
-        Args:
-            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
-
-        Returns:
-            AnalogMethod: Configured direct-method analog configuration.
-        """
-        return cls(evolution_method="direct", monte_carlo=monte_carlo)
-
-
-# ----------------------------
-# Execution config
-# ----------------------------
-
-
-class ExecutionConfig(QiliSimConfig):
-    """Configuration for execution-level controls (threading and randomness).
-
-    Args:
-        num_threads: Number of CPU threads used for simulation. If set to ``0``, all available cores are selected.
-        seed: Random seed used by the simulator. If ``None``, a random seed is generated.
-    """
-
-    model_config = PydanticConfigDict(validate_default=True)
-    num_threads: int = Field(
-        default=0,
-        ge=0,
-        description=("Number of CPU threads used for simulation. If set to 0, all available cores are selected."),
-    )  # 0 means "use all cores"
-    seed: int | None = Field(
-        default=None,
-        ge=0,
-        description="Random seed used by the simulator. If `None`, a random seed is generated.",
-    )
-
-    def get_config(self) -> SolverConfigDict:
-        """Return execution settings with resolved defaults."""
-        return {
-            "num_threads": self.num_threads,
-            "seed": int(self.seed) if self.seed is not None else 0,  # defensive
-        }
-
-    @field_validator("num_threads", mode="after")
-    @classmethod
-    def _validate_num_threads(cls, num_threads: int) -> int:
-        if num_threads <= 0:
-            return os.cpu_count() or 1
-        return num_threads
-
-    @field_validator("seed", mode="after")
-    @classmethod
-    def _validate_seed(cls, seed: int | None) -> int:
-        if seed is None:
-            return secrets.randbelow(2**15)
-        return seed
-
-
-# ----------------------------
-# Digital config
-# ----------------------------
-
-
-class DigitalMethod(QiliSimConfig):
-    """Configuration for digital-circuit simulation options.
-
-    Preferred constructors:
-        - :meth:`state_vector` for standard state-vector simulation settings.
-
-    Args:
-        max_cache_size: Maximum number of cached gate representations used by the digital simulator.
-    """
-
-    max_cache_size: int = Field(
-        default=1000,
-        ge=0,
-        description="Maximum number of cached gate representations used by the digital simulator.",
-    )
-
-    def get_config(self) -> SolverConfigDict:
-        """Return digital simulation settings in backend-compatible key names."""
-        return {
-            "max_cache_size": self.max_cache_size,
-        }
-
-    @classmethod
-    def state_vector(cls, *, max_cache_size: int = 1000) -> DigitalMethod:
-        """Build the standard state-vector simulation configuration.
-
-        Args:
-            max_cache_size: Maximum number of cached gate representations used by the digital simulator.
-
-        Returns:
-            DigitalMethod: Configured state-vector digital configuration.
-        """
-        return cls(max_cache_size=max_cache_size)
-
-
 class QiliSim(Backend):
     """
     Backend that runs both digital-circuit sampling and analog
     time-evolution experiments using a custom C++ simulator.
+
+    Setup Example:
+    .. code-block:: python
+
+    from qilisdk.backends import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig,  QiliSim
+
+    backend = QiliSim(
+        analog_simulation_method=AnalogMethod.arnoldi(
+            dim=16,
+            num_substeps=2
+        ),
+        digital_simulation_method=DigitalMethod.state_vector(max_cache_size=2_000),
+        execution_config=ExecutionConfig(num_threads=4, seed=42, monte_carlo=MonteCarloConfig(trajectories=200),),
+    )
     """
 
     def __init__(
@@ -321,7 +70,7 @@ class QiliSim(Backend):
                 :meth:`AnalogMethod.integrator`.
             digital_simulation_method: Digital simulation configuration. Available options: :meth:`DigitalMethod.state_vector`. Defaults to
                 :meth:`DigitalMethod.state_vector`.
-            execution_config: Execution-level configuration for threading and random seed.
+            execution_config: Execution-level configuration for threading, random seed and monte-carlo executions.
                 Defaults to the default configuration in :class:`ExecutionConfig`.
 
         Raises:

--- a/src/qilisdk/backends/qilisim.py
+++ b/src/qilisdk/backends/qilisim.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 
 import os
 import secrets
-from typing import TYPE_CHECKING
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from loguru import logger
+from pydantic import BaseModel, Field, field_validator
+from pydantic import ConfigDict as PydanticConfigDict
 from qilisim_module import QiliSimCpp  # ty:ignore[unresolved-import]
 
 from qilisdk.backends.backend import Backend
+from qilisdk.settings import get_settings
 
 if TYPE_CHECKING:
     from qilisdk.core import QTensor
@@ -31,120 +35,369 @@ if TYPE_CHECKING:
     from qilisdk.noise.noise_model import NoiseModel
 
 
+# ----------------------------
+# Base config interface
+# ----------------------------
+
+ConfigValue = bool | int | float | str
+SolverConfigDict = dict[str, ConfigValue]
+
+
+class QiliSimConfig(BaseModel, ABC):
+    """Abstract base class for all QiliSim configuration sections."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Disallow positional arguments to keep configuration explicit.
+
+        Raises:
+            TypeError: If positional arguments are provided.
+        """
+        if args:
+            cls = self.__class__
+            field_names = ", ".join(cls.model_fields.keys())
+
+            raise TypeError(
+                f"{cls.__name__} does not accept positional arguments. "
+                f"Use keyword arguments instead. "
+                f"Valid fields: [{field_names}].\n"
+                f"Received positional arguments: {args!r}."
+            )
+        super().__init__(**kwargs)
+
+    @abstractmethod
+    def get_config(self) -> SolverConfigDict:
+        """Serialize the configuration to the flat dictionary consumed by the C++ backend."""
+
+
+# ----------------------------
+# Analog (time evolution) config
+# ----------------------------
+
+
+class MonteCarloConfig(QiliSimConfig):
+    """Configuration for Monte Carlo trajectory sampling in open-system simulations.
+
+    Args:
+        trajectories: Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.
+    """
+
+    trajectories: int = Field(
+        default=100,
+        gt=0,
+        description="Number of Monte Carlo trajectories to simulate when Monte Carlo mode is enabled.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return Monte Carlo settings in backend-compatible key names."""
+        return {"num_monte_carlo_trajectories": self.trajectories}
+
+
+class AnalogMethod(QiliSimConfig):
+    """Configuration for analog time-evolution method selection and its hyperparameters.
+
+    Preferred constructors:
+        - :meth:`integrator` for integrate-based evolution.
+        - :meth:`arnoldi` for Krylov/Arnoldi-based evolution.
+        - :meth:`direct` for direct evolution.
+
+    Args:
+        evolution_method: Analog time-evolution method to use: ``"direct"``, ``"arnoldi"``, or ``"integrate"``.
+        arnoldi_dim: Dimension of the Arnoldi Krylov subspace used when ``evolution_method="arnoldi"``.
+        num_arnoldi_substeps: Number of integration substeps per schedule step for the Arnoldi method.
+        num_integrate_substeps: Number of integration substeps per schedule step for the Integrate method.
+        monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled and deterministic evolution is
+            used.
+    """
+
+    evolution_method: Literal["direct", "arnoldi", "integrate"] = Field(
+        default="integrate",
+        description="Analog time-evolution method to use: 'direct', 'arnoldi', or 'integrate'.",
+    )
+    arnoldi_dim: int = Field(
+        default=10,
+        gt=0,
+        description="Dimension of the Arnoldi Krylov subspace used when `evolution_method='arnoldi'`.",
+    )
+    num_arnoldi_substeps: int = Field(
+        default=1,
+        gt=0,
+        description="Number of integration substeps per schedule step when using the Arnoldi method.",
+    )
+    num_integrate_substeps: int = Field(
+        default=2,
+        gt=0,
+        description="Number of integration substeps per schedule step when using the Integrate method.",
+    )
+
+    # None means Monte-Carlo disabled
+    monte_carlo: Annotated[
+        MonteCarloConfig | None,
+        Field(
+            default=None,
+            description=(
+                "Monte Carlo configuration. If `None`, Monte Carlo is disabled and deterministic evolution is used."
+            ),
+        ),
+    ]
+
+    def get_config(self) -> SolverConfigDict:
+        """Return a complete analog solver configuration for the C++ backend."""
+        d: SolverConfigDict = {
+            "evolution_method": self.evolution_method,
+            "arnoldi_dim": self.arnoldi_dim,
+            "num_arnoldi_substeps": self.num_arnoldi_substeps,
+            "num_integrate_substeps": self.num_integrate_substeps,
+            "monte_carlo": self.monte_carlo is not None,
+        }
+        if self.monte_carlo is not None:
+            d.update(self.monte_carlo.get_config())
+        else:
+            d.update({"num_monte_carlo_trajectories": 100})
+        return d
+
+    @classmethod
+    def integrator(cls, *, num_substeps: int = 2, monte_carlo: MonteCarloConfig | None = None) -> AnalogMethod:
+        """Build an ``integrate`` analog method configuration.
+
+        Args:
+            num_substeps: Number of integration substeps per schedule step when using the Integrate method.
+            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
+
+        Returns:
+            AnalogMethod: Configured integrate-method analog configuration.
+        """
+        return cls(
+            evolution_method="integrate",
+            num_integrate_substeps=num_substeps,
+            monte_carlo=monte_carlo,
+        )
+
+    @classmethod
+    def arnoldi(
+        cls,
+        *,
+        num_substeps: int = 1,
+        dim: int = 10,
+        monte_carlo: MonteCarloConfig | None = None,
+    ) -> AnalogMethod:
+        """Build an ``arnoldi`` analog method configuration.
+
+        Args:
+            num_substeps: Number of integration substeps per schedule step when using the Arnoldi method.
+            dim: Dimension of the Arnoldi Krylov subspace.
+            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
+
+        Returns:
+            AnalogMethod: Configured arnoldi-method analog configuration.
+        """
+        return cls(
+            evolution_method="arnoldi",
+            arnoldi_dim=dim,
+            num_arnoldi_substeps=num_substeps,
+            monte_carlo=monte_carlo,
+        )
+
+    @classmethod
+    def direct(cls, *, monte_carlo: MonteCarloConfig | None = None) -> AnalogMethod:
+        """Build a ``direct`` analog method configuration.
+
+        Args:
+            monte_carlo: Monte Carlo configuration. If ``None``, Monte Carlo is disabled.
+
+        Returns:
+            AnalogMethod: Configured direct-method analog configuration.
+        """
+        return cls(evolution_method="direct", monte_carlo=monte_carlo)
+
+
+# ----------------------------
+# Execution config
+# ----------------------------
+
+
+class ExecutionConfig(QiliSimConfig):
+    """Configuration for execution-level controls (threading and randomness).
+
+    Args:
+        num_threads: Number of CPU threads used for simulation. If set to ``0``, all available cores are selected.
+        seed: Random seed used by the simulator. If ``None``, a random seed is generated.
+    """
+
+    model_config = PydanticConfigDict(validate_default=True)
+    num_threads: int = Field(
+        default=0,
+        ge=0,
+        description=("Number of CPU threads used for simulation. If set to 0, all available cores are selected."),
+    )  # 0 means "use all cores"
+    seed: int | None = Field(
+        default=None,
+        ge=0,
+        description="Random seed used by the simulator. If `None`, a random seed is generated.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return execution settings with resolved defaults."""
+        return {
+            "num_threads": self.num_threads,
+            "seed": int(self.seed) if self.seed is not None else 0,  # defensive
+        }
+
+    @field_validator("num_threads", mode="after")
+    @classmethod
+    def _validate_num_threads(cls, num_threads: int) -> int:
+        if num_threads <= 0:
+            return os.cpu_count() or 1
+        return num_threads
+
+    @field_validator("seed", mode="after")
+    @classmethod
+    def _validate_seed(cls, seed: int | None) -> int:
+        if seed is None:
+            return secrets.randbelow(2**15)
+        return seed
+
+
+# ----------------------------
+# Digital config
+# ----------------------------
+
+
+class DigitalMethod(QiliSimConfig):
+    """Configuration for digital-circuit simulation options.
+
+    Preferred constructors:
+        - :meth:`state_vector` for standard state-vector simulation settings.
+
+    Args:
+        max_cache_size: Maximum number of cached gate representations used by the digital simulator.
+    """
+
+    max_cache_size: int = Field(
+        default=1000,
+        ge=0,
+        description="Maximum number of cached gate representations used by the digital simulator.",
+    )
+
+    def get_config(self) -> SolverConfigDict:
+        """Return digital simulation settings in backend-compatible key names."""
+        return {
+            "max_cache_size": self.max_cache_size,
+        }
+
+    @classmethod
+    def state_vector(cls, *, max_cache_size: int = 1000) -> DigitalMethod:
+        """Build the standard state-vector simulation configuration.
+
+        Args:
+            max_cache_size: Maximum number of cached gate representations used by the digital simulator.
+
+        Returns:
+            DigitalMethod: Configured state-vector digital configuration.
+        """
+        return cls(max_cache_size=max_cache_size)
+
+
 class QiliSim(Backend):
     """
-    Backend based that runs both digital-circuit sampling and analog
+    Backend that runs both digital-circuit sampling and analog
     time-evolution experiments using a custom C++ simulator.
     """
 
     def __init__(
         self,
         noise_model: NoiseModel | None = None,
-        evolution_method: str = "integrate",
-        arnoldi_dim: int = 10,
-        num_arnoldi_substeps: int = 1,
-        num_integrate_substeps: int = 2,
-        monte_carlo: bool = False,
-        num_monte_carlo_trajectories: int = 100,
-        max_cache_size: int = 1000,
-        num_threads: int = 0,
-        seed: int | None = None,
-        atol: float = 1e-12,
+        analog_simulation_method: AnalogMethod | None = None,
+        digital_simulation_method: DigitalMethod | None = None,
+        execution_config: ExecutionConfig | None = None,
     ) -> None:
         """
         Instantiate a new :class:`QiliSim` backend. This is a CPU-based simulator
         implemented in C++, using pybind11 for bindings.
 
         Args:
-            evolution_method (str): The solver method to use. Options are 'direct', 'arnoldi' and 'integrate'.
-            arnoldi_dim (int): The dimension of the Arnoldi subspace to use for the 'arnoldi' method.
-            num_arnoldi_substeps (int): The number of substeps to use when using the Arnoldi method.
-            num_integrate_substeps (int): The number of substeps to use when using the Integrate method.
-            monte_carlo (bool): Whether to use the Monte Carlo method for open systems.
-            num_monte_carlo_trajectories (int): The number of trajectories to use when using the Monte Carlo method.
-            max_cache_size (int): The maximum size of the internal cache for gate caching.
-            num_threads (int): The number of threads to use for parallel execution. If 0, uses all available cores.
-            seed (int | None): Seed for the random number generator. If None, a random seed is chosen.
-            atol (float): Absolute tolerance for numerical methods.
+            noise_model: Optional noise model applied during execution.
+            analog_simulation_method: Analog simulation configuration. Available options: :meth:`AnalogMethod.integrator`,
+                :meth:`AnalogMethod.arnoldi`, or :meth:`AnalogMethod.direct`. Defaults to
+                :meth:`AnalogMethod.integrator`.
+            digital_simulation_method: Digital simulation configuration. Available options: :meth:`DigitalMethod.state_vector`. Defaults to
+                :meth:`DigitalMethod.state_vector`.
+            execution_config: Execution-level configuration for threading and random seed.
+                Defaults to the default configuration in :class:`ExecutionConfig`.
 
         Raises:
-            ValueError: If any of the parameters are invalid.
+            ValueError: If a configuration argument has an invalid type.
         """
-
-        # Sanity checks on params
-        # Note that these are also in the C++ code, so update there as well if changed here for consistency
-        if evolution_method not in {"direct", "arnoldi", "integrate"}:
-            raise ValueError(f"Unknown time evolution method: {evolution_method}")
-        if arnoldi_dim <= 0:
-            raise ValueError("arnoldi_dim must be a positive integer")
-        if num_arnoldi_substeps <= 0:
-            raise ValueError("num_arnoldi_substeps must be a positive integer")
-        if num_integrate_substeps <= 0:
-            raise ValueError("num_integrate_substeps must be a positive integer")
-        if num_monte_carlo_trajectories <= 0:
-            raise ValueError("num_monte_carlo_trajectories must be a positive integer")
-        if max_cache_size < 0:
-            raise ValueError("max_cache_size cannot be negative")
-        if atol <= 0:
-            raise ValueError("atol must be a positive float")
-
-        # Set number of threads if non-positive
-        if num_threads <= 0:
-            num_threads = os.cpu_count() or 1
-
-        # Set a random seed
-        if seed is None:
-            seed = secrets.randbelow(2**15)
 
         # Initialize the backend and the class vars
         super().__init__()
         self.qili_sim = QiliSimCpp()
         self._noise_model = noise_model
-        self.solver_params = {
-            "evolution_method": evolution_method,
-            "arnoldi_dim": arnoldi_dim,
-            "num_arnoldi_substeps": num_arnoldi_substeps,
-            "num_integrate_substeps": num_integrate_substeps,
-            "monte_carlo": monte_carlo,
-            "num_monte_carlo_trajectories": num_monte_carlo_trajectories,
-            "max_cache_size": max_cache_size,
-            "num_threads": num_threads,
-            "seed": seed,
-            "atol": atol,
-        }
+
+        analog_simulation_method: AnalogMethod = analog_simulation_method or AnalogMethod.integrator()
+        digital_simulation_method: DigitalMethod = digital_simulation_method or DigitalMethod.state_vector()
+        execution_config: ExecutionConfig = execution_config or ExecutionConfig()
+
+        if not isinstance(analog_simulation_method, AnalogMethod):
+            raise ValueError(
+                f"Analog simulation method provided ({analog_simulation_method.__class__}) is not a valid analog simulation method."
+            )
+
+        if not isinstance(digital_simulation_method, DigitalMethod):
+            raise ValueError(
+                f"Digital simulation method provided ({digital_simulation_method.__class__}) is not a valid digital simulation method."
+            )
+        if not isinstance(execution_config, ExecutionConfig):
+            raise ValueError(
+                f"Execution config provided ({execution_config.__class__}) is not a valid execution configuration."
+            )
+
+        self._solver_config = analog_simulation_method.get_config()
+        self._solver_config.update(execution_config.get_config())
+        self._solver_config.update(digital_simulation_method.get_config())
+        self._solver_config.update({"atol": get_settings().atol})
+
+    @property
+    def solver_params(self) -> SolverConfigDict:
+        """Backward-compatible alias for the backend configuration dictionary."""
+        return self._solver_config
+
+    def get_config(self) -> SolverConfigDict:
+        """Return the full flattened solver configuration used by the C++ backend."""
+        return dict(self._solver_config)
 
     def _execute_sampling(self, functional: Sampling, initial_state: QTensor | None = None) -> SamplingResult:
         """
-        Execute a quantum circuit and return the measurement results.
+        Execute a digital-circuit sampling functional and return measurement results.
 
         Args:
-            functional (Sampling): The Sampling function to execute.
+            functional: Sampling functional to execute.
+            initial_state: Optional initial state to start the simulation from.
 
         Returns:
-            SamplingResult: A result object containing the measurement samples and computed probabilities.
+            SamplingResult: Measurement samples and computed probabilities.
 
         """
         logger.info("Executing Sampling with {} shots", functional.nshots)
-        result = self.qili_sim.execute_sampling(functional, self._noise_model, initial_state, self.solver_params)
+        result = self.qili_sim.execute_sampling(functional, self._noise_model, initial_state, self._solver_config)
         logger.success("Sampling finished")
         return result
 
     def _execute_time_evolution(self, functional: TimeEvolution) -> TimeEvolutionResult:
         """
-        Computes the time evolution under of an initial state under the given schedule.
+        Compute analog time evolution for the provided schedule and initial state.
 
         Args:
-            functional (TimeEvolution): The TimeEvolution functional to execute.
+            functional: TimeEvolution functional to execute.
 
         Returns:
-            TimeEvolutionResult: The results of the evolution.
+            TimeEvolutionResult: Final state and requested observables.
         """
 
         # Get the time steps
         logger.info("Executing TimeEvolution (T={}, dt={})", functional.schedule.T, functional.schedule.dt)
 
         # Execute the time evolution
-        result = self.qili_sim.execute_time_evolution(functional, self._noise_model, self.solver_params)
+        result = self.qili_sim.execute_time_evolution(functional, self._noise_model, self._solver_config)
 
         logger.success("TimeEvolution finished")
         return result

--- a/tests/integration/backends/test_all_backend_integration.py
+++ b/tests/integration/backends/test_all_backend_integration.py
@@ -34,7 +34,7 @@ from qilisdk.analog.hamiltonian import Y as pauli_y
 from qilisdk.analog.hamiltonian import Z as pauli_z
 from qilisdk.analog.schedule import Schedule
 from qilisdk.backends import QutipBackend
-from qilisdk.backends.qilisim import QiliSim
+from qilisdk.backends.qilisim import ExecutionConfig, QiliSim
 from qilisdk.core.model import Constraint, Model, Objective
 from qilisdk.core.qtensor import QTensor, ket, tensor_prod
 from qilisdk.core.variables import BinaryVariable
@@ -58,14 +58,14 @@ pytest.importorskip(
 
 from qilisdk.backends.cuda_backend import CudaBackend
 
-backends = [QutipBackend(), QiliSim(seed=42, num_threads=1)]
+backends = [QutipBackend(), QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))]
 if pytest.importorskip(
     "cudaq",
     reason="CUDA backend tests require the 'cuda' optional dependency",
     exc_type=ImportError,
 ):
     backends.append(CudaBackend())
-backends_no_cuda = [QutipBackend(), QiliSim(seed=42, num_threads=1)]
+backends_no_cuda = [QutipBackend(), QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))]
 
 
 @pytest.mark.parametrize("backend", backends)

--- a/tests/integration/backends/test_all_backend_integration.py
+++ b/tests/integration/backends/test_all_backend_integration.py
@@ -34,7 +34,8 @@ from qilisdk.analog.hamiltonian import Y as pauli_y
 from qilisdk.analog.hamiltonian import Z as pauli_z
 from qilisdk.analog.schedule import Schedule
 from qilisdk.backends import QutipBackend
-from qilisdk.backends.qilisim import ExecutionConfig, QiliSim
+from qilisdk.backends.backend_config import ExecutionConfig
+from qilisdk.backends.qilisim import QiliSim
 from qilisdk.core.model import Constraint, Model, Objective
 from qilisdk.core.qtensor import QTensor, ket, tensor_prod
 from qilisdk.core.variables import BinaryVariable

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -19,7 +19,8 @@ from qilisdk.analog.hamiltonian import X as pauli_x
 from qilisdk.analog.hamiltonian import Y as pauli_y
 from qilisdk.analog.hamiltonian import Z as pauli_z
 from qilisdk.analog.schedule import Schedule
-from qilisdk.backends.qilisim import AnalogMethod, ExecutionConfig, MonteCarloConfig, QiliSim
+from qilisdk.backends.backend_config import AnalogMethod, ExecutionConfig, MonteCarloConfig
+from qilisdk.backends.qilisim import QiliSim
 from qilisdk.core.qtensor import ket
 from qilisdk.digital import Circuit, H, X
 from qilisdk.functionals.sampling import Sampling
@@ -29,23 +30,20 @@ from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 
 simulation_types = ["direct", "arnoldi", "integrate"]
 
-
-def _execution(seed: int | None) -> ExecutionConfig:
-    return ExecutionConfig(seed=seed, num_threads=1)
+_MONTE_CARLO_CONFIG = MonteCarloConfig(trajectories=100)
 
 
-def _analog_method(method: str, monte_carlo: bool = False) -> AnalogMethod:
-    monte_carlo_config = MonteCarloConfig(trajectories=100) if monte_carlo else None
+def _analog_method(method: str) -> AnalogMethod:
     if method == "direct":
-        return AnalogMethod.direct(monte_carlo=monte_carlo_config)
+        return AnalogMethod.direct()
     if method == "arnoldi":
-        return AnalogMethod.arnoldi(monte_carlo=monte_carlo_config)
-    return AnalogMethod.integrator(monte_carlo=monte_carlo_config)
+        return AnalogMethod.arnoldi()
+    return AnalogMethod.integrator()
 
 
 def test_seed_same():
-    backend1 = QiliSim(execution_config=_execution(seed=42))
-    backend2 = QiliSim(execution_config=_execution(seed=42))
+    backend1 = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
+    backend2 = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
     result1 = backend1.execute(Sampling(circuit=circuit, nshots=100))
@@ -54,7 +52,7 @@ def test_seed_same():
 
 
 def test_no_seed():
-    backend = QiliSim(execution_config=_execution(seed=None))
+    backend = QiliSim(execution_config=ExecutionConfig(seed=None, num_threads=1))
     seed = backend.get_config()["seed"]
     assert isinstance(seed, int)
     assert 0 <= seed < 2**15
@@ -66,8 +64,8 @@ def test_monte_carlo_circuit():
     initial_state_2 = ket(1).unit()
     initial_state = (initial_state_1.to_density_matrix() * (1 - p) + initial_state_2.to_density_matrix() * p).unit()
     backend = QiliSim(
-        analog_simulation_method=AnalogMethod.integrator(monte_carlo=MonteCarloConfig(trajectories=100)),
-        execution_config=_execution(seed=42),
+        analog_simulation_method=AnalogMethod.integrator(),
+        execution_config=ExecutionConfig(seed=42, num_threads=1, monte_carlo=MonteCarloConfig(trajectories=100)),
     )
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
@@ -79,8 +77,8 @@ def test_monte_carlo_circuit():
 
 
 def test_seed_different():
-    backend1 = QiliSim(execution_config=_execution(seed=42))
-    backend2 = QiliSim(execution_config=_execution(seed=43))
+    backend1 = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
+    backend2 = QiliSim(execution_config=ExecutionConfig(seed=43, num_threads=1))
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
     result1 = backend1.execute(Sampling(circuit=circuit, nshots=100))
@@ -108,7 +106,10 @@ def test_row_vec_ordering(method):
         pauli_y(0),  # measure y
     ]
 
-    backend = QiliSim(analog_simulation_method=_analog_method(method), execution_config=_execution(seed=42))
+    backend = QiliSim(
+        analog_simulation_method=_analog_method(method),
+        execution_config=ExecutionConfig(seed=42, num_threads=1, monte_carlo=_MONTE_CARLO_CONFIG),
+    )
     res = backend.execute(TimeEvolution(schedule=schedule, initial_state=psi0, observables=obs))
 
     assert isinstance(res, TimeEvolutionResult)
@@ -141,8 +142,8 @@ def test_monte_carlo_time_evolution(method):
     ]
 
     backend = QiliSim(
-        analog_simulation_method=_analog_method(method, monte_carlo=True),
-        execution_config=_execution(seed=42),
+        analog_simulation_method=_analog_method(method),
+        execution_config=ExecutionConfig(seed=42, num_threads=1, monte_carlo=_MONTE_CARLO_CONFIG),
     )
     res = backend.execute(TimeEvolution(schedule=schedule, initial_state=psi0, observables=obs))
 
@@ -154,7 +155,7 @@ def test_monte_carlo_time_evolution(method):
 
 
 def test_exponential_gates():
-    backend = QiliSim(execution_config=_execution(seed=42))
+    backend = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
     circuit = Circuit(nqubits=1)
     circuit.add(X(0).exponential())
     result = backend.execute(Sampling(circuit=circuit, nshots=100))

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -19,7 +19,7 @@ from qilisdk.analog.hamiltonian import X as pauli_x
 from qilisdk.analog.hamiltonian import Y as pauli_y
 from qilisdk.analog.hamiltonian import Z as pauli_z
 from qilisdk.analog.schedule import Schedule
-from qilisdk.backends.qilisim import QiliSim
+from qilisdk.backends.qilisim import AnalogMethod, ExecutionConfig, MonteCarloConfig, QiliSim
 from qilisdk.core.qtensor import ket
 from qilisdk.digital import Circuit, H, X
 from qilisdk.functionals.sampling import Sampling
@@ -30,9 +30,22 @@ from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
 simulation_types = ["direct", "arnoldi", "integrate"]
 
 
+def _execution(seed: int | None) -> ExecutionConfig:
+    return ExecutionConfig(seed=seed, num_threads=1)
+
+
+def _analog_method(method: str, monte_carlo: bool = False) -> AnalogMethod:
+    monte_carlo_config = MonteCarloConfig(trajectories=100) if monte_carlo else None
+    if method == "direct":
+        return AnalogMethod.direct(monte_carlo=monte_carlo_config)
+    if method == "arnoldi":
+        return AnalogMethod.arnoldi(monte_carlo=monte_carlo_config)
+    return AnalogMethod.integrator(monte_carlo=monte_carlo_config)
+
+
 def test_seed_same():
-    backend1 = QiliSim(seed=42, num_threads=1)
-    backend2 = QiliSim(seed=42, num_threads=1)
+    backend1 = QiliSim(execution_config=_execution(seed=42))
+    backend2 = QiliSim(execution_config=_execution(seed=42))
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
     result1 = backend1.execute(Sampling(circuit=circuit, nshots=100))
@@ -41,10 +54,10 @@ def test_seed_same():
 
 
 def test_no_seed():
-    backend = QiliSim(seed=None, num_threads=1)
-    seed = backend.solver_params["seed"]
+    backend = QiliSim(execution_config=_execution(seed=None))
+    seed = backend.get_config()["seed"]
     assert isinstance(seed, int)
-    assert 0 <= seed <= 2**15
+    assert 0 <= seed < 2**15
 
 
 def test_monte_carlo_circuit():
@@ -52,7 +65,10 @@ def test_monte_carlo_circuit():
     initial_state_1 = ket(0).unit()
     initial_state_2 = ket(1).unit()
     initial_state = (initial_state_1.to_density_matrix() * (1 - p) + initial_state_2.to_density_matrix() * p).unit()
-    backend = QiliSim(monte_carlo=True, num_monte_carlo_trajectories=100, seed=42, num_threads=1)
+    backend = QiliSim(
+        analog_simulation_method=AnalogMethod.integrator(monte_carlo=MonteCarloConfig(trajectories=100)),
+        execution_config=_execution(seed=42),
+    )
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
     result = backend._execute_sampling(Sampling(circuit=circuit, nshots=100), initial_state=initial_state)
@@ -63,8 +79,8 @@ def test_monte_carlo_circuit():
 
 
 def test_seed_different():
-    backend1 = QiliSim(seed=42, num_threads=1)
-    backend2 = QiliSim(seed=43, num_threads=1)
+    backend1 = QiliSim(execution_config=_execution(seed=42))
+    backend2 = QiliSim(execution_config=_execution(seed=43))
     circuit = Circuit(nqubits=1)
     circuit.add(H(0))
     result1 = backend1.execute(Sampling(circuit=circuit, nshots=100))
@@ -92,7 +108,7 @@ def test_row_vec_ordering(method):
         pauli_y(0),  # measure y
     ]
 
-    backend = QiliSim(evolution_method=method, seed=42, num_threads=1)
+    backend = QiliSim(analog_simulation_method=_analog_method(method), execution_config=_execution(seed=42))
     res = backend.execute(TimeEvolution(schedule=schedule, initial_state=psi0, observables=obs))
 
     assert isinstance(res, TimeEvolutionResult)
@@ -124,7 +140,10 @@ def test_monte_carlo_time_evolution(method):
         pauli_z(0),  # measure z
     ]
 
-    backend = QiliSim(evolution_method=method, monte_carlo=True, seed=42, num_threads=1)
+    backend = QiliSim(
+        analog_simulation_method=_analog_method(method, monte_carlo=True),
+        execution_config=_execution(seed=42),
+    )
     res = backend.execute(TimeEvolution(schedule=schedule, initial_state=psi0, observables=obs))
 
     assert isinstance(res, TimeEvolutionResult)
@@ -135,7 +154,7 @@ def test_monte_carlo_time_evolution(method):
 
 
 def test_exponential_gates():
-    backend = QiliSim(seed=42, num_threads=1)
+    backend = QiliSim(execution_config=_execution(seed=42))
     circuit = Circuit(nqubits=1)
     circuit.add(X(0).exponential())
     result = backend.execute(Sampling(circuit=circuit, nshots=100))

--- a/tests/integration/noise/test_noise_backends.py
+++ b/tests/integration/noise/test_noise_backends.py
@@ -16,7 +16,7 @@ import random
 import numpy as np
 import pytest
 
-from qilisdk.backends.qilisim import ExecutionConfig
+from qilisdk.backends.backend_config import ExecutionConfig
 
 pytest.importorskip(
     "cudaq",

--- a/tests/integration/noise/test_noise_backends.py
+++ b/tests/integration/noise/test_noise_backends.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import random
 
 import numpy as np
 import pytest
+
+from qilisdk.backends.qilisim import ExecutionConfig
 
 pytest.importorskip(
     "cudaq",
@@ -47,7 +48,7 @@ from qilisdk.noise import (
 from qilisdk.noise.representations import KrausChannel, LindbladGenerator
 
 backends = [QiliSim, CudaBackend]
-args_per_backend = {QiliSim: {"seed": 42, "num_threads": 1}, CudaBackend: {}}
+args_per_backend = {QiliSim: {"execution_config": ExecutionConfig(seed=42, num_threads=1)}, CudaBackend: {}}
 
 
 @pytest.mark.parametrize("backend_class", backends)

--- a/tests/unit/backends/test_qilisim_backend.py
+++ b/tests/unit/backends/test_qilisim_backend.py
@@ -195,7 +195,7 @@ def _build_quantum_reservoir_functional() -> QuantumReservoir:
 
 
 def test_execute_quantum_reservoir_qilisim(monkeypatch):
-    backend = QiliSim(seed=42, num_threads=1)
+    backend = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
     functional = _build_quantum_reservoir_functional()
     final_density = ket(0).to_density_matrix()
     monkeypatch.setattr(

--- a/tests/unit/backends/test_qilisim_backend.py
+++ b/tests/unit/backends/test_qilisim_backend.py
@@ -22,7 +22,8 @@ import qilisdk
 from qilisdk.analog import Hamiltonian, PauliZ, Schedule
 from qilisdk.analog.hamiltonian import X as pauli_x
 from qilisdk.analog.hamiltonian import Z as pauli_z
-from qilisdk.backends.qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig, QiliSim
+from qilisdk.backends.backend_config import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
+from qilisdk.backends.qilisim import QiliSim
 from qilisdk.core import ket
 from qilisdk.functionals import QuantumReservoir, ReservoirLayer, Sampling, TimeEvolution
 from qilisdk.functionals.time_evolution_result import TimeEvolutionResult
@@ -52,10 +53,9 @@ def test_qilisim_config_builders_and_validation():
     analog = AnalogMethod.arnoldi(
         dim=16,
         num_substeps=3,
-        monte_carlo=MonteCarloConfig(trajectories=250),
     )
     digital = DigitalMethod.state_vector(max_cache_size=2048)
-    execution = ExecutionConfig(seed=42, num_threads=2)
+    execution = ExecutionConfig(seed=42, num_threads=2, monte_carlo=MonteCarloConfig(trajectories=250))
 
     backend = QiliSim(
         analog_simulation_method=analog,

--- a/tests/unit/backends/test_qilisim_backend.py
+++ b/tests/unit/backends/test_qilisim_backend.py
@@ -16,12 +16,13 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 import qilisdk
 from qilisdk.analog import Hamiltonian, PauliZ, Schedule
 from qilisdk.analog.hamiltonian import X as pauli_x
 from qilisdk.analog.hamiltonian import Z as pauli_z
-from qilisdk.backends.qilisim import QiliSim
+from qilisdk.backends.qilisim import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig, QiliSim
 from qilisdk.core import ket
 from qilisdk.functionals import Sampling, TimeEvolution
 from qilisdk.noise import Dephasing, NoiseModel
@@ -29,22 +30,69 @@ from qilisdk.noise import Dephasing, NoiseModel
 
 def test_qilisim_init():
     backend = QiliSim()
-    assert backend.solver_params is not None
+    config = backend.get_config()
 
-    with pytest.raises(ValueError, match=r"Unknown time evolution method"):
-        QiliSim(evolution_method="invalid_method")
-    with pytest.raises(ValueError, match=r"arnoldi_dim must be a positive integer"):
-        QiliSim(arnoldi_dim=0)
-    with pytest.raises(ValueError, match=r"num_arnoldi_substeps must be a positive integer"):
-        QiliSim(num_arnoldi_substeps=-3)
-    with pytest.raises(ValueError, match=r"num_integrate_substeps must be a positive integer"):
-        QiliSim(num_integrate_substeps=0)
-    with pytest.raises(ValueError, match=r"num_monte_carlo_trajectories must be a positive integer"):
-        QiliSim(num_monte_carlo_trajectories=-10)
-    with pytest.raises(ValueError, match=r"max_cache_size cannot be negative"):
-        QiliSim(max_cache_size=-5)
-    with pytest.raises(ValueError, match=r"atol must be a positive float"):
-        QiliSim(atol=-1)
+    assert backend.solver_params is not None
+    assert config["evolution_method"] == "integrate"
+    assert config["num_integrate_substeps"] == 2
+    assert config["monte_carlo"] is False
+    assert config["num_monte_carlo_trajectories"] == 100
+    assert config["max_cache_size"] == 1000
+    assert config["num_threads"] >= 1
+    assert isinstance(config["seed"], int)
+    assert config["atol"] > 0
+
+    copied_config = backend.get_config()
+    copied_config["seed"] = -1
+    assert backend.get_config()["seed"] != -1
+
+
+def test_qilisim_config_builders_and_validation():
+    analog = AnalogMethod.arnoldi(
+        dim=16,
+        num_substeps=3,
+        monte_carlo=MonteCarloConfig(trajectories=250),
+    )
+    digital = DigitalMethod.state_vector(max_cache_size=2048)
+    execution = ExecutionConfig(seed=42, num_threads=2)
+
+    backend = QiliSim(
+        analog_simulation_method=analog,
+        digital_simulation_method=digital,
+        execution_config=execution,
+    )
+    config = backend.get_config()
+
+    assert config["evolution_method"] == "arnoldi"
+    assert config["arnoldi_dim"] == 16
+    assert config["num_arnoldi_substeps"] == 3
+    assert config["monte_carlo"] is True
+    assert config["num_monte_carlo_trajectories"] == 250
+    assert config["max_cache_size"] == 2048
+    assert config["num_threads"] == 2
+    assert config["seed"] == 42
+
+    with pytest.raises(ValidationError):
+        AnalogMethod(evolution_method="invalid_method")
+    with pytest.raises(ValidationError):
+        AnalogMethod(arnoldi_dim=0)
+    with pytest.raises(ValidationError):
+        MonteCarloConfig(trajectories=0)
+    with pytest.raises(ValidationError):
+        DigitalMethod(max_cache_size=-5)
+    with pytest.raises(ValidationError):
+        ExecutionConfig(seed=-1)
+    with pytest.raises(TypeError, match="does not accept positional arguments"):
+        ExecutionConfig(1)
+
+
+def test_qilisim_invalid_config_types():
+    with pytest.raises(ValueError, match="not a valid analog simulation method"):
+        QiliSim(analog_simulation_method=DigitalMethod())  # type:ignore[arg-type]
+    with pytest.raises(ValueError, match="not a valid digital simulation method"):
+        QiliSim(digital_simulation_method=AnalogMethod.integrator())  # type:ignore[arg-type]
+    with pytest.raises(ValueError, match="not a valid execution configuration"):
+        QiliSim(execution_config=AnalogMethod.integrator())  # type:ignore[arg-type]
 
 
 class QiliSimMock:
@@ -77,7 +125,7 @@ def test_qilisim_time_evolution_dummy(monkeypatch):
 
 
 def test_time_dependent_hamiltonian_bad_observable():
-    backend = QiliSim(seed=42, num_threads=1)
+    backend = QiliSim(execution_config=ExecutionConfig(seed=42, num_threads=1))
     o = 1.0
     dt = 0.5
     T = 100
@@ -107,14 +155,14 @@ def test_qilisim_dephasing_strength_changes_dynamics():
 
     weak_noise = NoiseModel()
     weak_noise.add(Dephasing(t_phi=1e6), qubits=[0])
-    weak_backend = QiliSim(noise_model=weak_noise, seed=42, num_threads=1)
+    weak_backend = QiliSim(noise_model=weak_noise, execution_config=ExecutionConfig(seed=42, num_threads=1))
     weak_result = weak_backend.execute(
         TimeEvolution(schedule=schedule, initial_state=initial_state, observables=[pauli_x(0)])
     )
 
     strong_noise = NoiseModel()
     strong_noise.add(Dephasing(t_phi=10), qubits=[0])
-    strong_backend = QiliSim(noise_model=strong_noise, seed=42, num_threads=1)
+    strong_backend = QiliSim(noise_model=strong_noise, execution_config=ExecutionConfig(seed=42, num_threads=1))
     strong_result = strong_backend.execute(
         TimeEvolution(schedule=schedule, initial_state=initial_state, observables=[pauli_x(0)])
     )


### PR DESCRIPTION
Refactored the QiliSim backend configuration API around typed Pydantic models and aligned docs/tests with the new usage.

Main changes:

* Introduced structured QiliSim configuration models:
  * `AnalogMethod` (with `integrator`, `arnoldi`, and `direct` builders)
  * `DigitalMethod` (with `state_vector` builder)
  * `ExecutionConfig` (threading and RNG seed controls)
  * `MonteCarloConfig` (trajectory control for Monte Carlo mode)
* Updated `QiliSim` initialization to accept:
  * `analog_simulation_method`
  * `digital_simulation_method`
  * `execution_config`
  instead of many flat constructor parameters.
* Added `QiliSim.get_config()` and kept `solver_params` as a backward-compatible alias.
* Fixed solver configuration wiring so execution paths use the refactored internal config dictionary.
* Expanded docstrings for new and affected methods/classes, including:
  * per-field `Field(description=...)` metadata for Pydantic model fields
  * top-level model parameter documentation for better IDE hover help
  * classmethod argument documentation aligned with field descriptions.
* Updated backend documentation (`docs/fundamentals/backends.rst`) to describe the new configuration objects and provide an updated configuration example.
* Updated and expanded QiliSim unit/integration tests to validate:
  * new configuration builders and validation behavior
  * new backend construction patterns using `ExecutionConfig`/`AnalogMethod`/`DigitalMethod`/`MonteCarloConfig`
  * compatibility of shared backend integration suites with the new API.