### PR TITLE
Hotfix - Fix Windows Build Workflow

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-wheels:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install qilisdk
-        run: uv -v sync --group dev --extra all-cu13 -Ccmake.build-type=Debug --reinstall
+        run: uv -v sync
 
       - name: Smoke test import
         run: uv run python -c "import qilisdk; print('qilisdk imported successfully')"

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install qilisdk
-        run: uv -v sync
+        run: uv sync --reinstall
 
       - name: Smoke test import
         run: uv run python -c "import qilisdk; print('qilisdk imported successfully')"

--- a/changes/210.misc.md
+++ b/changes/210.misc.md
@@ -1,0 +1,1 @@
+The "compile with debug" option was causing syntax issues in the Windows build process, it has been removed. The platform workflow has been simplified (no longer installs all optional dependencies etc.), it's now just does uv sync as a user would do.


### PR DESCRIPTION
The "compile with debug" option was causing syntax issues in the Windows build process, it has been removed. The platform workflow has been simplified (no longer installs all optional dependencies etc.), it's now just does `uv sync` as a user would do.

I also added a dispatch trigger, so we can manually run this workflow from a specific branch if we want, something that has been quite useful for the publish docs workflow.