### PR TITLE
HOTFIX - Fix Issues with the Multiversion Build

### DIFF
--- a/changes/182.bugfix.md
+++ b/changes/182.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug when building the docs. Versions of sphinx >= 9 cause issues with the newest (0.2.4) version of sphinx-multiversion, so now we limit the version of sphinx to be less than 9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,12 +99,12 @@ docs = [
     "astroid<3.2",
     "nbsphinx>=0.9.7",
     "pypandoc>=1.15",
-    "sphinx>=8.2.3",
+    "sphinx==8.2.3",
     "sphinx-autoapi>=3.4.0",
     "sphinx-automodapi>=0.20.0",
     "sphinx-design>=0.7.0",
     "sphinx-mdinclude>=0.6.2",
-    "sphinx-multiversion",
+    "sphinx-multiversion>=0.2.4",
     "sphinxawesome-theme>=5.3.2",
 ]
 


### PR DESCRIPTION
Fixed a bug when building the docs. Versions of sphinx >= 9 cause issues with the newest (0.2.4) version of sphinx-multiversion, so now we limit the version of sphinx to be less than 9.