### PR TITLE
[SDK-226] Removing the exposed Parameter objects in Gate, Hamiltonian, and Interpolator. 

### DIFF
--- a/changes/169.misc.md
+++ b/changes/169.misc.md
@@ -1,0 +1,1 @@
+Refactored parameter handling across digital and analog objects to use the shared `Parameterizable` interface, including explicit `get_*`/`set_*` parameter access patterns and synchronized tests/docs updates for the new structure.

--- a/docs/fundamentals/analog.rst
+++ b/docs/fundamentals/analog.rst
@@ -209,3 +209,8 @@ later.
     schedule.set_parameters({"gamma": 0.7})
     print(schedule.get_parameter_names())   # ['gamma', 'T']
     print(schedule.get_constraints())       # [0 <= T]
+
+.. note::
+
+   For schedules, Hamiltonians, and interpolators, use ``get_parameters`` and
+   related accessor methods to inspect parameter state.

--- a/docs/fundamentals/core.rst
+++ b/docs/fundamentals/core.rst
@@ -198,6 +198,15 @@ such as trainable parameters.
     trainable_values = circuit.get_parameter_values(where=lambda p: p.is_trainable)
     circuit.set_parameter_values([0.3], where=lambda p: p.is_trainable)
 
+.. note::
+
+    Parameterizable objects expose parameter state through
+    :meth:`~qilisdk.core.parameterizable.Parameterizable.get_parameters`,
+    :meth:`~qilisdk.core.parameterizable.Parameterizable.get_parameter_names`,
+    :meth:`~qilisdk.core.parameterizable.Parameterizable.get_parameter_values`,
+    and the corresponding ``set_*`` methods. Accessing ``.parameters`` directly
+    is not part of the public API.
+
 
 Mathematical Maps (sin, cos)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/fundamentals/digital.rst
+++ b/docs/fundamentals/digital.rst
@@ -521,6 +521,12 @@ update them selectively:
 These helpers make it straightforward to plug the circuit into classical
 optimization loops while keeping parameter metadata synchronized.
 
+.. note::
+
+   Parameterized gates and circuits expose parameter information through
+   ``get_parameter_names``, ``get_parameters``, ``get_parameter_values``, and
+   the matching ``set_*`` methods.
+
 Gate Modifiers and Measurement
 ------------------------------
 

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -291,20 +291,19 @@ class Hamiltonian(Parameterizable):
         Raises:
             ValueError: If the provided coefficients include generic variables instead of parameters.
         """
-        super(Hamiltonian, self).__init__()
+        super().__init__()
         self._elements: dict[tuple[PauliOperator, ...], complex | Term | Parameter] = defaultdict(complex)
-        self._parameters: dict[str, Parameter] = {}
         if elements:
             for key, val in elements.items():
                 if isinstance(val, Term):
                     for v in val.variables():
                         if isinstance(v, Parameter):
-                            self._parameters[v.label] = v
+                            self._add_parameter(v.label, v)
                         else:
                             raise ValueError(_GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE)
                 elif isinstance(val, BaseVariable):
                     if isinstance(val, Parameter):
-                        self._parameters[val.label] = val
+                        self._add_parameter(val.label, val)
 
                     else:
                         raise ValueError(_GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE)
@@ -327,11 +326,6 @@ class Hamiltonian(Parameterizable):
             )
             for k, v in self._elements.items()
         }
-
-    @property
-    def parameters(self) -> dict[str, Parameter]:
-        """Return a mapping from parameter labels to their corresponding parameter objects."""
-        return self._parameters
 
     def simplify(self) -> Hamiltonian:
         """Simplify the Hamiltonian expression by removing near-zero terms and accumulating constant terms.
@@ -954,7 +948,7 @@ class Hamiltonian(Parameterizable):
             for key, val in other._elements.items():  # noqa: SLF001
                 self._elements[key] += val
 
-            self._parameters.update(other.parameters)
+            self._update_parameters(other._parameters)  # noqa: SLF001
         elif isinstance(other, PauliOperator):
             # Just add 1 to that single operator key
             self._elements[other,] += 1
@@ -967,9 +961,9 @@ class Hamiltonian(Parameterizable):
             if isinstance(other, Term):
                 if not other.is_parameterized_term():
                     raise ValueError(_GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE)
-                self._parameters.update({v.label: v for v in other if isinstance(v, Parameter)})
+                self._update_parameters({v.label: v for v in other if isinstance(v, Parameter)})
             else:
-                self._parameters[other.label] = other
+                self._add_parameter(other.label, other)
             self._elements[PauliI(0),] += other
         else:
             raise InvalidHamiltonianOperation(f"Invalid addition between Hamiltonian and {other.__class__.__name__}.")
@@ -978,7 +972,7 @@ class Hamiltonian(Parameterizable):
         if isinstance(other, Hamiltonian):
             for key, val in other._elements.items():  # noqa: SLF001
                 self._elements[key] -= val
-            self._parameters.update(other._parameters)  # noqa: SLF001
+            self._update_parameters(other._parameters)  # noqa: SLF001
         elif isinstance(other, PauliOperator):
             self._elements[other,] -= 1
         elif isinstance(other, (int, float, complex)):
@@ -989,9 +983,9 @@ class Hamiltonian(Parameterizable):
             if isinstance(other, Term):
                 if not other.is_parameterized_term():
                     raise ValueError(_GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE)
-                self._parameters.update({v.label: v for v in other if isinstance(v, Parameter)})
+                self._update_parameters({v.label: v for v in other if isinstance(v, Parameter)})
             else:
-                self._parameters[other.label] = other
+                self._add_parameter(other.label, other)
             self._elements[PauliI(0),] -= other
         else:
             raise InvalidHamiltonianOperation(
@@ -1017,9 +1011,9 @@ class Hamiltonian(Parameterizable):
             if isinstance(other, Term):
                 if not other.is_parameterized_term():
                     raise ValueError(_GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE)
-                self._parameters.update({v.label: v for v in other if isinstance(v, Parameter)})
+                self._update_parameters({v.label: v for v in other if isinstance(v, Parameter)})
             else:
-                self._parameters[other.label] = other
+                self._add_parameter(other.label, other)
             for k in self._elements:
                 self._elements[k] *= other
             return None
@@ -1051,7 +1045,7 @@ class Hamiltonian(Parameterizable):
                     phase, new_ops = self._multiply_sets(ops1, ops2)
                     new_dict[new_ops] += phase * c1 * c2
             self._elements = new_dict
-            self._parameters.update(other._parameters)  # noqa: SLF001
+            self._update_parameters(other._parameters)  # noqa: SLF001
 
         else:
             raise InvalidHamiltonianOperation(

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -21,7 +21,7 @@ from numpy import linspace
 from qilisdk.analog.hamiltonian import Hamiltonian
 from qilisdk.core.interpolator import Interpolation, Interpolator, TimeDict
 from qilisdk.core.parameterizable import Parameterizable
-from qilisdk.core.variables import BaseVariable, ComparisonTerm, Domain, Parameter, Term
+from qilisdk.core.variables import BaseVariable, Domain, Parameter, Term
 from qilisdk.settings import get_settings
 from qilisdk.utils.visualization import ScheduleStyle
 from qilisdk.yaml import yaml
@@ -86,12 +86,11 @@ class Schedule(Parameterizable):
             ValueError: if the coefficients reference an undefined hamiltonian.
         """
         # THIS is the only runtime implementation
-        super(Schedule, self).__init__()
+        super().__init__()
 
         self._hamiltonians = hamiltonians if hamiltonians is not None else {}
         self._coefficients: dict[str, Interpolator] = {}
         self._interpolation = None
-        self._parameters: dict[str, Parameter] = {}
         self._current_time: Parameter = Parameter(_TIME_PARAMETER_NAME, 0, Domain.REAL)
         self.iter_time_step = 0
         self._max_time: PARAMETERIZED_NUMBER | None = None
@@ -106,10 +105,6 @@ class Schedule(Parameterizable):
             raise ValueError(f"Missing keys in hamiltonians: {missing}")
 
         for ham, hamiltonian in self._hamiltonians.items():
-            # Gather Hamiltonian parameters and nqubits
-            for param in hamiltonian.parameters.values():
-                self._parameters[param.label] = param
-
             # Build hamiltonian schedule
             if ham not in coefficients:
                 self._coefficients[ham] = Interpolator({0: 1}, interpolation=interpolation, nsamples=int(1 / dt))
@@ -119,9 +114,6 @@ class Schedule(Parameterizable):
                 self._coefficients[ham] = coeff
             elif isinstance(coeff, dict):
                 self._coefficients[ham] = Interpolator(coeff, interpolation, nsamples=int(1 / dt))
-
-            for p_name, p_value in self._coefficients[ham].parameters.items():
-                self._parameters[p_name] = p_value
 
         if total_time is not None:
             self.scale_max_time(total_time)
@@ -190,11 +182,6 @@ class Schedule(Parameterizable):
             return 0
         return max(self._hamiltonians.values(), key=lambda v: v.nqubits).nqubits
 
-    @property
-    def nparameters(self) -> int:
-        """Number of symbolic parameters introduced by the Hamiltonians or coefficients."""
-        return len(self._parameters)
-
     def _iter_parameter_children(self) -> Iterator[Parameterizable]:
         """Expose hamiltonians and interpolators to the shared parameter interface.
 
@@ -224,7 +211,7 @@ class Schedule(Parameterizable):
 
     def _extract_parameters(self, element: PARAMETERIZED_NUMBER) -> None:
         if isinstance(element, Parameter):
-            self._parameters[element.label] = element
+            self._add_parameter(element.label, element)
         elif isinstance(element, Term):
             if not element.is_parameterized_term():
                 raise ValueError(
@@ -232,49 +219,7 @@ class Schedule(Parameterizable):
                 )
             for p in element.variables():
                 if isinstance(p, Parameter):
-                    self._parameters[p.label] = p
-
-    def set_parameters(self, parameters: dict[str, int | float]) -> None:
-        """Update parameter values across all Hamiltonian coefficient interpolators.
-
-        Args:
-            parameters (dict[str, int | float]): Mapping from parameter labels to numeric values.
-
-        Raises:
-            ValueError: If an unknown parameter label is provided.
-        """
-        for label in parameters:
-            if label not in self._parameters:
-                raise ValueError(f"Parameter {label} is not defined in this Schedule.")
-        for h in self._hamiltonians:
-            self._coefficients[h].set_parameters(
-                {p: parameters[p] for p in self._coefficients[h].get_parameter_names() if p in parameters}
-            )
-        super().set_parameters(parameters)
-
-    def set_parameter_bounds(self, ranges: dict[str, tuple[float, float]]) -> None:
-        """Propagate bound updates to all interpolators and cached parameters.
-
-        Args:
-            ranges (dict[str, tuple[float, float]]): Mapping of parameter label to ``(lower, upper)`` bounds.
-
-        Raises:
-            ValueError: If an unknown parameter label is provided.
-        """
-        for label in ranges:
-            if label not in self._parameters:
-                raise ValueError(
-                    f"The provided parameter label {label} is not defined in the list of parameters in this object."
-                )
-        for h in self._hamiltonians:
-            self._coefficients[h].set_parameter_bounds(
-                {p: ranges[p] for p in self._coefficients[h].get_parameter_names() if p in ranges}
-            )
-        super().set_parameter_bounds(ranges)
-
-    def get_constraints(self) -> list[ComparisonTerm]:
-        """Return the set of parameter constraints arising from all interpolators."""
-        return list(set(super().get_constraints()))
+                    self._add_parameter(p.label, p)
 
     def scale_max_time(self, max_time: PARAMETERIZED_NUMBER) -> None:  # FIX!
         """
@@ -302,9 +247,6 @@ class Schedule(Parameterizable):
         self._hamiltonians[label] = hamiltonian
         self._coefficients[label] = Interpolator(coefficients, interpolation, nsamples=int(1 / self.dt))
 
-        for p_name, p_value in self._coefficients[label].parameters.items():
-            self._parameters[p_name] = p_value
-
     def _add_hamiltonian_from_interpolator(
         self, label: str, hamiltonian: Hamiltonian, coefficients: Interpolator
     ) -> None:
@@ -312,9 +254,6 @@ class Schedule(Parameterizable):
             raise ValueError(f"Can't add Hamiltonian because label {label} is already associated with a Hamiltonian.")
         self._hamiltonians[label] = hamiltonian
         self._coefficients[label] = coefficients
-
-        for p_name, p_value in self._coefficients[label].parameters.items():
-            self._parameters[p_name] = p_value
 
     @overload
     def add_hamiltonian(
@@ -362,15 +301,9 @@ class Schedule(Parameterizable):
                 new_coefficients, interpolation, nsamples=int(1 / self.dt)
             )  # TODO (ameer): allow for partial updates of the coefficients
 
-            for p_name, p_value in self._coefficients[label].parameters.items():
-                self._parameters[p_name] = p_value
-
     def _update_hamiltonian_from_interpolator(self, label: str, new_coefficients: Interpolator | None = None) -> None:
         if new_coefficients is not None:
             self._coefficients[label] = new_coefficients
-
-            for p_name, p_value in self._coefficients[label].parameters.items():
-                self._parameters[p_name] = p_value
 
     @overload
     def update_hamiltonian(

--- a/src/qilisdk/core/interpolator.py
+++ b/src/qilisdk/core/interpolator.py
@@ -307,16 +307,6 @@ class Interpolator(Parameterizable):
         """
         return [self._get_value(self[t]) for t in self.fixed_tlist]
 
-    @property
-    def parameters(self) -> dict[str, Parameter]:
-        """
-        Return the parameters discovered while building the interpolator.
-
-        Returns:
-            dict[str, Parameter]: Parameters collected from time points and coefficients.
-        """
-        return self._parameters
-
     def set_max_time(self, max_time: PARAMETERIZED_NUMBER) -> None:
         """
         Rescale all time points to a new maximum duration while keeping relative spacing.
@@ -383,7 +373,7 @@ class Interpolator(Parameterizable):
             ValueError: If the element contains variables that are not parameters.
         """
         if isinstance(element, Parameter) and element.label != _TIME_PARAMETER_NAME:
-            self._parameters[element.label] = element
+            self._add_parameter(element.label, element)
         elif isinstance(element, Term):
             if not element.is_parameterized_term():
                 raise ValueError(
@@ -391,7 +381,7 @@ class Interpolator(Parameterizable):
                 )
             for p in element.variables():
                 if isinstance(p, Parameter) and p.label != _TIME_PARAMETER_NAME:
-                    self._parameters[p.label] = p
+                    self._add_parameter(p.label, p)
 
     def add_time_point(
         self,
@@ -415,7 +405,7 @@ class Interpolator(Parameterizable):
             coeff, _params = _process_callable(coeff, self._current_time)  # ty:ignore[invalid-argument-type]
             self._extract_parameters(coeff)
             if len(_params) > 0:
-                self._parameters.update(_params)
+                self._update_parameters(_params)
         elif isinstance(coeff, (int, float, Parameter, Term)):
             self._extract_parameters(coeff)
         else:

--- a/src/qilisdk/core/parameterizable.py
+++ b/src/qilisdk/core/parameterizable.py
@@ -37,13 +37,13 @@ class Parameterizable(ABC):
         self._parameter_constraints: list[ComparisonTerm] = []
         self._prefix = ""
 
-    @property
-    def nparameters(self) -> int:
-        """Number of tunable parameters defined by the object."""
-        return len(dict(self._iter_parameter_items()))
+    # Private Methods
 
     def _iter_parameter_children(self) -> Iterable[Parameterizable]:  # noqa: PLR6301
-        """Yield parameterizable children to compose this object's parameter interface.
+        """Yield child objects that compose this object's parameter interface.
+
+        Override this method in subclasses that expose nested
+        :class:`Parameterizable` objects.
 
         Returns:
             Iterable[Parameterizable]: Child objects that contribute parameters to this instance.
@@ -56,6 +56,84 @@ class Parameterizable(ABC):
         yield from local_params.items()
         for child in self._iter_parameter_children():
             yield from child._iter_parameter_items()  # noqa: SLF001
+
+    def _add_parameter(self, label: str, parameter: Parameter) -> None:
+        """Add a parameter under the current prefix.
+
+        Args:
+            label (str): Parameter label before prefixing.
+            parameter (Parameter): Parameter instance to register.
+        """
+        self._parameters[self._prefix + label] = parameter
+
+    def _add_parameter_from(self, parameter_label: str, other: Parameterizable, new_label: str | None = None) -> None:
+        """Add a parameter from another :class:`Parameterizable`.
+
+        Args:
+            parameter_label (str): Label of the source parameter in ``other``.
+            other (Parameterizable): Object to pull the parameter from.
+            new_label (str | None, optional): Optional label to use in this object.
+        """
+        if new_label:
+            self._parameters[self._prefix + new_label] = other._parameters[parameter_label]
+        else:
+            self._parameters[self._prefix + parameter_label] = other._parameters[parameter_label]
+
+    @staticmethod
+    def _query_parameter_original_name(parameterizable: Parameterizable, label: str) -> str:
+        """Return the underlying parameter label stored on the :class:`Parameter`.
+
+        Args:
+            parameterizable (Parameterizable): Object containing the parameter.
+            label (str): Parameter label used in ``parameterizable``.
+
+        Returns:
+            str: Original parameter label.
+        """
+        return parameterizable._parameters[label].label
+
+    def _update_parameters(self, parameters: dict[str, Parameter]) -> None:
+        """Update local parameters with the provided mapping.
+
+        Args:
+            parameters (dict[str, Parameter]): Parameters to merge into this object.
+        """
+        self._parameters.update(parameters)
+
+    def _link_parameters(self, other: Parameterizable) -> None:
+        """Link all parameters from another object into this one.
+
+        Parameters are shared by reference, so updates in this object
+        affect the same underlying :class:`Parameter` instances.
+
+        Args:
+            other (Parameterizable): Object to copy parameter references from.
+        """
+        for label, p in other._parameters.items():
+            self._add_parameter(label, p)
+
+    def _filtered_parameter_map(
+        self,
+        where: Callable[[Parameter], bool] | None = None,
+    ) -> dict[str, Parameter]:
+        """Return parameters, optionally filtered by a predicate.
+
+        Args:
+            where (Callable[[Parameter], bool] | None, optional): Predicate applied to each parameter.
+
+        Returns:
+            dict[str, Parameter]: Filtered parameter mapping.
+        """
+        if where is None:
+            return dict(self._iter_parameter_items())
+        return {label: param for label, param in self._iter_parameter_items() if where(param)}
+
+    # Public Methods
+
+    @property
+    def nparameters(self) -> int:
+        """Number of tunable parameters defined by the object."""
+        return len(dict(self._iter_parameter_items()))
 
     def set_prefix(
         self,
@@ -85,32 +163,6 @@ class Parameterizable(ABC):
         """Return the currently configured parameter prefix for this object."""
         return self._prefix
 
-    def _add_parameter(self, label: str, parameter: Parameter) -> None:
-        """An interface to unify how parameters are added.
-
-        Args:
-            label (str): The label of the parameter. If the class has a prefix then the prefix is added.
-            parameter (Parameter): The parameter to be added.
-        """
-        self._parameters[self._prefix + label] = parameter
-
-    def _add_parameter_from(self, parameter_label: str, other: Parameterizable, new_label: str | None = None) -> None:
-        if new_label:
-            self._parameters[self._prefix + new_label] = other._parameters[parameter_label]
-        else:
-            self._parameters[self._prefix + parameter_label] = other._parameters[parameter_label]
-
-    @staticmethod
-    def _query_parameter_original_name(parameterizable: Parameterizable, label: str) -> str:
-        return parameterizable._parameters[label].label
-
-    def _update_parameters(self, parameters: dict[str, Parameter]) -> None:
-        self._parameters.update(parameters)
-
-    def _link_parameters(self, other: Parameterizable) -> None:
-        for label, p in other._parameters.items():
-            self._add_parameter(label, p)
-
     def add_parameter_constraint(self, constraint: ComparisonTerm) -> None:
         """Add a constraint on a single or a set of parameters
 
@@ -126,14 +178,6 @@ class Parameterizable(ABC):
             )
 
         self._parameter_constraints.append(constraint)
-
-    def _filtered_parameter_map(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> dict[str, Parameter]:
-        if where is None:
-            return dict(self._iter_parameter_items())
-        return {label: param for label, param in self._iter_parameter_items() if where(param)}
 
     def get_parameter_values(
         self,

--- a/src/qilisdk/core/parameterizable.py
+++ b/src/qilisdk/core/parameterizable.py
@@ -72,10 +72,7 @@ class Parameterizable(ABC):
             The ``where`` predicate is applied to local parameters only. Child parameterizable
             objects always receive the same prefix operation recursively.
         """
-        if where:
-            old_keys: list[str] = [key for key, value in self._parameters.items() if where(value)]
-        else:
-            old_keys: list[str] = list(self._parameters.keys())
+        old_keys: list[str] = list(self._filtered_parameter_map(where=where))
         for name in old_keys:
             if not name.startswith(prefix):
                 _name = name.removeprefix(self._prefix) if self._prefix and name.startswith(self._prefix) else name

--- a/src/qilisdk/core/parameterizable.py
+++ b/src/qilisdk/core/parameterizable.py
@@ -128,6 +128,25 @@ class Parameterizable(ABC):
             return dict(self._iter_parameter_items())
         return {label: param for label, param in self._iter_parameter_items() if where(param)}
 
+    def _pop(self, label: str) -> Parameter:
+        """Remove parameter from the Parameterizable interface.
+
+        Args:
+            label (str): the label of the parameter as specified in the Parameterizable object.
+
+        Raises:
+            ValueError: If the label is not a valid label in the current Parameterizable object or any of its children.
+
+        Returns:
+            Parameter: the removed parameter.
+        """
+        if label in self._parameters:
+            return self._parameters.pop(label)
+        for child in self._iter_parameter_children():
+            if label in child.get_parameter_names():
+                return child._pop(label)  # noqa: SLF001
+        raise ValueError(f"Parameter {label} is not defined in the current object or any of its children.")
+
     # Public Methods
 
     @property
@@ -150,7 +169,9 @@ class Parameterizable(ABC):
             The ``where`` predicate is applied to local parameters only. Child parameterizable
             objects always receive the same prefix operation recursively.
         """
-        old_keys: list[str] = list(self._filtered_parameter_map(where=where))
+        old_keys: list[str] = [
+            label for label, param in self._parameters.items() if where is None or where(param)
+        ]
         for name in old_keys:
             if not name.startswith(prefix):
                 _name = name.removeprefix(self._prefix) if self._prefix and name.startswith(self._prefix) else name

--- a/src/qilisdk/core/parameterizable.py
+++ b/src/qilisdk/core/parameterizable.py
@@ -169,9 +169,7 @@ class Parameterizable(ABC):
             The ``where`` predicate is applied to local parameters only. Child parameterizable
             objects always receive the same prefix operation recursively.
         """
-        old_keys: list[str] = [
-            label for label, param in self._parameters.items() if where is None or where(param)
-        ]
+        old_keys: list[str] = [label for label, param in self._parameters.items() if where is None or where(param)]
         for name in old_keys:
             if not name.startswith(prefix):
                 _name = name.removeprefix(self._prefix) if self._prefix and name.startswith(self._prefix) else name

--- a/src/qilisdk/core/parameterizable.py
+++ b/src/qilisdk/core/parameterizable.py
@@ -37,6 +37,11 @@ class Parameterizable(ABC):
         self._parameter_constraints: list[ComparisonTerm] = []
         self._prefix = ""
 
+    @property
+    def nparameters(self) -> int:
+        """Number of tunable parameters defined by the object."""
+        return len(dict(self._iter_parameter_items()))
+
     def _iter_parameter_children(self) -> Iterable[Parameterizable]:  # noqa: PLR6301
         """Yield parameterizable children to compose this object's parameter interface.
 
@@ -83,6 +88,48 @@ class Parameterizable(ABC):
         """Return the currently configured parameter prefix for this object."""
         return self._prefix
 
+    def _add_parameter(self, label: str, parameter: Parameter) -> None:
+        """An interface to unify how parameters are added.
+
+        Args:
+            label (str): The label of the parameter. If the class has a prefix then the prefix is added.
+            parameter (Parameter): The parameter to be added.
+        """
+        self._parameters[self._prefix + label] = parameter
+
+    def _add_parameter_from(self, parameter_label: str, other: Parameterizable, new_label: str | None = None) -> None:
+        if new_label:
+            self._parameters[self._prefix + new_label] = other._parameters[parameter_label]
+        else:
+            self._parameters[self._prefix + parameter_label] = other._parameters[parameter_label]
+
+    @staticmethod
+    def _query_parameter_original_name(parameterizable: Parameterizable, label: str) -> str:
+        return parameterizable._parameters[label].label
+
+    def _update_parameters(self, parameters: dict[str, Parameter]) -> None:
+        self._parameters.update(parameters)
+
+    def _link_parameters(self, other: Parameterizable) -> None:
+        for label, p in other._parameters.items():
+            self._add_parameter(label, p)
+
+    def add_parameter_constraint(self, constraint: ComparisonTerm) -> None:
+        """Add a constraint on a single or a set of parameters
+
+        Args:
+            constraint (ComparisonTerm): The comparison term to specify the constraint. Only Parameter objects are allowed in the constraint.
+
+        Raises:
+            ValueError: If Generic Variables are present in the constraint.
+        """
+        if not (constraint.lhs.is_parameterized_term() and constraint.rhs.is_parameterized_term()):
+            raise ValueError(
+                "The constraint should only contain parameters and having generic variables is not allowed."
+            )
+
+        self._parameter_constraints.append(constraint)
+
     def _filtered_parameter_map(
         self,
         where: Callable[[Parameter], bool] | None = None,
@@ -90,11 +137,6 @@ class Parameterizable(ABC):
         if where is None:
             return dict(self._iter_parameter_items())
         return {label: param for label, param in self._iter_parameter_items() if where(param)}
-
-    @property
-    def nparameters(self) -> int:
-        """Number of tunable parameters defined by the object."""
-        return len(dict(self._iter_parameter_items()))
 
     def get_parameter_values(
         self,

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable
 
 import numpy as np
 from typing_extensions import Self
@@ -30,8 +30,6 @@ from .exceptions import QubitOutOfRangeError
 from .gates import BasicGate, Gate
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from qilisdk.core.types import RealNumber
 
 
@@ -75,7 +73,7 @@ class Circuit(Parameterizable):
         self._nqubits: int = nqubits
         self._gates: list[Gate] = []
         self._init_state: np.ndarray = np.zeros(nqubits)
-        self._parameters: dict[str, Parameter] = {}
+        self._parameters_link: dict[str, tuple[str, Gate]] = {}
 
     @property
     def nqubits(self) -> int:
@@ -107,68 +105,6 @@ class Circuit(Parameterizable):
         """
         return self._gates
 
-    def get_parameter_values(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> list[float]:
-        """
-        Retrieve parameter values from gates in insertion order.
-
-        Args:
-            where (Callable[[Parameter], bool] | None): Optional predicate used to filter parameters.
-
-        Returns:
-            list[float]: Parameter values matching the optional filter.
-        """
-        return super().get_parameter_values(where=where)
-
-    def get_parameter_names(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> list[str]:
-        """
-        Retrieve parameter labels from gates in insertion order.
-
-        Args:
-            where (Callable[[Parameter], bool] | None): Optional predicate used to filter parameters.
-
-        Returns:
-            list[str]: Parameter labels matching the optional filter.
-        """
-        return super().get_parameter_names(where=where)
-
-    def get_parameters(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> dict[str, float]:
-        """
-        Retrieve parameter labels and values from the circuit.
-
-        Args:
-            where (Callable[[Parameter], bool] | None): Optional predicate used to filter parameters.
-
-        Returns:
-            dict[str, float]: Mapping of parameter labels to their current values.
-        """
-        return super().get_parameters(where=where)
-
-    def set_parameter_values(
-        self,
-        values: list[float],
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> None:
-        """
-        Set new parameter values for all parameterized gates in the circuit.
-
-        Args:
-            values (list[float]): A list containing new parameter values to assign to the parameterized gates.
-            where (Callable[[Parameter], bool] | None): Optional predicate selecting parameters to update.
-
-        Raises:
-            ParametersNotEqualError: If ``values`` length does not match the selected parameter count.
-        """
-        super().set_parameter_values(values=values, where=where)
-
     def set_parameters(self, parameters: dict[str, RealNumber]) -> None:
         """Set the parameter values by their label. No need to provide the full list of parameters.
 
@@ -178,16 +114,14 @@ class Circuit(Parameterizable):
         Raises:
             ValueError: if the label provided doesn't correspond to a parameter defined in this circuit.
         """
+        if not self.check_constraints(parameters):
+            raise ValueError(
+                f"New assignation of the parameters breaks the parameter constraints: \n{self.get_constraints()}"
+            )
         for label, param in parameters.items():
             if label not in self._parameters:
                 raise ValueError(f"Parameter {label} is not defined in this circuit.")
-            self._parameters[label].set_value(param)
-
-    def get_parameter_bounds(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> dict[str, tuple[float, float]]:
-        return super().get_parameter_bounds(where=where)
+            self._parameters_link[label][1].set_parameters({self._parameters_link[label][0]: param})
 
     def set_parameter_bounds(self, ranges: dict[str, tuple[float, float]]) -> None:
         for label, bound in ranges.items():
@@ -195,7 +129,35 @@ class Circuit(Parameterizable):
                 raise ValueError(
                     f"The provided parameter label {label} is not defined in the list of parameters in this object."
                 )
-            self._parameters[label].set_bounds(bound[0], bound[1])
+            self._parameters_link[label][1].set_parameter_bounds({self._parameters_link[label][0]: bound})
+
+    def set_prefix(
+        self,
+        prefix: str,
+        where: Callable[[Parameter], bool] | None = None,
+    ) -> None:
+        """Set a prefix on parameter labels.
+
+        Args:
+            prefix (str): Prefix to prepend to selected parameter labels.
+            where (Callable[[Parameter], bool] | None): Optional predicate selecting local parameters.
+
+        Notes:
+            The ``where`` predicate is applied to local parameters only. Child parameterizable
+            objects always receive the same prefix operation recursively.
+        """
+        if where:
+            old_keys: list[str] = [key for key, value in self._parameters.items() if where(value)]
+        else:
+            old_keys: list[str] = list(self._parameters.keys())
+        for name in old_keys:
+            if not name.startswith(prefix):
+                _name = name.removeprefix(self._prefix) if self._prefix and name.startswith(self._prefix) else name
+                self._parameters[prefix + _name] = self._parameters.pop(name)
+                self._parameters_link[prefix + _name] = self._parameters_link.pop(name)
+        for child in self._iter_parameter_children():
+            child.set_prefix(prefix)
+        self._prefix = prefix
 
     def _parse_params(self, gate: Gate) -> None:
         """Parse The parameters in the gate
@@ -205,12 +167,14 @@ class Circuit(Parameterizable):
         """
         if gate.is_parameterized:
             param_base_label = self.get_prefix() + f"{gate.name}({','.join(map(str, gate.qubits))})"
-            for label, parameter in gate.parameters.items():
-                if label == parameter.label and label in gate.PARAMETER_NAMES:
+            for label in gate.get_parameter_names():
+                _parameter_name = self._query_parameter_original_name(gate, label)
+                if label == _parameter_name and label in gate.PARAMETER_NAMES:
                     parameter_label = param_base_label + f"_{label}_{len(self._parameters)}"
                 else:
-                    parameter_label = parameter.label
-                self._parameters[parameter_label] = gate.parameters[label]
+                    parameter_label = _parameter_name
+                self._add_parameter_from(label, gate, new_label=parameter_label)
+                self._parameters_link[parameter_label] = (label, gate)
 
     def _add(self, gate: Gate) -> None:
         """

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -146,18 +146,12 @@ class Circuit(Parameterizable):
             The ``where`` predicate is applied to local parameters only. Child parameterizable
             objects always receive the same prefix operation recursively.
         """
-        if where:
-            old_keys: list[str] = [key for key, value in self._parameters.items() if where(value)]
-        else:
-            old_keys: list[str] = list(self._parameters.keys())
+        old_keys = list(self._filtered_parameter_map(where=where))
         for name in old_keys:
             if not name.startswith(prefix):
                 _name = name.removeprefix(self._prefix) if self._prefix and name.startswith(self._prefix) else name
-                self._parameters[prefix + _name] = self._parameters.pop(name)
                 self._parameters_link[prefix + _name] = self._parameters_link.pop(name)
-        for child in self._iter_parameter_children():
-            child.set_prefix(prefix)
-        self._prefix = prefix
+        super().set_prefix(prefix=prefix, where=where)
 
     def _parse_params(self, gate: Gate) -> None:
         """Parse The parameters in the gate

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -49,6 +49,9 @@ class Gate(Parameterizable, ABC):
 
     PARAMETER_NAMES: ClassVar[list[str]] = []
 
+    def __init__(self) -> None:
+        super().__init__()
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -132,15 +135,6 @@ class Gate(Parameterizable, ABC):
         """
         return self.nparameters != 0
 
-    @property
-    def parameters(self) -> dict[str, Parameter]:
-        """Returns the raw parameter objects stored in the gate.
-
-        Returns:
-            dict[str, Parameter]: Mapping from parameter label to parameter object.
-        """
-        return {}
-
     def get_parameters(
         self,
         where: Callable[[Parameter], bool] | None = None,
@@ -202,6 +196,7 @@ class Gate(Parameterizable, ABC):
 
         if any(name not in self.get_parameters() for name in parameters):
             raise InvalidParameterNameError
+        super().set_parameters(parameters=parameters)
 
     def set_parameter_values(
         self,
@@ -224,6 +219,7 @@ class Gate(Parameterizable, ABC):
 
         if len(values) != len(self.get_parameters(where=where)):
             raise ParametersNotEqualError
+        super().set_parameter_values(values=values, where=where)
 
     def get_parameter_bounds(
         self,
@@ -235,6 +231,7 @@ class Gate(Parameterizable, ABC):
     def set_parameter_bounds(self, ranges: dict[str, tuple[float, float]]) -> None:
         if not self.is_parameterized:
             raise GateNotParameterizedError
+        super().set_parameter_bounds(ranges=ranges)
 
     def __repr__(self) -> str:
         qubits_str = f"({self.qubits[0]})" if self.nqubits == 1 else str(self.qubits)
@@ -266,7 +263,7 @@ class BasicGate(Gate):
             InvalidParameterNameError: if any parameter mentioned in parameter_transforms is not in parameters.
         """
         # Check for duplicate integers in target_qubits.
-        super(BasicGate, self).__init__()
+        super().__init__()
         if len(target_qubits) != len(set(target_qubits)):
             raise ValueError("Duplicate target qubits found.")
 
@@ -296,20 +293,8 @@ class BasicGate(Gate):
     def target_qubits(self) -> tuple[int, ...]:
         return self._target_qubits
 
-    @property
-    def parameters(self) -> dict[str, Parameter]:
-        return self._parameters
-
-    def get_parameters(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> dict[str, float]:
-        return super().get_parameters(where=where)
-
     def set_parameters(self, parameters: dict[str, float]) -> None:
         super().set_parameters(parameters=parameters)
-        for k, v in parameters.items():
-            self._parameters[k].set_value(v)
         self._matrix = self._generate_matrix()
 
     def set_parameter_values(
@@ -318,23 +303,11 @@ class BasicGate(Gate):
         where: Callable[[Parameter], bool] | None = None,
     ) -> None:
         super().set_parameter_values(values=values, where=where)
-        for key, value in zip(self.get_parameters(where=where), values):
-            self._parameters[key].set_value(value)
-
         self._matrix = self._generate_matrix()
-
-    def get_parameter_bounds(
-        self,
-        where: Callable[[Parameter], bool] | None = None,
-    ) -> dict[str, tuple[float, float]]:
-        return super().get_parameter_bounds(where=where)
 
     def set_parameter_bounds(self, ranges: dict[str, tuple[float, float]]) -> None:
         super().set_parameter_bounds(ranges=ranges)
-        for label, bound in ranges.items():
-            if label not in self._parameters:
-                raise InvalidParameterNameError
-            self._parameters[label].set_bounds(bound[0], bound[1])
+        self._matrix = self._generate_matrix()
 
     def controlled(self: Self, *control_qubits: int) -> Controlled[Self]:
         """
@@ -384,8 +357,10 @@ class BasicGate(Gate):
 @yaml.register_class
 class Modified(Gate, Generic[TBasicGate]):
     def __init__(self, basic_gate: TBasicGate) -> None:
+        super().__init__()
         self._basic_gate: TBasicGate = basic_gate
         self._matrix: np.ndarray
+        self._link_parameters(self._basic_gate)
 
     @property
     def basic_gate(self) -> TBasicGate:
@@ -406,10 +381,6 @@ class Modified(Gate, Generic[TBasicGate]):
     @property
     def is_parameterized(self) -> bool:
         return self._basic_gate.is_parameterized
-
-    @property
-    def parameters(self) -> dict[str, Parameter]:
-        return self._basic_gate.parameters
 
     def get_parameters(
         self,

--- a/tests/unit/analog/test_hamiltionian.py
+++ b/tests/unit/analog/test_hamiltionian.py
@@ -87,6 +87,15 @@ def test_parameters():
     assert H.get_parameters() == {"z": 1.5}
 
 
+def test_hamiltonian_does_not_expose_public_parameters_attribute():
+    hamiltonian = Parameter("theta", 0.4) * Z(0)
+
+    with pytest.raises(AttributeError):
+        _ = hamiltonian.parameters
+
+    assert hamiltonian.get_parameters() == {"theta": 0.4}
+
+
 def test_get_pauli_returns_correct_instance():
     assert isinstance(_get_pauli("X", 0), PauliX)
     assert isinstance(_get_pauli("Y", 1), PauliY)

--- a/tests/unit/analog/test_schedule.py
+++ b/tests/unit/analog/test_schedule.py
@@ -53,25 +53,25 @@ def test_schedule_parameters():
 
     schedule = Schedule(total_time=10, hamiltonians={"H0": H0, "H1": H1}, coefficients={})
 
-    assert p[0] in list(schedule._parameters.values())
-    assert p[1] in list(schedule._parameters.values())
-    assert p[2] not in list(schedule._parameters.values())
+    assert p[0] in list(schedule._filtered_parameter_map().values())
+    assert p[1] in list(schedule._filtered_parameter_map().values())
+    assert p[2] not in list(schedule._filtered_parameter_map().values())
     assert schedule.nparameters == 2
 
     schedule = Schedule(
         hamiltonians={"H0": H0, "H1": H1}, coefficients={"H0": {(0, 10): 1 + p[2]}, "H1": {(0, 10): p[3]}}
     )
 
-    assert p[2] in list(schedule._parameters.values())
-    assert p[3] in list(schedule._parameters.values())
+    assert p[2] in list(schedule._filtered_parameter_map().values())
+    assert p[3] in list(schedule._filtered_parameter_map().values())
     assert schedule.nparameters == 4
 
     schedule = Schedule(hamiltonians={"H0": H0, "H1": H1})
     schedule.update_hamiltonian("H0", new_coefficients={0: 1 + p[2]})
     schedule.update_hamiltonian("H1", new_coefficients={0: p[3]})
 
-    assert p[2] in list(schedule._parameters.values())
-    assert p[3] in list(schedule._parameters.values())
+    assert p[2] in list(schedule._filtered_parameter_map().values())
+    assert p[3] in list(schedule._filtered_parameter_map().values())
     assert schedule.nparameters == 4
 
     assert all(_isclose(schedule.get_parameter_values()[i], 0.0) for i in range(schedule.nparameters))
@@ -97,7 +97,7 @@ def test_schedule_parameters():
 
     with pytest.raises(
         ValueError,
-        match=r"Parameter test is not defined in this Schedule.",
+        match=r"Parameter test is not defined for this object.",
     ):
         schedule.set_parameters({"test": 0})
 
@@ -541,11 +541,12 @@ def test_schedule_extract_parameters():
     term1 = 2 * param1 + 3
 
     sched._extract_parameters(term1)
-    assert param1 in sched._parameters.values()
-    sched._parameters.clear()
+    assert param1 in sched._filtered_parameter_map().values()
+    assert sched.get_parameter_names() == ["param1"]
 
+    sched = Schedule(dt=1)
     sched._extract_parameters(param1)
-    assert param1 in sched._parameters.values()
+    assert param1 in sched._filtered_parameter_map().values()
 
     var = Variable("var", Domain.REAL)
     bad_term = 2 * param2 + var

--- a/tests/unit/core/test_interpolator.py
+++ b/tests/unit/core/test_interpolator.py
@@ -211,9 +211,18 @@ def test_interpolator_parameters():
         points,
         Interpolation.LINEAR,
     )
-    parameters = interp.parameters
+    parameters = interp._parameters
     expected_parameters = {"a": Parameter("a", 1.0), "b": Parameter("b", 2.0)}
     assert parameters == expected_parameters
+
+
+def test_interpolator_does_not_expose_public_parameters_attribute():
+    interp = Interpolator({0: Parameter("a", 1.0), 1: 2.0}, Interpolation.LINEAR)
+
+    with pytest.raises(AttributeError):
+        _ = interp.parameters
+
+    assert interp.get_parameters() == {"a": 1.0}
 
 
 def test_interpolator_set_bad_max_time():
@@ -259,7 +268,7 @@ def test_interpolar_set_parameter_bounds():
         Interpolation.LINEAR,
     )
     interp.set_parameter_bounds({"a": (0.5, 1.5)})
-    param_a = interp.parameters["a"]
+    param_a = interp._parameters["a"]
     assert np.isclose(param_a.lower_bound, 0.5)
     assert np.isclose(param_a.upper_bound, 1.5)
 

--- a/tests/unit/core/test_parameterizable.py
+++ b/tests/unit/core/test_parameterizable.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 from qilisdk.core.parameterizable import Parameterizable
-from qilisdk.core.variables import LEQ, Parameter
+from qilisdk.core.variables import LEQ, Domain, Parameter, Variable
 from qilisdk.settings import get_settings
 
 
@@ -53,6 +53,23 @@ class CompositeParameterizable(Parameterizable):
     def _iter_parameter_children(self) -> Iterator[Parameterizable]:
         yield self._left
         yield self._right
+
+
+class EmptyParameterizable(Parameterizable):
+    pass
+
+
+class ParentWithLocalAndChild(Parameterizable):
+    def __init__(self) -> None:
+        super().__init__()
+        self._parameters = {
+            "local_trainable": Parameter("local_trainable", 0.5, trainable=True),
+            "local_fixed": Parameter("local_fixed", 0.25, trainable=False),
+        }
+        self.child = LeafParameterizable("child_theta", 0.1, trainable=False)
+
+    def _iter_parameter_children(self) -> Iterator[Parameterizable]:
+        yield self.child
 
 
 @pytest.fixture
@@ -185,3 +202,77 @@ def test_parameter_filter_predicate_supports_custom_queries():
     parent.set_parameter_values([0.7], where=lambda param: param.label.startswith("output_encoding_"))
     assert _isclose(parent.get_parameters()["input_encoding_theta"], 0.1)
     assert _isclose(parent.get_parameters()["output_encoding_theta"], 0.7)
+
+
+def test_private_helpers_add_and_query_parameter_names():
+    source = DummyParameterizable()
+    target = EmptyParameterizable()
+    target.set_prefix("pref_")
+
+    target._add_parameter("gamma", Parameter("gamma", 3.0))
+    target._add_parameter_from("alpha", source)
+    target._add_parameter_from("beta", source, new_label="beta_alias")
+
+    assert "pref_gamma" in target.get_parameter_names()
+    assert target._parameters["pref_alpha"] is source._parameters["alpha"]
+    assert target._parameters["pref_beta_alias"] is source._parameters["beta"]
+    assert target._query_parameter_original_name(target, "pref_beta_alias") == "beta"
+
+
+def test_private_helpers_update_and_link_share_parameter_references():
+    source = DummyParameterizable()
+    linked = LeafParameterizable("theta", 0.4)
+    target = EmptyParameterizable()
+
+    target._update_parameters({"alpha_copy": source._parameters["alpha"]})
+    target._link_parameters(linked)
+
+    assert target.get_parameter_names() == ["alpha_copy", "theta"]
+    assert target._parameters["theta"] is linked._parameters["theta"]
+
+    target.set_parameters({"theta": 0.9})
+    assert _isclose(linked.get_parameters()["theta"], 0.9)
+
+
+def test_set_prefix_where_is_local_only_but_children_are_recursive():
+    parent = ParentWithLocalAndChild()
+
+    parent.set_prefix("p_", where=lambda param: param.is_trainable)
+    assert parent.get_parameter_names() == ["local_fixed", "p_local_trainable", "p_child_theta"]
+    assert parent.get_prefix() == "p_"
+    assert parent.child.get_prefix() == "p_"
+
+    parent.set_prefix("q_", where=lambda _: True)
+    assert set(parent.get_parameter_names()) == {"q_local_trainable", "q_local_fixed", "q_child_theta"}
+    assert parent.child.get_parameter_names() == ["q_child_theta"]
+    assert parent.get_prefix() == "q_"
+    assert parent.child.get_prefix() == "q_"
+
+
+def test_add_parameter_constraint_rejects_non_parameter_variables():
+    parameterizable = DummyParameterizable()
+    generic_variable = Variable("x", domain=Domain.REAL, bounds=(0.0, 1.0))
+
+    with pytest.raises(
+        ValueError,
+        match=r"The constraint should only contain parameters and having generic variables is not allowed.",
+    ):
+        parameterizable.add_parameter_constraint(LEQ(parameterizable._parameters["alpha"], generic_variable))
+
+
+def test_pop_removes_local_or_child_parameters_and_errors_on_unknown_label():
+    parent = ParentWithLocalAndChild()
+
+    popped_local = parent._pop("local_fixed")
+    assert popped_local.label == "local_fixed"
+    assert "local_fixed" not in parent.get_parameter_names()
+
+    popped_child = parent._pop("child_theta")
+    assert popped_child.label == "child_theta"
+    assert "child_theta" not in parent.child.get_parameter_names()
+
+    with pytest.raises(
+        ValueError,
+        match=r"Parameter unknown is not defined in the current object or any of its children.",
+    ):
+        parent._pop("unknown")

--- a/tests/unit/digital/test_circuit.py
+++ b/tests/unit/digital/test_circuit.py
@@ -20,12 +20,10 @@ import pytest
 
 import qilisdk.utils.visualization.circuit_renderers
 from qilisdk.core import Parameter
+from qilisdk.core.variables import LEQ
 from qilisdk.digital import CNOT, RX, RY, RZ, U1, U2, U3, Circuit, M, S, X
 from qilisdk.digital.circuit import _apply_gate_left
-from qilisdk.digital.exceptions import (
-    GateHasNoMatrixError,
-    QubitOutOfRangeError,
-)
+from qilisdk.digital.exceptions import GateHasNoMatrixError, QubitOutOfRangeError
 from qilisdk.digital.gates import BasicGate, Gate
 
 
@@ -59,7 +57,7 @@ def test_apply_gate_left_noop_for_zero_qubit_gate():
 def test_circuit_set_parameters_bad():
     c = Circuit(nqubits=1)
     assert c.nparameters == 0
-    with pytest.raises(ValueError, match="not defined in this circuit"):
+    with pytest.raises(ValueError, match="not defined for this object"):
         c.set_parameters({"param1": 0.5})
     with pytest.raises(ValueError, match="not defined in the list of"):
         c.set_parameter_bounds({"param1": (0.0, np.pi)})
@@ -81,6 +79,35 @@ def test_circuit_set_parameters_values():
     assert c.nparameters == 1
     c.set_parameter_values([0.5])
     assert c.get_parameter_values() == [0.5]
+
+
+def test_circuit_set_prefix_keeps_parameter_links():
+    c = Circuit(nqubits=1)
+    c.add(RX(qubit=0, theta=np.pi / 4))
+
+    c.set_prefix("p_")
+    assert c.get_parameter_names() == ["p_RX(0)_theta_0"]
+
+    c.set_parameters({"p_RX(0)_theta_0": np.pi / 3})
+    assert np.isclose(c.get_parameter_values()[0], np.pi / 3)
+
+
+def test_circuit_constraints_are_enforced_on_set_parameters():
+    c = Circuit(nqubits=1)
+    left = Parameter("left", 0.1)
+    right = Parameter("right", 0.2)
+    c.add(RX(qubit=0, theta=left))
+    c.add(RY(qubit=0, theta=right))
+    c.add_parameter_constraint(LEQ(left, right))
+
+    with pytest.raises(
+        ValueError,
+        match=r"New assignation of the parameters breaks the parameter constraints:",
+    ):
+        c.set_parameters({"left": 0.9, "right": 0.1})
+
+    c.set_parameters({"left": 0.2, "right": 0.9})
+    assert c.get_parameters() == {"left": 0.2, "right": 0.9}
 
 
 def test_parameter_bounds():
@@ -244,7 +271,7 @@ def test_user_provides_custom_parameter():
     assert all(
         label in gate.PARAMETER_NAMES and parameter.label == angle.label and parameter.value == angle.value
         for gate in c.gates
-        for label, parameter in gate.parameters.items()
+        for label, parameter in gate._parameters.items()
     )
 
 
@@ -322,7 +349,7 @@ def test_add_operator_supports_gate_and_circuit():
     assert all(
         label in gate.PARAMETER_NAMES and parameter.label == angle.label and parameter.value == angle.value
         for gate in c.gates
-        for label, parameter in gate.parameters.items()
+        for label, parameter in gate._parameters.items()
     )
 
 

--- a/tests/unit/digital/test_gates.py
+++ b/tests/unit/digital/test_gates.py
@@ -68,7 +68,7 @@ def test_non_parameterized_gate(gate_class: type, expected_name: str, expected_m
     assert gate.is_parameterized is False
     assert gate.nparameters == 0
     assert gate.get_parameter_names() == []
-    assert gate.parameters == {}
+    assert gate._parameters == {}
 
     # Check target qubits
     assert gate.target_qubits == (qubit,)
@@ -102,6 +102,15 @@ def test_measurement_gate():
     # The base Gate sets `_matrix` to an empty array by default (since M has no matrix).
     with pytest.raises(GateHasNoMatrixError):
         gate.matrix
+
+
+def test_gate_does_not_expose_public_parameters_attribute():
+    gate = RX(0, theta=np.pi / 4)
+
+    with pytest.raises(AttributeError):
+        _ = gate.parameters
+
+    assert gate.get_parameters() == {"theta": np.pi / 4}
 
 
 # ------------------------------------------------------------------------------
@@ -606,7 +615,7 @@ def test_gate_parameter_methods(gate_class, ctor_kwargs, valid_dict, invalid_dic
     gate.set_parameters(valid_dict)
     # Verify the gate's 'parameters' match the new values
     for param_name, param_value in valid_dict.items():
-        assert gate.parameters[param_name].value == param_value, (
+        assert gate._parameters[param_name].value == param_value, (
             f"Parameter '{param_name}' not updated to {param_value}"
         )
 
@@ -618,7 +627,7 @@ def test_gate_parameter_methods(gate_class, ctor_kwargs, valid_dict, invalid_dic
     gate.set_parameter_values(valid_list)
     param_names = gate.get_parameter_names()
     for i, val in enumerate(valid_list):
-        assert gate.parameters[param_names[i]].value == val, f"Parameter '{param_names[i]}' not updated to {val}"
+        assert gate._parameters[param_names[i]].value == val, f"Parameter '{param_names[i]}' not updated to {val}"
 
     # 4) set_parameter_values() with an invalid list (length mismatch)
     with pytest.raises(ParametersNotEqualError):
@@ -839,7 +848,7 @@ def test_base_gate_class():
     assert gate.nqubits == 0
     assert gate.target_qubits == ()
     assert gate.control_qubits == ()
-    assert gate.parameters == {}
+    assert gate._parameters == {}
     assert gate.get_parameter_bounds() == {}
     assert gate.is_parameterized is False
     assert gate.get_parameter_names() == []
@@ -933,7 +942,10 @@ def test_parameterized_custom_gate():
     gate.set_parameter_bounds({"param": (0.0, 2 * np.pi)})
     assert gate.get_parameter_bounds() == {"param": (0.0, 2 * np.pi)}
 
-    with pytest.raises(InvalidParameterNameError):
+    with pytest.raises(
+        ValueError,
+        match=r"The provided parameter label unknown_param is not defined in the list of parameters in this object.",
+    ):
         gate.set_parameter_bounds({"unknown_param": (0.0, 1.0)})
 
 
@@ -950,7 +962,7 @@ def test_modified_parameterized_gate():
     assert gate_mod.control_qubits == (control_qubit,)
     assert gate_mod.is_parameterized is True
     assert gate_mod.nparameters == 1
-    assert gate_mod.parameters == {"theta": np.pi / 2}
+    assert gate_mod.basic_gate._parameters == {"theta": np.pi / 2}
     assert gate_mod.get_parameter_names() == ["theta"]
     assert gate_mod.get_parameters() == {"theta": np.pi / 2}
     assert gate_mod.get_parameter_values() == [np.pi / 2]


### PR DESCRIPTION
Refactored parameter handling across digital and analog objects to use the shared `Parameterizable` interface, including explicit `get_*`/`set_*` parameter access patterns and synchronized tests/docs updates for the new structure.
