### PR TITLE
[SDK-255] Allow extra variables in .env file

### DIFF
--- a/changes/201.bugfix.md
+++ b/changes/201.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `.env` file loading in `QiliSDKSettings` so that only variables prefixed with `QILISDK_` are read, preventing unrelated environment variables in the user's `.env` from causing validation errors.

--- a/src/qilisdk/settings.py
+++ b/src/qilisdk/settings.py
@@ -52,7 +52,9 @@ class QiliSDKSettings(BaseSettings):
     prefixed with `QILISDK_`, or from a local `.env` file if present.
     """
 
-    model_config = SettingsConfigDict(env_prefix="qilisdk_", env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_prefix="qilisdk_", env_file=".env", env_file_encoding="utf-8", dotenv_filtering="match_prefix"
+    )
 
     complex_precision: Precision = Field(default=Precision.COMPLEX_128, description="[env: QILISDK_COMPLEX_PRECISION]")
     logging_config_path: Path = Field(


### PR DESCRIPTION
Fixed `.env` file loading in `QiliSDKSettings` so that only variables prefixed with `QILISDK_` are read, preventing unrelated environment variables in the user's `.env` from causing validation errors.
