### PR TITLE
[HOTFIX] Fix the Previous Hotfix Regarding Docs Building

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ def _safe_collect_pages(app):  # noqa: ANN001, ANN201
     env = app.builder.env
     if not hasattr(env, "_viewcode_modules"):
         return
-    if not _viewcode.is_supported_builder(app.builder, app.config.viewcode_enable_epub):
+    if not _viewcode.is_supported_builder(app.builder):
         return
 
     highlighter = app.builder.highlighter


### PR DESCRIPTION
This hotfix fixes a previous error introduced by the last hotfix. Now that we're on the older version of sphinx we don't need the `app.config.viewcode_enable_epub` arg anymore.

I just ran this locally and it builds both the normal docs and the multiversion fine.