### PR TITLE
[SDK-285] Added Missing Translations, Fixed OpenQASM3 Bug

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -36,4 +36,4 @@ jobs:
         run: uv sync --reinstall
 
       - name: Smoke test import
-        run: uv run python -c "import qilisdk; print('qilisdk imported successfully')"
+        run: uv run python -c "from qilisdk.backends import QiliSim; print('QiliSim imported successfully')"

--- a/.gitignore
+++ b/.gitignore
@@ -19,15 +19,6 @@ scripts/*.log
 lib*.a
 qili*.lib
 
-# these are generated if you check the docs code
-circuit_custom_font.png
-my_circuit.svg
-test.png
-bell.bc
-bell.ll
-*.qasm
-*.lp
-
 # Profiling stuff
 *.prof
 callgrind*

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ qili*.lib
 circuit_custom_font.png
 my_circuit.svg
 test.png
+bell.bc
+bell.ll
+*.qasm
+*.lp
 
 # Profiling stuff
 *.prof

--- a/changes/207.feature.md
+++ b/changes/207.feature.md
@@ -45,6 +45,7 @@ round_tripped = from_lp(lp_text)
 
 Reading an existing LP file is a one-liner:
 
+<!-- SKIP -->
 ```python
 from qilisdk.utils.lp_parser import from_lp_file
 

--- a/changes/209.feature.md
+++ b/changes/209.feature.md
@@ -26,6 +26,7 @@ Supported gates map to the standard `__quantum__qis__*__body` intrinsics: `X`, `
 
 OpenQASM 2 and 3 support has been moved to an optional dependency group and now lives under the `qilisdk.utils.openqasm` package. Install with `pip install qilisdk[openqasm]`; the public entry points (`to_qasm2`, `from_qasm2`, `to_qasm2_file`, `from_qasm2_file`, `to_qasm3`, `from_qasm3`, `to_qasm3_file`, `from_qasm3_file`) are unchanged but now imported from `qilisdk.utils.openqasm` rather than `qilisdk.utils.openqasm2` / `qilisdk.utils.openqasm3`:
 
+<!-- SKIP -->
 ```python
 # Before
 from qilisdk.utils.openqasm2 import to_qasm2, from_qasm2

--- a/changes/212.misc.md
+++ b/changes/212.misc.md
@@ -1,5 +1,7 @@
-Added missing translations for the QASM and QIR docs.
+Added documentation for the OpenQASM 2.0 and 3.0 parsers.
+
+Added missing translations for the QIR docs.
 
 Improved the specificity of the platform build checker.
 
-Fixed a bug when doing an OpenQASM3 round-trip with CNOT and measurement gates.
+Fixed a bug when doing an OpenQASM3 round-trip with CNOT and measurement gates. 

--- a/changes/212.misc.md
+++ b/changes/212.misc.md
@@ -1,0 +1,5 @@
+Added missing translations for the QASM and QIR docs.
+
+Improved the specificity of the platform build checker.
+
+Fixed a bug when doing an OpenQASM3 round-trip with CNOT and measurement gates.

--- a/docs/locale/ca/LC_MESSAGES/getting_started/installation.po
+++ b/docs/locale/ca/LC_MESSAGES/getting_started/installation.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 14:50+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -28,9 +28,9 @@ msgid ""
 "QiliSDK and its optional extras are distributed via PyPI. Use pip to "
 "install the core package, plus any extra modules you need."
 msgstr ""
-"QiliSDK i els seus extras opcionals es distribueixen a través de PyPI."
-" Useu pip per instal·lar el paquet principal, més qualsevol mòdul"
-" addicional que necessiteu."
+"QiliSDK i els seus extras opcionals es distribueixen a través de PyPI. "
+"Useu pip per instal·lar el paquet principal, més qualsevol mòdul "
+"addicional que necessiteu."
 
 #: ../../getting_started/installation.rst:6
 msgid "**Base package**"
@@ -55,9 +55,9 @@ msgid ""
 "on their official website: https://nvidia.github.io/cuda-"
 "quantum/latest/using/quick_start.html#install-cuda-q"
 msgstr ""
-"El backend CUDA requereix una GPU amb acceleració CUDA disponible al"
-" vostre sistema i els controladors adequats instal·lats. Podeu trobar més"
-" informació al seu lloc web oficial: https://nvidia.github.io/cuda-"
+"El backend CUDA requereix una GPU amb acceleració CUDA disponible al "
+"vostre sistema i els controladors adequats instal·lats. Podeu trobar més "
+"informació al seu lloc web oficial: https://nvidia.github.io/cuda-"
 "quantum/latest/using/quick_start.html#install-cuda-q"
 
 #: ../../getting_started/installation.rst:24
@@ -108,69 +108,110 @@ msgid ""
 "aware that this is not recommended for most users, and we make no "
 "promises that the latest code will be stable."
 msgstr ""
-"El mètode anterior instal·larà els binaris precompilats de QiliSDK de la"
-" versió més recent. Si voleu obtenir les característiques més noves"
-" (aquelles en les quals encara estem treballant), podeu compilar la"
-" biblioteca des del codi font, però tingueu en compte que això no es"
-" recomana per a la majoria d'usuaris, i no garantim que el codi més recent"
+"El mètode anterior instal·larà els binaris precompilats de QiliSDK de la "
+"versió més recent. Si voleu obtenir les característiques més noves "
+"(aquelles en les quals encara estem treballant), podeu compilar la "
+"biblioteca des del codi font, però tingueu en compte que això no es "
+"recomana per a la majoria d'usuaris, i no garantim que el codi més recent"
 " sigui estable."
 
 #: ../../getting_started/installation.rst:58
 msgid ""
 "Support for Windows is limited, so we recommend using WSL, which can be "
 "installed as per `this guide <https://learn.microsoft.com/en-"
-"us/windows/wsl/install>`__."
+"us/windows/wsl/install>`__. With this you should then following the Linux"
+" instructions below. If you must use pure Windows, the Windows "
+"instructions below should work, although they disable certain code "
+"features (notably some parallelized loops)."
 msgstr ""
-"El suport per a Windows és limitat, per la qual cosa recomanem usar WSL,"
-" que es pot instal·lar seguint `aquesta guia <https://learn.microsoft.com/en-"
-"us/windows/wsl/install>`__."
+"El suport per a Windows és limitat, per la qual cosa recomanem usar WSL, "
+"que es pot instal·lar seguint `aquesta guia <https://learn.microsoft.com/"
+"en-us/windows/wsl/install>`__. Amb això, hauríeu de seguir les "
+"instruccions de Linux a continuació. Si heu d'usar Windows pur, les "
+"instruccions de Windows a continuació haurien de funcionar, tot i que "
+"deshabiliten certes funcions del codi (especialment alguns bucles "
+"paral·lelitzats)."
 
-#: ../../getting_started/installation.rst:61
+#: ../../getting_started/installation.rst:63
 msgid ""
-"First, make sure you have a Python, pip, git, and build-essentials "
-"installed. For Ubuntu/Debian, you can run:"
+"First, make sure you have Python, pip, git, cmake and a C++ compiler "
+"installed:"
 msgstr ""
-"Primer, assegureu-vos de tenir instal·lats Python, pip, git i"
-" build-essentials. Per a Ubuntu/Debian, podeu executar:"
+"Primer, assegureu-vos de tenir instal·lats Python, pip, git, cmake i un "
+"compilador de C++:"
 
-#: ../../getting_started/installation.rst:68
-msgid "or on MacOS with:"
-msgstr "o a MacOS amb:"
+#: ../../getting_started/installation.rst:67
+#: ../../getting_started/installation.rst:93
+#: ../../getting_started/installation.rst:128
+msgid "Linux"
+msgstr "Linux"
 
-#: ../../getting_started/installation.rst:75
+#: ../../getting_started/installation.rst:74
+#: ../../getting_started/installation.rst:99
+#: ../../getting_started/installation.rst:134
+msgid "Mac OSX"
+msgstr "Mac OSX"
+
+#: ../../getting_started/installation.rst:81
+#: ../../getting_started/installation.rst:105
+#: ../../getting_started/installation.rst:140
+msgid "Windows"
+msgstr "Windows"
+
+#: ../../getting_started/installation.rst:83
+msgid "Install Python via the Microsoft Store."
+msgstr "Instal·leu Python a través de la Microsoft Store."
+
+#: ../../getting_started/installation.rst:85
+msgid "Install Git via https://git-scm.com/install/windows."
+msgstr "Instal·leu Git des de https://git-scm.com/install/windows."
+
+#: ../../getting_started/installation.rst:87
+msgid ""
+"Install C++ build tools by installing the \"C/C++ Extension Pack\" "
+"extension for VSCode."
+msgstr ""
+"Instal·leu les eines de compilació de C++ instal·lant l'extensió \"C/C++ "
+"Extension Pack\" per a VSCode."
+
+#: ../../getting_started/installation.rst:89
 msgid "Install uv globally with:"
 msgstr "Instal·leu uv globalment amb:"
 
-#: ../../getting_started/installation.rst:81
+#: ../../getting_started/installation.rst:111
 msgid "Then, clone (i.e. download) and enter the repository:"
 msgstr "Després, cloneu (és a dir, descarregueu) i accediu al repositori:"
 
-#: ../../getting_started/installation.rst:88
-msgid "Create a new virtual environment using uv and activate it:"
-msgstr "Creeu un nou entorn virtual usant uv i activeu-lo:"
+#: ../../getting_started/installation.rst:118
+msgid "Create a new virtual environment using uv:"
+msgstr "Creeu un nou entorn virtual usant uv:"
 
-#: ../../getting_started/installation.rst:95
+#: ../../getting_started/installation.rst:124
+msgid "Then activate the environment:"
+msgstr "Després activeu l'entorn:"
+
+#: ../../getting_started/installation.rst:148
 msgid "To then install QiliSDK into this new environment, run:"
 msgstr "Per instal·lar QiliSDK en aquest nou entorn, executeu:"
 
-#: ../../getting_started/installation.rst:101
+#: ../../getting_started/installation.rst:154
 msgid ""
 "If you want to install with extras, you can run the following, adjusting "
 "as needed:"
 msgstr ""
-"Si voleu instal·lar amb extras, podeu executar el següent, ajustant"
-" segons calgui:"
+"Si voleu instal·lar amb extras, podeu executar el següent, ajustant "
+"segons calgui:"
 
-#: ../../getting_started/installation.rst:107
+#: ../../getting_started/installation.rst:160
 msgid ""
 "You then have an environment with the latest version of QiliSDK "
 "installed. If you want to install other things to the environment you'll "
 "need to use pip with uv:"
 msgstr ""
-"Llavors tindreu un entorn amb la darrera versió de QiliSDK instal·lada."
-" Si voleu instal·lar altres coses a l'entorn, haureu d'usar pip amb uv:"
+"Llavors tindreu un entorn amb la darrera versió de QiliSDK instal·lada. "
+"Si voleu instal·lar altres coses a l'entorn, haureu d'usar pip amb uv:"
 
-#: ../../getting_started/installation.rst:114
+#: ../../getting_started/installation.rst:167
 msgid "And then to run a Python script within the environment, you can use:"
 msgstr "I per executar un script de Python dins de l'entorn, podeu usar:"
 
@@ -188,3 +229,19 @@ msgstr "I per executar un script de Python dins de l'entorn, podeu usar:"
 #~ "essentials installed. For Ubuntu/Debian, you"
 #~ " can run:"
 #~ msgstr ""
+
+#~ msgid ""
+#~ "Support for Windows is limited, so "
+#~ "we recommend using WSL, which can "
+#~ "be installed as per `this guide "
+#~ "<https://learn.microsoft.com/en-us/windows/wsl/install>`__."
+#~ msgstr ""
+#~ "El suport per a Windows és "
+#~ "limitat, per la qual cosa recomanem "
+#~ "usar WSL, que es pot instal·lar "
+#~ "seguint `aquesta guia <https://learn.microsoft.com"
+#~ "/en-us/windows/wsl/install>`__."
+
+#~ msgid "or on MacOS with:"
+#~ msgstr "o a MacOS amb:"
+

--- a/docs/locale/ca/LC_MESSAGES/modules/core/core_lp_parser.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/core/core_lp_parser.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 12:00+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -20,37 +20,49 @@ msgstr ""
 "Generated-By: Babel 2.18.0\n"
 
 #: ../../modules/core/core_lp_parser.rst:2
-msgid "LP File Parser"
-msgstr "Analitzador de fitxers LP"
+msgid "Linear Programming File Parser and Serializer"
+msgstr "Analitzador i Serialitzador de Fitxers de Programació Lineal"
 
 #: ../../modules/core/core_lp_parser.rst:4
 msgid ""
-"QiliSDK ships with a parser for the CPLEX-flavor `LP format "
-"<https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-format-"
-"algebraic-representation>`_, exposed as :func:`~qilisdk.utils.from_lp` "
-"(parse a string) and :func:`~qilisdk.utils.from_lp_file` (read and parse "
-"a file). Both produce a fully-formed :class:`~qilisdk.core.model.Model`."
+"QiliSDK ships with a parser and a serializer for the CPLEX-flavor `LP "
+"format <https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-"
+"format-algebraic-representation>`_. The parser is exposed as "
+":func:`~qilisdk.utils.lp_parser.from_lp` (parse a string) and "
+":func:`~qilisdk.utils.lp_parser.from_lp_file` (read and parse a file); "
+"both produce a fully-formed :class:`~qilisdk.core.model.Model`. The "
+"inverse pair, :func:`~qilisdk.utils.lp_parser.to_lp` and "
+":func:`~qilisdk.utils.lp_parser.to_lp_file`, serializes a "
+":class:`~qilisdk.core.model.Model` back to LP-format text."
 msgstr ""
-"QiliSDK inclou un analitzador per al `format LP "
+"QiliSDK inclou un analitzador i un serialitzador per al `format LP "
 "<https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-format-"
-"algebraic-representation>`_ en la seva variant CPLEX, exposat com a "
-":func:`~qilisdk.utils.from_lp` (analitza una cadena) i "
-":func:`~qilisdk.utils.from_lp_file` (llegeix i analitza un fitxer). "
-"Tots dos produeixen un :class:`~qilisdk.core.model.Model` complet."
+"algebraic-representation>`_ en la seva variant CPLEX. L'analitzador "
+"s'exposa com a :func:`~qilisdk.utils.lp_parser.from_lp` (analitza una "
+"cadena) i :func:`~qilisdk.utils.lp_parser.from_lp_file` (llegeix i "
+"analitza un fitxer); tots dos produeixen un "
+":class:`~qilisdk.core.model.Model` complet. El parell invers, "
+":func:`~qilisdk.utils.lp_parser.to_lp` i "
+":func:`~qilisdk.utils.lp_parser.to_lp_file`, serialitza un "
+":class:`~qilisdk.core.model.Model` de tornada a text en format LP."
 
-#: ../../modules/core/core_lp_parser.rst:10
+#: ../../modules/core/core_lp_parser.rst:14
 msgid "Quick start"
 msgstr "Inici ràpid"
 
-#: ../../modules/core/core_lp_parser.rst:19
+#: ../../modules/core/core_lp_parser.rst:24
 msgid "A small inline example:"
 msgstr "Un petit exemple en línia:"
 
-#: ../../modules/core/core_lp_parser.rst:40
+#: ../../modules/core/core_lp_parser.rst:45
+msgid "Round-tripping a model back to LP text:"
+msgstr "Serialització d'un model de tornada a text LP:"
+
+#: ../../modules/core/core_lp_parser.rst:55
 msgid "Supported features"
 msgstr "Funcionalitats suportades"
 
-#: ../../modules/core/core_lp_parser.rst:42
+#: ../../modules/core/core_lp_parser.rst:57
 msgid ""
 "**Objective sense**: ``Maximize`` / ``Minimize`` (and the ``Max`` / "
 "``Min`` / ``Maximum`` / ``Minimum`` aliases, case-insensitive)."
@@ -59,53 +71,53 @@ msgstr ""
 "``Max`` / ``Min`` / ``Maximum`` / ``Minimum``, sense distinció entre "
 "majúscules i minúscules)."
 
-#: ../../modules/core/core_lp_parser.rst:44
+#: ../../modules/core/core_lp_parser.rst:59
 msgid ""
 "**Section keywords**: ``Subject To`` (also ``subj to``, ``s.t.``, "
 "``st``), ``Bounds``, ``General``, ``Binary``, ``End``."
 msgstr ""
-"**Paraules clau de secció**: ``Subject To`` (també ``subj to``, "
-"``s.t.``, ``st``), ``Bounds``, ``General``, ``Binary``, ``End``."
+"**Paraules clau de secció**: ``Subject To`` (també ``subj to``, ``s.t.``,"
+" ``st``), ``Bounds``, ``General``, ``Binary``, ``End``."
 
-#: ../../modules/core/core_lp_parser.rst:46
+#: ../../modules/core/core_lp_parser.rst:61
 msgid ""
-"**Objective expressions**: linear and quadratic terms, including "
-"bilinear monomials such as ``x1 * x2`` and parenthesised sub-expressions"
-" like ``- [x + 1]``. Repeated occurrences of the same variable are "
-"aggregated automatically (``x + x`` becomes ``2*x``)."
+"**Objective expressions**: linear and quadratic terms, including bilinear"
+" monomials such as ``x1 * x2`` and parenthesised sub-expressions like ``-"
+" [x + 1]``. Repeated occurrences of the same variable are aggregated "
+"automatically (``x + x`` becomes ``2*x``)."
 msgstr ""
 "**Expressions de l'objectiu**: termes lineals i quadràtics, incloent-hi "
 "monomis bilineals com ``x1 * x2`` i subexpressions entre claudàtors com "
 "``- [x + 1]``. Les ocurrències repetides de la mateixa variable "
 "s'agreguen automàticament (``x + x`` esdevé ``2*x``)."
 
-#: ../../modules/core/core_lp_parser.rst:50
+#: ../../modules/core/core_lp_parser.rst:65
 msgid ""
-"**Constraint senses**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — each maps "
-"to the corresponding :class:`~qilisdk.core.variables.ComparisonTerm`. "
+"**Constraint senses**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — each maps to"
+" the corresponding :class:`~qilisdk.core.variables.ComparisonTerm`. "
 "Constraint labels are optional; missing labels are auto-generated as "
 "``c1``, ``c2``, …"
 msgstr ""
-"**Sentits de restricció**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — "
-"cadascun es mapeja al :class:`~qilisdk.core.variables.ComparisonTerm` "
+"**Sentits de restricció**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — cadascun"
+" es mapeja al :class:`~qilisdk.core.variables.ComparisonTerm` "
 "corresponent. Les etiquetes de les restriccions són opcionals; quan no "
 "se'n proporcionen, es generen automàticament com ``c1``, ``c2``, …"
 
-#: ../../modules/core/core_lp_parser.rst:53
+#: ../../modules/core/core_lp_parser.rst:68
 msgid ""
 "**Bounds**: two-sided ranges (``-2.5 <= x <= 7.5``), open sides via "
 "``+inf`` / ``-infinity``, and the ``free`` shorthand for unbounded "
 "variables."
 msgstr ""
 "**Cotes**: rangs de dos costats (``-2.5 <= x <= 7.5``), extrems oberts "
-"mitjançant ``+inf`` / ``-infinity`` i la drecera ``free`` per a "
-"variables sense fitar."
+"mitjançant ``+inf`` / ``-infinity`` i la drecera ``free`` per a variables"
+" sense fitar."
 
-#: ../../modules/core/core_lp_parser.rst:55
+#: ../../modules/core/core_lp_parser.rst:70
 msgid "**Variable domains**:"
 msgstr "**Dominis de variables**:"
 
-#: ../../modules/core/core_lp_parser.rst:57
+#: ../../modules/core/core_lp_parser.rst:72
 msgid ""
 "Variables listed in ``Binary`` are "
 ":class:`~qilisdk.core.variables.BinaryVariable`."
@@ -113,7 +125,7 @@ msgstr ""
 "Les variables llistades a ``Binary`` són "
 ":class:`~qilisdk.core.variables.BinaryVariable`."
 
-#: ../../modules/core/core_lp_parser.rst:58
+#: ../../modules/core/core_lp_parser.rst:73
 msgid ""
 "Variables listed in ``General`` are integer "
 ":class:`~qilisdk.core.variables.Variable` with "
@@ -122,10 +134,10 @@ msgid ""
 msgstr ""
 "Les variables llistades a ``General`` són "
 ":class:`~qilisdk.core.variables.Variable` enteres amb "
-":attr:`~qilisdk.core.variables.Domain.INTEGER`. Les cotes declarades "
-"a la secció ``Bounds`` es conserven."
+":attr:`~qilisdk.core.variables.Domain.INTEGER`. Les cotes declarades a la"
+" secció ``Bounds`` es conserven."
 
-#: ../../modules/core/core_lp_parser.rst:61
+#: ../../modules/core/core_lp_parser.rst:76
 msgid ""
 "Variables that appear only in the ``Bounds`` section are continuous "
 "(``Domain.REAL``) with the declared bounds."
@@ -133,71 +145,137 @@ msgstr ""
 "Les variables que només apareixen a la secció ``Bounds`` són contínues "
 "(``Domain.REAL``) amb les cotes declarades."
 
-#: ../../modules/core/core_lp_parser.rst:63
+#: ../../modules/core/core_lp_parser.rst:78
 msgid ""
 "Variables that appear only inside expressions are auto-created as "
 "continuous with the LP-format default bounds ``[0, +inf)``."
 msgstr ""
 "Les variables que només apareixen dins d'expressions es creen "
-"automàticament com a contínues amb les cotes per defecte del format "
-"LP, ``[0, +inf)``."
+"automàticament com a contínues amb les cotes per defecte del format LP, "
+"``[0, +inf)``."
 
-#: ../../modules/core/core_lp_parser.rst:66
+#: ../../modules/core/core_lp_parser.rst:81
 msgid ""
-"**Comments**: backslash (``\\\\``) starts a line comment that runs to "
-"the end of the line."
+"**Comments**: backslash (``\\\\``) starts a line comment that runs to the"
+" end of the line."
 msgstr ""
 "**Comentaris**: la barra invertida (``\\\\``) inicia un comentari de "
 "línia que s'estén fins al final de la mateixa."
 
-#: ../../modules/core/core_lp_parser.rst:70
+#: ../../modules/core/core_lp_parser.rst:85
+msgid "Serialization conventions"
+msgstr "Convencions de serialització"
+
+#: ../../modules/core/core_lp_parser.rst:87
+msgid ""
+":func:`~qilisdk.utils.lp_parser.to_lp` produces grammar-compliant output "
+"that :func:`~qilisdk.utils.lp_parser.from_lp` can read back. Notable "
+"conventions:"
+msgstr ""
+":func:`~qilisdk.utils.lp_parser.to_lp` produeix una sortida conforme a la"
+" gramàtica que :func:`~qilisdk.utils.lp_parser.from_lp` pot tornar a "
+"llegir. Convencions destacades:"
+
+#: ../../modules/core/core_lp_parser.rst:90
+msgid ""
+"Quadratic and bilinear monomials are expanded into explicit products (``x"
+" * x``, ``x * y``) since the LP grammar accepted by the parser has no "
+"``^`` operator."
+msgstr ""
+"Els monomis quadràtics i bilineals s'expandeixen en productes explícits "
+"(``x * x``, ``x * y``) ja que la gramàtica LP acceptada per l'analitzador"
+" no té l'operador ``^``."
+
+#: ../../modules/core/core_lp_parser.rst:93
+msgid ""
+"A unit coefficient is omitted (``x`` rather than ``1 x``); a ``-1`` "
+"coefficient becomes a leading ``- x``."
+msgstr ""
+"Un coeficient unitari s'omet (``x`` en lloc de ``1 x``); un coeficient "
+"``-1`` es converteix en un ``- x`` inicial."
+
+#: ../../modules/core/core_lp_parser.rst:95
+msgid ""
+"Constraint right-hand sides are emitted as a single constant — any "
+"constant appearing on the left-hand side is folded into the rhs first."
+msgstr ""
+"Els costats drets de les restriccions s'emeten com una única constant — "
+"qualsevol constant que aparegui al costat esquerre es plega al rhs primer."
+
+#: ../../modules/core/core_lp_parser.rst:97
+msgid ""
+"Unbounded continuous variables are emitted as ``var free``; one-sided "
+"bounds use ``var >= lo`` or ``-infinity <= var <= up``. Variables "
+"matching the LP default of ``[0, +inf)`` are omitted from the ``Bounds`` "
+"section entirely."
+msgstr ""
+"Les variables contínues sense cotes s'emeten com ``var free``; les cotes "
+"unilaterals utilitzen ``var >= lo`` o ``-infinity <= var <= up``. Les "
+"variables que coincideixen amb el valor per defecte LP de ``[0, +inf)`` "
+"s'ometen completament de la secció ``Bounds``."
+
+#: ../../modules/core/core_lp_parser.rst:100
+msgid ""
+":class:`~qilisdk.core.variables.BinaryVariable` variables are listed in "
+"the ``Binary`` section; integer ones in ``General`` (with their bounds, "
+"if any)."
+msgstr ""
+"Les variables :class:`~qilisdk.core.variables.BinaryVariable` es llisten "
+"a la secció ``Binary``; les enteres a ``General`` (amb les seves cotes, "
+"si n'hi ha)."
+
+#: ../../modules/core/core_lp_parser.rst:104
 msgid "Worked example"
 msgstr "Exemple desenvolupat"
 
-#: ../../modules/core/core_lp_parser.rst:96
-msgid ""
-"Parsing it returns a :class:`~qilisdk.core.model.Model` with:"
-msgstr ""
-"L'anàlisi retorna un :class:`~qilisdk.core.model.Model` amb:"
+#: ../../modules/core/core_lp_parser.rst:129
+msgid "Parsing it returns a :class:`~qilisdk.core.model.Model` with:"
+msgstr "L'anàlisi retorna un :class:`~qilisdk.core.model.Model` amb:"
 
-#: ../../modules/core/core_lp_parser.rst:98
+#: ../../modules/core/core_lp_parser.rst:131
 msgid ""
 "five real-valued variables (``x1``, ``x2``, ``x3``, ``x4`` plus auto-"
 "typed ones, plus integer ``y``),"
 msgstr ""
-"cinc variables de valor real (``x1``, ``x2``, ``x3``, ``x4`` a més de "
-"les creades automàticament, juntament amb l'entera ``y``),"
+"cinc variables de valor real (``x1``, ``x2``, ``x3``, ``x4`` a més de les"
+" creades automàticament, juntament amb l'entera ``y``),"
 
-#: ../../modules/core/core_lp_parser.rst:100
+#: ../../modules/core/core_lp_parser.rst:133
 msgid "two binary variables (``b1``, ``b2``),"
 msgstr "dues variables binàries (``b1``, ``b2``),"
 
-#: ../../modules/core/core_lp_parser.rst:101
-msgid ""
-"a maximization objective with linear, bilinear, and parenthesised "
-"terms,"
+#: ../../modules/core/core_lp_parser.rst:134
+msgid "a maximization objective with linear, bilinear, and parenthesised terms,"
 msgstr ""
 "un objectiu de maximització amb termes lineals, bilineals i agrupats "
 "entre claudàtors,"
 
-#: ../../modules/core/core_lp_parser.rst:102
-msgid ""
-"three labelled constraints covering the ``<=``, ``>=``, and ``=`` "
-"senses."
+#: ../../modules/core/core_lp_parser.rst:135
+msgid "three labelled constraints covering the ``<=``, ``>=``, and ``=`` senses."
 msgstr ""
-"tres restriccions etiquetades que cobreixen els sentits ``<=``, ``>=`` "
-"i ``=``."
+"tres restriccions etiquetades que cobreixen els sentits ``<=``, ``>=`` i "
+"``=``."
 
-#: ../../modules/core/core_lp_parser.rst:104
+#: ../../modules/core/core_lp_parser.rst:137
 msgid ""
 "The resulting model can be inspected, evaluated against a sample with "
-":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, or "
-"converted to a QUBO via :meth:`Model.to_qubo "
-"<qilisdk.core.model.Model.to_qubo>` like any other model built directly "
-"with the symbolic API."
+":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, or converted "
+"to a QUBO via :meth:`Model.to_qubo <qilisdk.core.model.Model.to_qubo>` "
+"like any other model built directly with the symbolic API. Passing the "
+"model to :func:`~qilisdk.utils.lp_parser.to_lp` yields an LP-format "
+"string that, when fed back through "
+":func:`~qilisdk.utils.lp_parser.from_lp`, reconstructs an equivalent "
+"model."
 msgstr ""
 "El model resultant es pot inspeccionar, avaluar sobre una mostra amb "
-":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, o convertir"
-" a QUBO mitjançant :meth:`Model.to_qubo "
-"<qilisdk.core.model.Model.to_qubo>` com qualsevol altre model construït"
-" directament amb l'API simbòlica."
+":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, o convertir a"
+" QUBO mitjançant :meth:`Model.to_qubo <qilisdk.core.model.Model.to_qubo>`"
+" com qualsevol altre model construït directament amb l'API simbòlica. "
+"Passar el model a :func:`~qilisdk.utils.lp_parser.to_lp` produeix una "
+"cadena en format LP que, en ser processada de nou per "
+":func:`~qilisdk.utils.lp_parser.from_lp`, reconstrueix un model "
+"equivalent."
+
+#~ msgid "LP File Parser"
+#~ msgstr "Analitzador de fitxers LP"
+

--- a/docs/locale/ca/LC_MESSAGES/modules/core/core_overview.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/core/core_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -64,17 +64,21 @@ msgid ":doc:`core_model` to build constrained optimization programs."
 msgstr ":doc:`core_model` per construir programes d'optimització amb restriccions."
 
 #: ../../modules/core/core_overview.rst:13
-msgid ":doc:`core_lp_parser` to load models from LP-format files."
+#, fuzzy
+msgid ""
+":doc:`core_lp_parser` to load models from and write models to LP-format "
+"files."
 msgstr ":doc:`core_lp_parser` per carregar models des de fitxers en format LP."
 
 #: ../../modules/core/core_overview.rst:14
 msgid ":doc:`core_qubo` to convert models to QUBO format."
 msgstr ":doc:`core_qubo` per convertir models al format QUBO."
 
-#: ../../modules/core/core_overview.rst:14
+#: ../../modules/core/core_overview.rst:15
 msgid ""
 ":doc:`core_qtensor` to manage sparse quantum objects, such as states and "
 "operators."
 msgstr ""
 ":doc:`core_qtensor` per gestionar objectes quàntics dispersos, com ara "
 "estats i operadors."
+

--- a/docs/locale/ca/LC_MESSAGES/modules/digital/digital_circuits.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/digital/digital_circuits.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -62,8 +62,9 @@ msgid ""
 "You can also initialize a random circuit with a specified number of gates"
 " using the :meth:`~qilisdk.digital.circuit.Circuit.random` method:"
 msgstr ""
-"També podeu inicialitzar un circuit aleatori amb un nombre especificat de "
-"portes utilitzant el mètode :meth:`~qilisdk.digital.circuit.Circuit.random`:"
+"També podeu inicialitzar un circuit aleatori amb un nombre especificat de"
+" portes utilitzant el mètode "
+":meth:`~qilisdk.digital.circuit.Circuit.random`:"
 
 #: ../../modules/digital/digital_circuits.rst:69
 msgid "Parameterized Circuits"
@@ -74,8 +75,8 @@ msgid ""
 "Circuits can include parameterized gates. Adding them is similar to "
 "regular gates:"
 msgstr ""
-"Els circuits poden incloure portes parametritzades. Afegir-les és similar "
-"a les portes regulars:"
+"Els circuits poden incloure portes parametritzades. Afegir-les és similar"
+" a les portes regulars:"
 
 #: ../../modules/digital/digital_circuits.rst:81
 msgid "You can retrieve the current parameter using:"
@@ -88,7 +89,9 @@ msgstr "**Sortida:**"
 
 #: ../../modules/digital/digital_circuits.rst:95
 msgid "You can also retrieve a list containing only the current parameter values:"
-msgstr "També podeu recuperar una llista que contingui només els valors actuals dels paràmetres:"
+msgstr ""
+"També podeu recuperar una llista que contingui només els valors actuals "
+"dels paràmetres:"
 
 #: ../../modules/digital/digital_circuits.rst:109
 msgid "To update parameters by their keys:"
@@ -103,8 +106,8 @@ msgid ""
 "The order of parameters in the list passed to ``set_parameter_values`` "
 "must match the order in which the gates were added to the circuit."
 msgstr ""
-"L'ordre dels paràmetres a la llista passada a ``set_parameter_values`` "
-"ha de coincidir amb l'ordre en què les portes van ser afegides al circuit."
+"L'ordre dels paràmetres a la llista passada a ``set_parameter_values`` ha"
+" de coincidir amb l'ordre en què les portes van ser afegides al circuit."
 
 #: ../../modules/digital/digital_circuits.rst:126
 msgid "Visualization"
@@ -120,31 +123,33 @@ msgid ""
 "styling to the specific call without modifying global Matplotlib "
 "settings."
 msgstr ""
-"Utilitzeu :meth:`~qilisdk.digital.circuit.Circuit.draw` per renderitzar un "
-"circuit amb Matplotlib. Per defecte, el renderitzador aplica l'estil integrat "
-"de la biblioteca (inclosa la font predeterminada inclosa si està disponible). "
-"Podeu **ometre tots els valors predeterminats** passant un "
-":class:`~qilisdk.utils.visualization.style.CircuitStyle` personalitzat, que "
-"limita l'estil a la crida específica sense modificar la configuració global "
-"de Matplotlib."
+"Utilitzeu :meth:`~qilisdk.digital.circuit.Circuit.draw` per renderitzar "
+"un circuit amb Matplotlib. Per defecte, el renderitzador aplica l'estil "
+"integrat de la biblioteca (inclosa la font predeterminada inclosa si està"
+" disponible). Podeu **ometre tots els valors predeterminats** passant un "
+":class:`~qilisdk.utils.visualization.style.CircuitStyle` personalitzat, "
+"que limita l'estil a la crida específica sense modificar la configuració "
+"global de Matplotlib."
 
 #: ../../modules/digital/digital_circuits.rst:145
 msgid "**Output**"
 msgstr "**Sortida**"
 
-#: ../../modules/digital/digital_circuits.rst:148
+#: ../../modules/digital/digital_circuits.rst:147
 msgid "Example digital circuit rendered with Circuit.draw"
 msgstr "Exemple de circuit digital renderitzat amb Circuit.draw"
 
-#: ../../modules/digital/digital_circuits.rst:152
+#: ../../modules/digital/digital_circuits.rst:151
 msgid "Example circuit produced by ``circuit.draw()``."
 msgstr "Exemple de circuit produït per ``circuit.draw()``."
 
-#: ../../modules/digital/digital_circuits.rst:155
-msgid "Saving to a file"
-msgstr "Desar en un fitxer"
+#: ../../modules/digital/digital_circuits.rst:153
+msgid ""
+"The plot can also be saved to a file by providing a filepath to the draw "
+"method:"
+msgstr ""
 
-#: ../../modules/digital/digital_circuits.rst:163
+#: ../../modules/digital/digital_circuits.rst:161
 msgid ""
 "Custom styling with "
 ":class:`~qilisdk.utils.visualization.style.CircuitStyle`"
@@ -152,7 +157,7 @@ msgstr ""
 "Estil personalitzat amb "
 ":class:`~qilisdk.utils.visualization.style.CircuitStyle`"
 
-#: ../../modules/digital/digital_circuits.rst:165
+#: ../../modules/digital/digital_circuits.rst:163
 msgid ""
 "Create a style object to control theme, fonts, spacing, DPI, labels, and "
 "more. Passing this object to "
@@ -165,12 +170,12 @@ msgstr ""
 "Creeu un objecte d'estil per controlar el tema, les fonts, l'espaiat, el "
 "DPI, les etiquetes i molt més. Passar aquest objecte a "
 ":meth:`~qilisdk.digital.circuit.Circuit.draw` substitueix els valors "
-"predeterminats de la biblioteca per a aquesta crida. També podeu canviar si "
-"l'ordre del dibuix segueix l'ordre en què s'afegeixen o si compacta les capes "
-"tant com sigui possible canviant el paràmetre **layout** a *\"normal\"* "
-"(predeterminat) o *\"compact\"* respectivament."
+"predeterminats de la biblioteca per a aquesta crida. També podeu canviar "
+"si l'ordre del dibuix segueix l'ordre en què s'afegeixen o si compacta "
+"les capes tant com sigui possible canviant el paràmetre **layout** a "
+"*\"normal\"* (predeterminat) o *\"compact\"* respectivament."
 
-#: ../../modules/digital/digital_circuits.rst:209
+#: ../../modules/digital/digital_circuits.rst:207
 msgid ""
 "``CircuitStyle`` fields map directly to the renderer's layout and font "
 "configuration. In particular, you can switch fonts in two ways: (1) "
@@ -179,19 +184,19 @@ msgid ""
 "``fontfamily=[...]`` to use system-resolved fonts. Both approaches only "
 "affect the current draw call."
 msgstr ""
-"Els camps de ``CircuitStyle`` es mapegen directament a la configuració de "
-"disposició i fonts del renderitzador. En particular, podeu canviar les fonts "
-"de dues maneres: (1) proporcioneu un fitxer de font específic via "
-"``fontfname=\"/path/to/MyFont.ttf\"``; o (2) establiu ``fontfname=None`` i "
-"trieu una llista de famílies amb ``fontfamily=[...]`` per usar fonts "
+"Els camps de ``CircuitStyle`` es mapegen directament a la configuració de"
+" disposició i fonts del renderitzador. En particular, podeu canviar les "
+"fonts de dues maneres: (1) proporcioneu un fitxer de font específic via "
+"``fontfname=\"/path/to/MyFont.ttf\"``; o (2) establiu ``fontfname=None`` "
+"i trieu una llista de famílies amb ``fontfamily=[...]`` per usar fonts "
 "resoltes pel sistema. Ambdós enfocaments afecten únicament la crida de "
 "dibuix actual."
 
-#: ../../modules/digital/digital_circuits.rst:215
+#: ../../modules/digital/digital_circuits.rst:213
 msgid "Parameter Utilities"
 msgstr "Utilitats de paràmetres"
 
-#: ../../modules/digital/digital_circuits.rst:217
+#: ../../modules/digital/digital_circuits.rst:215
 msgid ""
 "Circuits collect the symbolic parameters contributed by each gate. Beyond"
 " the quick examples above, you can query names, current values, and "
@@ -201,15 +206,16 @@ msgstr ""
 "Més enllà dels exemples ràpids anteriors, podeu consultar noms, valors "
 "actuals i límits, o actualitzar-los de manera selectiva:"
 
-#: ../../modules/digital/digital_circuits.rst:242
+#: ../../modules/digital/digital_circuits.rst:240
 msgid ""
 "These helpers make it straightforward to plug the circuit into classical "
 "optimization loops while keeping parameter metadata synchronized."
 msgstr ""
 "Aquests assistents permeten integrar fàcilment el circuit en bucles "
-"d'optimització clàssics mantenint els metadades dels paràmetres sincronitzats."
+"d'optimització clàssics mantenint els metadades dels paràmetres "
+"sincronitzats."
 
-#: ../../modules/digital/digital_circuits.rst:247
+#: ../../modules/digital/digital_circuits.rst:245
 msgid ""
 "Parameterized gates and circuits expose parameter information through "
 "``get_parameter_names``, ``get_parameters``, ``get_parameter_values``, "
@@ -221,3 +227,7 @@ msgstr ""
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Aneu a un subapartat específic d'una pàgina."
+
+#~ msgid "Saving to a file"
+#~ msgstr "Desar en un fitxer"
+

--- a/docs/locale/ca/LC_MESSAGES/modules/digital/digital_overview.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/digital/digital_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -50,4 +50,13 @@ msgstr ""
 
 #: ../../modules/digital/digital_overview.rst:9
 msgid ":doc:`digital_ansatz`: Predefined circuits that can serve as Ansätze."
-msgstr ":doc:`digital_ansatz`: Circuits predefinits que poden servir com a Ansätze."
+msgstr ""
+":doc:`digital_ansatz`: Circuits predefinits que poden servir com a "
+"Ansätze."
+
+#: ../../modules/digital/digital_overview.rst:10
+msgid ""
+":doc:`digital_qir`: Import and export circuits to / from the QIR Base "
+"Profile."
+msgstr ""
+

--- a/docs/locale/ca/LC_MESSAGES/modules/digital/digital_qasm.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/digital/digital_qasm.po
@@ -1,0 +1,476 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Qilimanjaro Quantum Tech
+# This file is distributed under the same license as the QiliSDK package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: QiliSDK \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ca\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../modules/digital/digital_qasm.rst:2
+msgid "OpenQASM Import and Export"
+msgstr "Importació i Exportació OpenQASM"
+
+#: ../../modules/digital/digital_qasm.rst:4
+msgid ""
+"QiliSDK can bridge :class:`~qilisdk.digital.Circuit` and both OpenQASM "
+"2.0 and OpenQASM 3.0 via the following entry-points in "
+":mod:`qilisdk.utils.openqasm`:"
+msgstr ""
+"QiliSDK pot connectar :class:`~qilisdk.digital.Circuit` tant amb OpenQASM"
+" 2.0 com amb OpenQASM 3.0 a través dels punts d'entrada següents a "
+":mod:`qilisdk.utils.openqasm`:"
+
+#: ../../modules/digital/digital_qasm.rst:7
+msgid "**OpenQASM 2.0**"
+msgstr "**OpenQASM 2.0**"
+
+#: ../../modules/digital/digital_qasm.rst:9
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2` — parse an OpenQASM "
+"2.0 string into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2` — analitza una "
+"cadena OpenQASM 2.0 en un Circuit."
+
+#: ../../modules/digital/digital_qasm.rst:10
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2_file` — read a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2_file` — llegeix un "
+"fitxer ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:11
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2` — serialize a Circuit "
+"to an OpenQASM 2.0 string."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2` — serialitza un "
+"Circuit a una cadena OpenQASM 2.0."
+
+#: ../../modules/digital/digital_qasm.rst:12
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2_file` — write a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2_file` — escriu un "
+"fitxer ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:14
+msgid "**OpenQASM 3.0**"
+msgstr "**OpenQASM 3.0**"
+
+#: ../../modules/digital/digital_qasm.rst:16
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3` — parse an OpenQASM "
+"3.0 string into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3` — analitza una "
+"cadena OpenQASM 3.0 en un Circuit."
+
+#: ../../modules/digital/digital_qasm.rst:17
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3_file` — read a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3_file` — llegeix un "
+"fitxer ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:18
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3` — serialize a Circuit "
+"to an OpenQASM 3.0 string."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3` — serialitza un "
+"Circuit a una cadena OpenQASM 3.0."
+
+#: ../../modules/digital/digital_qasm.rst:19
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3_file` — write a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3_file` — escriu un "
+"fitxer ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:21
+msgid ""
+"The ``openqasm3`` dependency is optional; install it with the "
+"``openqasm`` extra:"
+msgstr ""
+"La dependència ``openqasm3`` és opcional; instal·leu-la amb l'extra "
+"``openqasm``:"
+
+#: ../../modules/digital/digital_qasm.rst:28
+msgid "Quick start"
+msgstr "Inici ràpid"
+
+#: ../../modules/digital/digital_qasm.rst:50
+msgid "Reading and writing files:"
+msgstr "Lectura i escriptura de fitxers:"
+
+#: ../../modules/digital/digital_qasm.rst:64
+msgid "OpenQASM 3.0 supported features"
+msgstr "Funcionalitats suportades d'OpenQASM 3.0"
+
+#: ../../modules/digital/digital_qasm.rst:66
+msgid "✅: The feature is fully supported"
+msgstr "✅: La funcionalitat és totalment suportada"
+
+#: ../../modules/digital/digital_qasm.rst:67
+msgid "🟡: The feature is partially supported, see the note for explanation"
+msgstr ""
+"🟡: La funcionalitat és parcialment suportada, vegeu la nota per a més "
+"explicació"
+
+#: ../../modules/digital/digital_qasm.rst:68
+msgid "❌: The feature is not supported"
+msgstr "❌: La funcionalitat no està suportada"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "OpenQASM 3 feature"
+msgstr "Característica OpenQASM 3"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "QiliSDK"
+msgstr "QiliSDK"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "Notes"
+msgstr "Notes"
+
+#: ../../modules/digital/digital_qasm.rst:73
+msgid "comments"
+msgstr "comentaris"
+
+#: ../../modules/digital/digital_qasm.rst:73
+#: ../../modules/digital/digital_qasm.rst:74
+#: ../../modules/digital/digital_qasm.rst:75
+#: ../../modules/digital/digital_qasm.rst:76
+#: ../../modules/digital/digital_qasm.rst:77
+#: ../../modules/digital/digital_qasm.rst:85
+#: ../../modules/digital/digital_qasm.rst:86
+#: ../../modules/digital/digital_qasm.rst:87
+#: ../../modules/digital/digital_qasm.rst:89
+#: ../../modules/digital/digital_qasm.rst:92
+#: ../../modules/digital/digital_qasm.rst:97
+#: ../../modules/digital/digital_qasm.rst:100
+#: ../../modules/digital/digital_qasm.rst:102
+msgid "✅"
+msgstr "✅"
+
+#: ../../modules/digital/digital_qasm.rst:74
+msgid "QASM version string"
+msgstr "Cadena de versió QASM"
+
+#: ../../modules/digital/digital_qasm.rst:75
+msgid "include"
+msgstr "include"
+
+#: ../../modules/digital/digital_qasm.rst:76
+msgid "unicode names"
+msgstr "noms unicode"
+
+#: ../../modules/digital/digital_qasm.rst:77
+msgid "qubit"
+msgstr "qubit"
+
+#: ../../modules/digital/digital_qasm.rst:78
+msgid "bit"
+msgstr "bit"
+
+#: ../../modules/digital/digital_qasm.rst:78
+#: ../../modules/digital/digital_qasm.rst:79
+#: ../../modules/digital/digital_qasm.rst:80
+#: ../../modules/digital/digital_qasm.rst:81
+#: ../../modules/digital/digital_qasm.rst:82
+#: ../../modules/digital/digital_qasm.rst:83
+#: ../../modules/digital/digital_qasm.rst:84
+#: ../../modules/digital/digital_qasm.rst:90
+#: ../../modules/digital/digital_qasm.rst:93
+#: ../../modules/digital/digital_qasm.rst:98
+#: ../../modules/digital/digital_qasm.rst:101
+#: ../../modules/digital/digital_qasm.rst:103
+#: ../../modules/digital/digital_qasm.rst:105
+#: ../../modules/digital/digital_qasm.rst:106
+#: ../../modules/digital/digital_qasm.rst:107
+#: ../../modules/digital/digital_qasm.rst:108
+#: ../../modules/digital/digital_qasm.rst:109
+#: ../../modules/digital/digital_qasm.rst:110
+#: ../../modules/digital/digital_qasm.rst:111
+#: ../../modules/digital/digital_qasm.rst:112
+#: ../../modules/digital/digital_qasm.rst:113
+#: ../../modules/digital/digital_qasm.rst:114
+#: ../../modules/digital/digital_qasm.rst:115
+#: ../../modules/digital/digital_qasm.rst:116
+#: ../../modules/digital/digital_qasm.rst:117
+#: ../../modules/digital/digital_qasm.rst:119
+#: ../../modules/digital/digital_qasm.rst:120
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "🟡"
+msgstr "🟡"
+
+#: ../../modules/digital/digital_qasm.rst:78
+#: ../../modules/digital/digital_qasm.rst:79
+#: ../../modules/digital/digital_qasm.rst:80
+#: ../../modules/digital/digital_qasm.rst:81
+#: ../../modules/digital/digital_qasm.rst:82
+#: ../../modules/digital/digital_qasm.rst:83
+#: ../../modules/digital/digital_qasm.rst:84
+#: ../../modules/digital/digital_qasm.rst:90
+#: ../../modules/digital/digital_qasm.rst:93
+#: ../../modules/digital/digital_qasm.rst:98
+#: ../../modules/digital/digital_qasm.rst:101
+#: ../../modules/digital/digital_qasm.rst:106
+#: ../../modules/digital/digital_qasm.rst:107
+#: ../../modules/digital/digital_qasm.rst:108
+#: ../../modules/digital/digital_qasm.rst:109
+#: ../../modules/digital/digital_qasm.rst:110
+#: ../../modules/digital/digital_qasm.rst:111
+#: ../../modules/digital/digital_qasm.rst:112
+#: ../../modules/digital/digital_qasm.rst:113
+#: ../../modules/digital/digital_qasm.rst:114
+#: ../../modules/digital/digital_qasm.rst:115
+#: ../../modules/digital/digital_qasm.rst:116
+#: ../../modules/digital/digital_qasm.rst:117
+#: ../../modules/digital/digital_qasm.rst:119
+#: ../../modules/digital/digital_qasm.rst:120
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "1"
+msgstr "1"
+
+#: ../../modules/digital/digital_qasm.rst:79
+msgid "bool"
+msgstr "bool"
+
+#: ../../modules/digital/digital_qasm.rst:80
+msgid "int"
+msgstr "int"
+
+#: ../../modules/digital/digital_qasm.rst:81
+msgid "uint"
+msgstr "uint"
+
+#: ../../modules/digital/digital_qasm.rst:82
+msgid "float"
+msgstr "float"
+
+#: ../../modules/digital/digital_qasm.rst:83
+msgid "angle"
+msgstr "angle"
+
+#: ../../modules/digital/digital_qasm.rst:84
+msgid "complex"
+msgstr "complex"
+
+#: ../../modules/digital/digital_qasm.rst:85
+msgid "const"
+msgstr "const"
+
+#: ../../modules/digital/digital_qasm.rst:86
+msgid "pi/π/tau/τ/euler/ℇ"
+msgstr "pi/π/tau/τ/euler/ℇ"
+
+#: ../../modules/digital/digital_qasm.rst:87
+msgid "Aliasing: ``let``"
+msgstr "Àlies: ``let``"
+
+#: ../../modules/digital/digital_qasm.rst:88
+msgid "register concatenation"
+msgstr "concatenació de registres"
+
+#: ../../modules/digital/digital_qasm.rst:88
+#: ../../modules/digital/digital_qasm.rst:91
+#: ../../modules/digital/digital_qasm.rst:94
+#: ../../modules/digital/digital_qasm.rst:95
+#: ../../modules/digital/digital_qasm.rst:96
+#: ../../modules/digital/digital_qasm.rst:99
+#: ../../modules/digital/digital_qasm.rst:104
+#: ../../modules/digital/digital_qasm.rst:118
+#: ../../modules/digital/digital_qasm.rst:122
+msgid "❌"
+msgstr "❌"
+
+#: ../../modules/digital/digital_qasm.rst:89
+msgid "casting (``expr.Cast``)"
+msgstr "conversió de tipus (``expr.Cast``)"
+
+#: ../../modules/digital/digital_qasm.rst:90
+msgid "duration"
+msgstr "duration"
+
+#: ../../modules/digital/digital_qasm.rst:91
+msgid "durationof"
+msgstr "durationof"
+
+#: ../../modules/digital/digital_qasm.rst:92
+msgid "ns/μs/us/ms/s/dt"
+msgstr "ns/μs/us/ms/s/dt"
+
+#: ../../modules/digital/digital_qasm.rst:93
+msgid "stretch (``expr.Stretch``)"
+msgstr "stretch (``expr.Stretch``)"
+
+#: ../../modules/digital/digital_qasm.rst:94
+msgid "delay"
+msgstr "delay"
+
+#: ../../modules/digital/digital_qasm.rst:95
+msgid "barrier"
+msgstr "barrier"
+
+#: ../../modules/digital/digital_qasm.rst:96
+msgid "box"
+msgstr "box"
+
+#: ../../modules/digital/digital_qasm.rst:97
+msgid "built-in ``U``"
+msgstr "``U`` integrada"
+
+#: ../../modules/digital/digital_qasm.rst:98
+msgid "gate definition"
+msgstr "definició de porta"
+
+#: ../../modules/digital/digital_qasm.rst:99
+msgid "gphase"
+msgstr "gphase"
+
+#: ../../modules/digital/digital_qasm.rst:100
+msgid "``ctrl @``"
+msgstr "``ctrl @``"
+
+#: ../../modules/digital/digital_qasm.rst:101
+msgid "``negctrl @``"
+msgstr "``negctrl @``"
+
+#: ../../modules/digital/digital_qasm.rst:102
+msgid "``inv @``"
+msgstr "``inv @``"
+
+#: ../../modules/digital/digital_qasm.rst:103
+msgid "``pow(k) @``"
+msgstr "``pow(k) @``"
+
+#: ../../modules/digital/digital_qasm.rst:103
+msgid "1, 2"
+msgstr "1, 2"
+
+#: ../../modules/digital/digital_qasm.rst:104
+msgid "reset"
+msgstr "reset"
+
+#: ../../modules/digital/digital_qasm.rst:105
+msgid "measure"
+msgstr "measure"
+
+#: ../../modules/digital/digital_qasm.rst:105
+msgid "3"
+msgstr "3"
+
+#: ../../modules/digital/digital_qasm.rst:106
+msgid "bit operations"
+msgstr "operacions de bits"
+
+#: ../../modules/digital/digital_qasm.rst:107
+msgid "boolean operations"
+msgstr "operacions booleanes"
+
+#: ../../modules/digital/digital_qasm.rst:108
+msgid "arithmetic expressions"
+msgstr "expressions aritmètiques"
+
+#: ../../modules/digital/digital_qasm.rst:109
+msgid "comparisons"
+msgstr "comparacions"
+
+#: ../../modules/digital/digital_qasm.rst:110
+msgid "``if``"
+msgstr "``if``"
+
+#: ../../modules/digital/digital_qasm.rst:111
+msgid "``else``"
+msgstr "``else``"
+
+#: ../../modules/digital/digital_qasm.rst:112
+msgid "``else if``"
+msgstr "``else if``"
+
+#: ../../modules/digital/digital_qasm.rst:113
+msgid "for loops"
+msgstr "bucles for"
+
+#: ../../modules/digital/digital_qasm.rst:114
+msgid "switch"
+msgstr "switch"
+
+#: ../../modules/digital/digital_qasm.rst:115
+msgid "while loops"
+msgstr "bucles while"
+
+#: ../../modules/digital/digital_qasm.rst:116
+msgid "``continue``"
+msgstr "``continue``"
+
+#: ../../modules/digital/digital_qasm.rst:117
+msgid "``break``"
+msgstr "``break``"
+
+#: ../../modules/digital/digital_qasm.rst:118
+msgid "extern"
+msgstr "extern"
+
+#: ../../modules/digital/digital_qasm.rst:119
+msgid "def subroutines"
+msgstr "subrutines def"
+
+#: ../../modules/digital/digital_qasm.rst:120
+msgid "return"
+msgstr "return"
+
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "input"
+msgstr "input"
+
+#: ../../modules/digital/digital_qasm.rst:122
+msgid "output"
+msgstr "output"
+
+#: ../../modules/digital/digital_qasm.rst:125
+msgid ""
+"Reading these constructs is fully supported, but the expressions are not "
+"stored in the :class:`~qilisdk.digital.Circuit` object and will not be "
+"written back out when converting to OpenQASM. For example, declaring "
+"``int x = 5;`` causes ``x`` to be evaluated and used during parsing, but "
+"the variable declaration will not appear in the resulting circuit object "
+"or in any re-exported QASM string."
+msgstr ""
+"La lectura d'aquestes construccions és totalment suportada, però les "
+"expressions no s'emmagatzemen a l'objecte :class:`~qilisdk.digital.Circuit`"
+" i no s'escriuran en convertir a OpenQASM. Per exemple, declarar "
+"``int x = 5;`` fa que ``x`` sigui avaluada i usada durant l'anàlisi, però"
+" la declaració de variable no apareixerà a l'objecte de circuit resultant "
+"ni en cap cadena QASM reexportada."
+
+#: ../../modules/digital/digital_qasm.rst:132
+msgid ""
+"``pow(k) @`` is only supported when ``k`` is an integer; it is "
+"implemented by repeated gate application."
+msgstr ""
+"``pow(k) @`` només està suportat quan ``k`` és un enter; s'implementa "
+"mitjançant aplicació repetida de la porta."
+
+#: ../../modules/digital/digital_qasm.rst:135
+msgid "Mid-circuit measurements are not supported in QiliSDK."
+msgstr "Les mesures a mig circuit no estan suportades a QiliSDK."

--- a/docs/locale/ca/LC_MESSAGES/modules/digital/digital_qir.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/digital/digital_qir.po
@@ -1,0 +1,485 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Qilimanjaro Quantum Tech
+# This file is distributed under the same license as the QiliSDK package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: QiliSDK \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ca\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../modules/digital/digital_qir.rst:2
+msgid "QIR Import and Export"
+msgstr "Importació i Exportació QIR"
+
+#: ../../modules/digital/digital_qir.rst:4
+msgid ""
+"QiliSDK can bridge :class:`~qilisdk.digital.Circuit` and the `QIR Base "
+"Profile <https://github.com/qir-alliance/qir-"
+"spec/blob/main/specification/under_development/profiles/Base_Profile.md>`_"
+" via Microsoft's `pyqir <https://pypi.org/project/pyqir/>`_ library. Four"
+" entry-points live in :mod:`qilisdk.utils.qir`:"
+msgstr ""
+"QiliSDK pot connectar :class:`~qilisdk.digital.Circuit` amb el `Perfil "
+"Base QIR <https://github.com/qir-alliance/qir-"
+"spec/blob/main/specification/under_development/profiles/Base_Profile.md>`_"
+" a través de la biblioteca `pyqir <https://pypi.org/project/pyqir/>`_ de "
+"Microsoft. Quatre punts d'entrada es troben a :mod:`qilisdk.utils.qir`:"
+
+#: ../../modules/digital/digital_qir.rst:9
+msgid ""
+":func:`~qilisdk.utils.qir.from_qir` — parse a QIR textual LLVM IR string "
+"into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.qir.from_qir` — analitza una cadena LLVM IR textual"
+" QIR en un Circuit."
+
+#: ../../modules/digital/digital_qir.rst:10
+msgid ""
+":func:`~qilisdk.utils.qir.from_qir_file` — read a ``.ll`` or ``.bc`` file"
+" (dispatched by extension)."
+msgstr ""
+":func:`~qilisdk.utils.qir.from_qir_file` — llegeix un fitxer ``.ll`` o "
+"``.bc`` (segons l'extensió)."
+
+#: ../../modules/digital/digital_qir.rst:11
+msgid ":func:`~qilisdk.utils.qir.to_qir` — serialize a Circuit to QIR textual IR."
+msgstr ""
+":func:`~qilisdk.utils.qir.to_qir` — serialitza un Circuit a IR textual QIR."
+
+#: ../../modules/digital/digital_qir.rst:12
+msgid ""
+":func:`~qilisdk.utils.qir.to_qir_file` — write a ``.ll`` or ``.bc`` file "
+"(dispatched by extension)."
+msgstr ""
+":func:`~qilisdk.utils.qir.to_qir_file` — escriu un fitxer ``.ll`` o "
+"``.bc`` (segons l'extensió)."
+
+#: ../../modules/digital/digital_qir.rst:14
+msgid "The ``pyqir`` dependency is optional; install it with the ``qir`` extra:"
+msgstr ""
+"La dependència ``pyqir`` és opcional; instal·leu-la amb l'extra ``qir``:"
+
+#: ../../modules/digital/digital_qir.rst:21
+msgid "Quick start"
+msgstr "Inici ràpid"
+
+#: ../../modules/digital/digital_qir.rst:38
+msgid ""
+"Reading and writing files dispatches on the extension — ``.ll`` is "
+"treated as textual LLVM IR, ``.bc`` as LLVM bitcode:"
+msgstr ""
+"La lectura i escriptura de fitxers es despacha segons l'extensió — "
+"``.ll`` es tracta com a IR LLVM textual, ``.bc`` com a bitcode LLVM:"
+
+#: ../../modules/digital/digital_qir.rst:51
+msgid "Supported features"
+msgstr "Funcionalitats suportades"
+
+#: ../../modules/digital/digital_qir.rst:53
+msgid ""
+"QiliSDK targets the QIR Base Profile — a flat, statically-allocated "
+"subset of QIR with no classical control flow. The table below maps QIR "
+"features to their support status in QiliSDK:"
+msgstr ""
+"QiliSDK apunta al Perfil Base QIR — un subconjunt pla i estàticament "
+"assignat de QIR sense flux de control clàssic. La taula següent mapeja "
+"les característiques QIR amb el seu estat de suport a QiliSDK:"
+
+#: ../../modules/digital/digital_qir.rst:57
+msgid "✅: The feature is fully supported"
+msgstr "✅: La funcionalitat és totalment suportada"
+
+#: ../../modules/digital/digital_qir.rst:58
+msgid "🟡: The feature is partially supported, see the note for explanation"
+msgstr ""
+"🟡: La funcionalitat és parcialment suportada, vegeu la nota per a més "
+"explicació"
+
+#: ../../modules/digital/digital_qir.rst:59
+msgid "❌: The feature is not supported"
+msgstr "❌: La funcionalitat no està suportada"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "QIR feature"
+msgstr "Característica QIR"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "QiliSDK"
+msgstr "QiliSDK"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "Notes"
+msgstr "Notes"
+
+#: ../../modules/digital/digital_qir.rst:64
+msgid "Base Profile module layout"
+msgstr "Estructura del mòdul del Perfil Base"
+
+#: ../../modules/digital/digital_qir.rst:64
+#: ../../modules/digital/digital_qir.rst:65
+#: ../../modules/digital/digital_qir.rst:66
+#: ../../modules/digital/digital_qir.rst:67
+#: ../../modules/digital/digital_qir.rst:68
+#: ../../modules/digital/digital_qir.rst:69
+#: ../../modules/digital/digital_qir.rst:70
+#: ../../modules/digital/digital_qir.rst:71
+#: ../../modules/digital/digital_qir.rst:72
+#: ../../modules/digital/digital_qir.rst:73
+msgid "✅"
+msgstr "✅"
+
+#: ../../modules/digital/digital_qir.rst:65
+msgid "Entry-point function"
+msgstr "Funció de punt d'entrada"
+
+#: ../../modules/digital/digital_qir.rst:66
+msgid "Static qubit allocation"
+msgstr "Assignació estàtica de qubits"
+
+#: ../../modules/digital/digital_qir.rst:67
+msgid "Static result allocation"
+msgstr "Assignació estàtica de resultats"
+
+#: ../../modules/digital/digital_qir.rst:68
+msgid "``required_num_qubits`` / ``_num_results``"
+msgstr "``required_num_qubits`` / ``_num_results``"
+
+#: ../../modules/digital/digital_qir.rst:69
+msgid "Textual LLVM IR (``.ll``)"
+msgstr "IR LLVM textual (``.ll``)"
+
+#: ../../modules/digital/digital_qir.rst:70
+msgid "LLVM bitcode (``.bc``)"
+msgstr "Bitcode LLVM (``.bc``)"
+
+#: ../../modules/digital/digital_qir.rst:71
+msgid "Single-qubit QIS gates"
+msgstr "Portes QIS d'un sol qubit"
+
+#: ../../modules/digital/digital_qir.rst:71
+#: ../../modules/digital/digital_qir.rst:72
+msgid "1"
+msgstr "1"
+
+#: ../../modules/digital/digital_qir.rst:72
+msgid "Two-qubit QIS gates"
+msgstr "Portes QIS de dos qubits"
+
+#: ../../modules/digital/digital_qir.rst:73
+msgid "Adjoint QIS gates (``s_adj`` / ``t_adj``)"
+msgstr "Portes QIS adjuntes (``s_adj`` / ``t_adj``)"
+
+#: ../../modules/digital/digital_qir.rst:74
+msgid "Parameterized rotations"
+msgstr "Rotacions parametritzades"
+
+#: ../../modules/digital/digital_qir.rst:74
+#: ../../modules/digital/digital_qir.rst:75
+#: ../../modules/digital/digital_qir.rst:76
+msgid "🟡"
+msgstr "🟡"
+
+#: ../../modules/digital/digital_qir.rst:74
+msgid "2"
+msgstr "2"
+
+#: ../../modules/digital/digital_qir.rst:75
+msgid "Measurement (``mz``)"
+msgstr "Mesura (``mz``)"
+
+#: ../../modules/digital/digital_qir.rst:75
+msgid "3"
+msgstr "3"
+
+#: ../../modules/digital/digital_qir.rst:76
+msgid "Multi-qubit measurement grouping"
+msgstr "Agrupació de mesures multi-qubit"
+
+#: ../../modules/digital/digital_qir.rst:76
+msgid "4"
+msgstr "4"
+
+#: ../../modules/digital/digital_qir.rst:77
+msgid "``barrier`` / ``reset``"
+msgstr "``barrier`` / ``reset``"
+
+#: ../../modules/digital/digital_qir.rst:77
+#: ../../modules/digital/digital_qir.rst:78
+#: ../../modules/digital/digital_qir.rst:79
+#: ../../modules/digital/digital_qir.rst:80
+#: ../../modules/digital/digital_qir.rst:81
+#: ../../modules/digital/digital_qir.rst:82
+#: ../../modules/digital/digital_qir.rst:83
+#: ../../modules/digital/digital_qir.rst:84
+msgid "❌"
+msgstr "❌"
+
+#: ../../modules/digital/digital_qir.rst:78
+msgid "``ccx`` and other three-qubit intrinsics"
+msgstr "``ccx`` i altres intrínsecs de tres qubits"
+
+#: ../../modules/digital/digital_qir.rst:78
+#: ../../modules/digital/digital_qir.rst:83
+#: ../../modules/digital/digital_qir.rst:84
+msgid "5"
+msgstr "5"
+
+#: ../../modules/digital/digital_qir.rst:79
+msgid "Adaptive Profile / classical control"
+msgstr "Perfil Adaptatiu / control clàssic"
+
+#: ../../modules/digital/digital_qir.rst:80
+msgid "Branching on measurement results"
+msgstr "Bifurcació en resultats de mesura"
+
+#: ../../modules/digital/digital_qir.rst:81
+msgid "Output recording calls (``rt__*``)"
+msgstr "Crides de gravació de sortida (``rt__*``)"
+
+#: ../../modules/digital/digital_qir.rst:82
+msgid "Dynamic qubit / result management"
+msgstr "Gestió dinàmica de qubits / resultats"
+
+#: ../../modules/digital/digital_qir.rst:83
+msgid "``U1`` / ``U2`` / ``U3``"
+msgstr "``U1`` / ``U2`` / ``U3``"
+
+#: ../../modules/digital/digital_qir.rst:84
+msgid "Arbitrary ``Controlled`` / ``Exponential``"
+msgstr "``Controlled`` / ``Exponential`` arbitrari"
+
+#: ../../modules/digital/digital_qir.rst:88
+msgid "See the \"Supported gates\" table below for the exact intrinsic mapping."
+msgstr ""
+"Consulteu la taula \"Portes suportades\" a continuació per al mapeig "
+"exacte d'intrínsecs."
+
+#: ../../modules/digital/digital_qir.rst:90
+msgid ""
+"Rotation angles are exported as their currently-resolved numeric values. "
+"Base Profile does not support symbolic parameters, so rebind any "
+":class:`~qilisdk.core.Parameter` values to concrete numbers before "
+"calling :func:`~qilisdk.utils.qir.to_qir`."
+msgstr ""
+"Els angles de rotació s'exporten com els seus valors numèrics actualment "
+"resolts. El Perfil Base no admet paràmetres simbòlics, per la qual cosa "
+"vinculeu qualsevol valor de :class:`~qilisdk.core.Parameter` a números "
+"concrets abans de cridar :func:`~qilisdk.utils.qir.to_qir`."
+
+#: ../../modules/digital/digital_qir.rst:95
+msgid ""
+"Only ``mz`` is emitted; mid-circuit measurement followed by classical "
+"control is not supported (and is forbidden by the Base Profile)."
+msgstr ""
+"Només s'emet ``mz``; la mesura a mig circuit seguida de control clàssic "
+"no està suportada (i està prohibida pel Perfil Base)."
+
+#: ../../modules/digital/digital_qir.rst:98
+msgid ""
+"A multi-qubit :class:`~qilisdk.digital.gates.M` is serialized as one "
+"``mz`` call per target qubit. On reparse it comes back as one "
+":class:`~qilisdk.digital.gates.M` per measured qubit — the qubit set is "
+"preserved but the grouping is not."
+msgstr ""
+"Un :class:`~qilisdk.digital.gates.M` multi-qubit es serialitza com una "
+"crida ``mz`` per qubit destí. En reanàlisi torna com un "
+":class:`~qilisdk.digital.gates.M` per qubit mesurat — el conjunt de "
+"qubits es conserva, però no l'agrupació."
+
+#: ../../modules/digital/digital_qir.rst:103
+msgid ""
+"These must be decomposed into supported primitives before export, "
+"otherwise :func:`~qilisdk.utils.qir.to_qir` raises "
+":class:`NotImplementedError`."
+msgstr ""
+"Aquests han de descompondre's en primitius suportats abans d'exportar; "
+"altrament, :func:`~qilisdk.utils.qir.to_qir` llança "
+":class:`NotImplementedError`."
+
+#: ../../modules/digital/digital_qir.rst:107
+msgid "Supported gates"
+msgstr "Portes suportades"
+
+#: ../../modules/digital/digital_qir.rst:109
+msgid ""
+"The exporter maps the following gates onto the standard "
+"``__quantum__qis__*__body`` intrinsics; everything else raises "
+":class:`NotImplementedError` to surface the need for decomposition."
+msgstr ""
+"L'exportador mapeja les portes següents als intrínsecs estàndard "
+"``__quantum__qis__*__body``; tot la resta llança "
+":class:`NotImplementedError` per indicar la necessitat de descomposició."
+
+#: ../../modules/digital/digital_qir.rst:114
+msgid "QiliSDK gate"
+msgstr "Porta QiliSDK"
+
+#: ../../modules/digital/digital_qir.rst:114
+msgid "QIR intrinsic"
+msgstr "Intrínsec QIR"
+
+#: ../../modules/digital/digital_qir.rst:116
+msgid ":class:`~qilisdk.digital.gates.I`"
+msgstr ":class:`~qilisdk.digital.gates.I`"
+
+#: ../../modules/digital/digital_qir.rst:116
+msgid "*(no-op, emitted as nothing)*"
+msgstr "*(sense operació, no s'emet res)*"
+
+#: ../../modules/digital/digital_qir.rst:117
+msgid ":class:`~qilisdk.digital.gates.X` /"
+msgstr ":class:`~qilisdk.digital.gates.X` /"
+
+#: ../../modules/digital/digital_qir.rst:118
+msgid ":class:`~qilisdk.digital.gates.Y` /"
+msgstr ":class:`~qilisdk.digital.gates.Y` /"
+
+#: ../../modules/digital/digital_qir.rst:119
+msgid ":class:`~qilisdk.digital.gates.Z`"
+msgstr ":class:`~qilisdk.digital.gates.Z`"
+
+#: ../../modules/digital/digital_qir.rst:119
+msgid "``__quantum__qis__x/y/z__body``"
+msgstr "``__quantum__qis__x/y/z__body``"
+
+#: ../../modules/digital/digital_qir.rst:120
+msgid ":class:`~qilisdk.digital.gates.H`"
+msgstr ":class:`~qilisdk.digital.gates.H`"
+
+#: ../../modules/digital/digital_qir.rst:120
+msgid "``__quantum__qis__h__body``"
+msgstr "``__quantum__qis__h__body``"
+
+#: ../../modules/digital/digital_qir.rst:121
+msgid ":class:`~qilisdk.digital.gates.S` /"
+msgstr ":class:`~qilisdk.digital.gates.S` /"
+
+#: ../../modules/digital/digital_qir.rst:122
+msgid ":class:`~qilisdk.digital.gates.T`"
+msgstr ":class:`~qilisdk.digital.gates.T`"
+
+#: ../../modules/digital/digital_qir.rst:122
+msgid "``__quantum__qis__s/t__body``"
+msgstr "``__quantum__qis__s/t__body``"
+
+#: ../../modules/digital/digital_qir.rst:123
+msgid "``Adjoint(S)`` / ``Adjoint(T)``"
+msgstr "``Adjoint(S)`` / ``Adjoint(T)``"
+
+#: ../../modules/digital/digital_qir.rst:123
+msgid "``__quantum__qis__s/t__adj``"
+msgstr "``__quantum__qis__s/t__adj``"
+
+#: ../../modules/digital/digital_qir.rst:124
+msgid ":class:`~qilisdk.digital.gates.RX` /"
+msgstr ":class:`~qilisdk.digital.gates.RX` /"
+
+#: ../../modules/digital/digital_qir.rst:125
+msgid ":class:`~qilisdk.digital.gates.RY` /"
+msgstr ":class:`~qilisdk.digital.gates.RY` /"
+
+#: ../../modules/digital/digital_qir.rst:126
+msgid ":class:`~qilisdk.digital.gates.RZ`"
+msgstr ":class:`~qilisdk.digital.gates.RZ`"
+
+#: ../../modules/digital/digital_qir.rst:126
+msgid "``__quantum__qis__rx/ry/rz__body``"
+msgstr "``__quantum__qis__rx/ry/rz__body``"
+
+#: ../../modules/digital/digital_qir.rst:127
+msgid ":class:`~qilisdk.digital.gates.CNOT`"
+msgstr ":class:`~qilisdk.digital.gates.CNOT`"
+
+#: ../../modules/digital/digital_qir.rst:127
+msgid "``__quantum__qis__cnot__body``"
+msgstr "``__quantum__qis__cnot__body``"
+
+#: ../../modules/digital/digital_qir.rst:128
+msgid ":class:`~qilisdk.digital.gates.CZ`"
+msgstr ":class:`~qilisdk.digital.gates.CZ`"
+
+#: ../../modules/digital/digital_qir.rst:128
+msgid "``__quantum__qis__cz__body``"
+msgstr "``__quantum__qis__cz__body``"
+
+#: ../../modules/digital/digital_qir.rst:129
+msgid ":class:`~qilisdk.digital.gates.SWAP`"
+msgstr ":class:`~qilisdk.digital.gates.SWAP`"
+
+#: ../../modules/digital/digital_qir.rst:129
+msgid "``__quantum__qis__swap__body``"
+msgstr "``__quantum__qis__swap__body``"
+
+#: ../../modules/digital/digital_qir.rst:130
+msgid ":class:`~qilisdk.digital.gates.M`"
+msgstr ":class:`~qilisdk.digital.gates.M`"
+
+#: ../../modules/digital/digital_qir.rst:130
+msgid "one ``__quantum__qis__mz__body`` call per target qubit"
+msgstr "una crida ``__quantum__qis__mz__body`` per qubit destí"
+
+#: ../../modules/digital/digital_qir.rst:134
+msgid ""
+"Gates outside this table (``U1`` / ``U2`` / ``U3``, three-qubit "
+"unitaries, arbitrary :class:`~qilisdk.digital.gates.Controlled` / "
+":class:`~qilisdk.digital.gates.Exponential` wrappers) need to be "
+"decomposed into the supported set before export."
+msgstr ""
+"Les portes fora d'aquesta taula (``U1`` / ``U2`` / ``U3``, unitàries de "
+"tres qubits, embolcalls arbitraris de "
+":class:`~qilisdk.digital.gates.Controlled` / "
+":class:`~qilisdk.digital.gates.Exponential`) han de descompondre's en el "
+"conjunt suportat abans d'exportar."
+
+#: ../../modules/digital/digital_qir.rst:140
+msgid "Profile and round-trip notes"
+msgstr "Notes sobre el perfil i el cicle d'anada i tornada"
+
+#: ../../modules/digital/digital_qir.rst:142
+msgid ""
+"Modules are emitted with one entry-point function and statically "
+"allocated qubit and result registers (one result register per qubit), "
+"matching the Base Profile contract."
+msgstr ""
+"Els mòduls s'emeten amb una funció de punt d'entrada i registres de "
+"qubits i resultats assignats estàticament (un registre de resultat per "
+"qubit), seguint el contracte del Perfil Base."
+
+#: ../../modules/digital/digital_qir.rst:145
+msgid ""
+"Round-tripping preserves gate types, qubit indices, and rotation angles. "
+"A multi-qubit :class:`~qilisdk.digital.gates.M` instance is serialized as"
+" one ``mz`` call per target; on parse it comes back as one "
+":class:`~qilisdk.digital.gates.M` per measured qubit (i.e. the qubit set "
+"is preserved but the grouping is not)."
+msgstr ""
+"El cicle d'anada i tornada preserva els tipus de portes, els índexs de "
+"qubits i els angles de rotació. Una instància de "
+":class:`~qilisdk.digital.gates.M` multi-qubit es serialitza com una "
+"crida ``mz`` per destí; en analitzar, torna com un "
+":class:`~qilisdk.digital.gates.M` per qubit mesurat (és a dir, el "
+"conjunt de qubits es conserva, però no l'agrupació)."
+
+#: ../../modules/digital/digital_qir.rst:150
+msgid ""
+"Parameterized rotations are exported with their currently-resolved "
+"numeric angles; Base Profile does not support symbolic parameters, so "
+"rebind any :class:`~qilisdk.core.Parameter` values to concrete numbers "
+"before calling :func:`~qilisdk.utils.qir.to_qir`."
+msgstr ""
+"Les rotacions parametritzades s'exporten amb els seus angles numèrics "
+"actualment resolts; el Perfil Base no admet paràmetres simbòlics, per la "
+"qual cosa vinculeu qualsevol valor de :class:`~qilisdk.core.Parameter` a "
+"números concrets abans de cridar :func:`~qilisdk.utils.qir.to_qir`."

--- a/docs/locale/es/LC_MESSAGES/getting_started/installation.po
+++ b/docs/locale/es/LC_MESSAGES/getting_started/installation.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 14:50+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -28,9 +28,9 @@ msgid ""
 "QiliSDK and its optional extras are distributed via PyPI. Use pip to "
 "install the core package, plus any extra modules you need."
 msgstr ""
-"QiliSDK y sus extras opcionales se distribuyen a través de PyPI. Use pip"
-" para instalar el paquete principal, más cualquier módulo adicional que"
-" necesite."
+"QiliSDK y sus extras opcionales se distribuyen a través de PyPI. Use pip "
+"para instalar el paquete principal, más cualquier módulo adicional que "
+"necesite."
 
 #: ../../getting_started/installation.rst:6
 msgid "**Base package**"
@@ -55,9 +55,9 @@ msgid ""
 "on their official website: https://nvidia.github.io/cuda-"
 "quantum/latest/using/quick_start.html#install-cuda-q"
 msgstr ""
-"El backend CUDA requiere una GPU con aceleración CUDA disponible en su"
-" sistema y los controladores adecuados instalados. Puede encontrar más"
-" información en su sitio web oficial: https://nvidia.github.io/cuda-"
+"El backend CUDA requiere una GPU con aceleración CUDA disponible en su "
+"sistema y los controladores adecuados instalados. Puede encontrar más "
+"información en su sitio web oficial: https://nvidia.github.io/cuda-"
 "quantum/latest/using/quick_start.html#install-cuda-q"
 
 #: ../../getting_started/installation.rst:24
@@ -108,60 +108,100 @@ msgid ""
 "aware that this is not recommended for most users, and we make no "
 "promises that the latest code will be stable."
 msgstr ""
-"El método anterior instalará los binarios precompilados de QiliSDK de la"
-" versión más reciente. Si desea obtener las características más nuevas"
-" (aquellas en las que aún estamos trabajando), puede compilar la biblioteca"
-" desde el código fuente, pero tenga en cuenta que esto no se recomienda"
-" para la mayoría de los usuarios, y no garantizamos que el código más"
-" reciente sea estable."
+"El método anterior instalará los binarios precompilados de QiliSDK de la "
+"versión más reciente. Si desea obtener las características más nuevas "
+"(aquellas en las que aún estamos trabajando), puede compilar la "
+"biblioteca desde el código fuente, pero tenga en cuenta que esto no se "
+"recomienda para la mayoría de los usuarios, y no garantizamos que el "
+"código más reciente sea estable."
 
 #: ../../getting_started/installation.rst:58
 msgid ""
 "Support for Windows is limited, so we recommend using WSL, which can be "
 "installed as per `this guide <https://learn.microsoft.com/en-"
-"us/windows/wsl/install>`__."
+"us/windows/wsl/install>`__. With this you should then following the Linux"
+" instructions below. If you must use pure Windows, the Windows "
+"instructions below should work, although they disable certain code "
+"features (notably some parallelized loops)."
 msgstr ""
-"El soporte para Windows es limitado, por lo que recomendamos usar WSL,"
-" que se puede instalar según `esta guía <https://learn.microsoft.com/en-"
-"us/windows/wsl/install>`__."
+"El soporte para Windows es limitado, por lo que recomendamos usar WSL, "
+"que se puede instalar según `esta guía <https://learn.microsoft.com/en-"
+"us/windows/wsl/install>`__. Con esto, debería seguir las instrucciones de"
+" Linux a continuación. Si debe usar Windows puro, las instrucciones de "
+"Windows a continuación deberían funcionar, aunque deshabilitan ciertas "
+"funciones del código (especialmente algunos bucles paralelizados)."
 
-#: ../../getting_started/installation.rst:61
+#: ../../getting_started/installation.rst:63
 msgid ""
-"First, make sure you have a Python, pip, git, and build-essentials "
-"installed. For Ubuntu/Debian, you can run:"
+"First, make sure you have Python, pip, git, cmake and a C++ compiler "
+"installed:"
 msgstr ""
-"Primero, asegúrese de tener instalados Python, pip, git y build-essentials."
-" Para Ubuntu/Debian, puede ejecutar:"
+"Primero, asegúrese de tener instalados Python, pip, git, cmake y un "
+"compilador de C++:"
 
-#: ../../getting_started/installation.rst:68
-msgid "or on MacOS with:"
-msgstr "o en MacOS con:"
+#: ../../getting_started/installation.rst:67
+#: ../../getting_started/installation.rst:93
+#: ../../getting_started/installation.rst:128
+msgid "Linux"
+msgstr "Linux"
 
-#: ../../getting_started/installation.rst:75
+#: ../../getting_started/installation.rst:74
+#: ../../getting_started/installation.rst:99
+#: ../../getting_started/installation.rst:134
+msgid "Mac OSX"
+msgstr "Mac OSX"
+
+#: ../../getting_started/installation.rst:81
+#: ../../getting_started/installation.rst:105
+#: ../../getting_started/installation.rst:140
+msgid "Windows"
+msgstr "Windows"
+
+#: ../../getting_started/installation.rst:83
+msgid "Install Python via the Microsoft Store."
+msgstr "Instale Python a través de la Microsoft Store."
+
+#: ../../getting_started/installation.rst:85
+msgid "Install Git via https://git-scm.com/install/windows."
+msgstr "Instale Git desde https://git-scm.com/install/windows."
+
+#: ../../getting_started/installation.rst:87
+msgid ""
+"Install C++ build tools by installing the \"C/C++ Extension Pack\" "
+"extension for VSCode."
+msgstr ""
+"Instale las herramientas de compilación de C++ instalando la extensión "
+"\"C/C++ Extension Pack\" para VSCode."
+
+#: ../../getting_started/installation.rst:89
 msgid "Install uv globally with:"
 msgstr "Instale uv globalmente con:"
 
-#: ../../getting_started/installation.rst:81
+#: ../../getting_started/installation.rst:111
 msgid "Then, clone (i.e. download) and enter the repository:"
 msgstr "Luego, clone (es decir, descargue) y acceda al repositorio:"
 
-#: ../../getting_started/installation.rst:88
-msgid "Create a new virtual environment using uv and activate it:"
-msgstr "Cree un nuevo entorno virtual usando uv y actívelo:"
+#: ../../getting_started/installation.rst:118
+msgid "Create a new virtual environment using uv:"
+msgstr "Cree un nuevo entorno virtual usando uv:"
 
-#: ../../getting_started/installation.rst:95
+#: ../../getting_started/installation.rst:124
+msgid "Then activate the environment:"
+msgstr "Luego active el entorno:"
+
+#: ../../getting_started/installation.rst:148
 msgid "To then install QiliSDK into this new environment, run:"
 msgstr "Para instalar QiliSDK en este nuevo entorno, ejecute:"
 
-#: ../../getting_started/installation.rst:101
+#: ../../getting_started/installation.rst:154
 msgid ""
 "If you want to install with extras, you can run the following, adjusting "
 "as needed:"
 msgstr ""
-"Si desea instalar con extras, puede ejecutar lo siguiente, ajustando según"
-" sea necesario:"
+"Si desea instalar con extras, puede ejecutar lo siguiente, ajustando "
+"según sea necesario:"
 
-#: ../../getting_started/installation.rst:107
+#: ../../getting_started/installation.rst:160
 msgid ""
 "You then have an environment with the latest version of QiliSDK "
 "installed. If you want to install other things to the environment you'll "
@@ -170,7 +210,7 @@ msgstr ""
 "Entonces tendrá un entorno con la última versión de QiliSDK instalada. Si"
 " desea instalar otras cosas en el entorno, necesitará usar pip con uv:"
 
-#: ../../getting_started/installation.rst:114
+#: ../../getting_started/installation.rst:167
 msgid "And then to run a Python script within the environment, you can use:"
 msgstr "Y para ejecutar un script de Python dentro del entorno, puede usar:"
 
@@ -188,3 +228,19 @@ msgstr "Y para ejecutar un script de Python dentro del entorno, puede usar:"
 #~ "essentials installed. For Ubuntu/Debian, you"
 #~ " can run:"
 #~ msgstr ""
+
+#~ msgid ""
+#~ "Support for Windows is limited, so "
+#~ "we recommend using WSL, which can "
+#~ "be installed as per `this guide "
+#~ "<https://learn.microsoft.com/en-us/windows/wsl/install>`__."
+#~ msgstr ""
+#~ "El soporte para Windows es limitado, "
+#~ "por lo que recomendamos usar WSL, "
+#~ "que se puede instalar según `esta "
+#~ "guía <https://learn.microsoft.com/en-"
+#~ "us/windows/wsl/install>`__."
+
+#~ msgid "or on MacOS with:"
+#~ msgstr "o en MacOS con:"
+

--- a/docs/locale/es/LC_MESSAGES/modules/core/core_lp_parser.po
+++ b/docs/locale/es/LC_MESSAGES/modules/core/core_lp_parser.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 12:00+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -20,37 +20,48 @@ msgstr ""
 "Generated-By: Babel 2.18.0\n"
 
 #: ../../modules/core/core_lp_parser.rst:2
-msgid "LP File Parser"
-msgstr "Analizador de archivos LP"
+msgid "Linear Programming File Parser and Serializer"
+msgstr "Analizador y Serializador de Archivos de Programación Lineal"
 
 #: ../../modules/core/core_lp_parser.rst:4
 msgid ""
-"QiliSDK ships with a parser for the CPLEX-flavor `LP format "
-"<https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-format-"
-"algebraic-representation>`_, exposed as :func:`~qilisdk.utils.from_lp` "
-"(parse a string) and :func:`~qilisdk.utils.from_lp_file` (read and parse "
-"a file). Both produce a fully-formed :class:`~qilisdk.core.model.Model`."
+"QiliSDK ships with a parser and a serializer for the CPLEX-flavor `LP "
+"format <https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-"
+"format-algebraic-representation>`_. The parser is exposed as "
+":func:`~qilisdk.utils.lp_parser.from_lp` (parse a string) and "
+":func:`~qilisdk.utils.lp_parser.from_lp_file` (read and parse a file); "
+"both produce a fully-formed :class:`~qilisdk.core.model.Model`. The "
+"inverse pair, :func:`~qilisdk.utils.lp_parser.to_lp` and "
+":func:`~qilisdk.utils.lp_parser.to_lp_file`, serializes a "
+":class:`~qilisdk.core.model.Model` back to LP-format text."
 msgstr ""
-"QiliSDK incluye un analizador para el `formato LP "
+"QiliSDK incluye un analizador y un serializador para el `formato LP "
 "<https://www.ibm.com/docs/en/icos/22.1.1?topic=cplex-lp-file-format-"
-"algebraic-representation>`_ en su variante CPLEX, expuesto como "
-":func:`~qilisdk.utils.from_lp` (analiza una cadena) y "
-":func:`~qilisdk.utils.from_lp_file` (lee y analiza un archivo). Ambos "
-"producen un :class:`~qilisdk.core.model.Model` completo."
+"algebraic-representation>`_ en su variante CPLEX. El analizador se expone"
+" como :func:`~qilisdk.utils.lp_parser.from_lp` (analiza una cadena) y "
+":func:`~qilisdk.utils.lp_parser.from_lp_file` (lee y analiza un archivo);"
+" ambos producen un :class:`~qilisdk.core.model.Model` completo. El par "
+"inverso, :func:`~qilisdk.utils.lp_parser.to_lp` y "
+":func:`~qilisdk.utils.lp_parser.to_lp_file`, serializa un "
+":class:`~qilisdk.core.model.Model` de vuelta a texto en formato LP."
 
-#: ../../modules/core/core_lp_parser.rst:10
+#: ../../modules/core/core_lp_parser.rst:14
 msgid "Quick start"
 msgstr "Inicio rápido"
 
-#: ../../modules/core/core_lp_parser.rst:19
+#: ../../modules/core/core_lp_parser.rst:24
 msgid "A small inline example:"
 msgstr "Un pequeño ejemplo en línea:"
 
-#: ../../modules/core/core_lp_parser.rst:40
+#: ../../modules/core/core_lp_parser.rst:45
+msgid "Round-tripping a model back to LP text:"
+msgstr "Serialización de un modelo de vuelta a texto LP:"
+
+#: ../../modules/core/core_lp_parser.rst:55
 msgid "Supported features"
 msgstr "Características soportadas"
 
-#: ../../modules/core/core_lp_parser.rst:42
+#: ../../modules/core/core_lp_parser.rst:57
 msgid ""
 "**Objective sense**: ``Maximize`` / ``Minimize`` (and the ``Max`` / "
 "``Min`` / ``Maximum`` / ``Minimum`` aliases, case-insensitive)."
@@ -59,7 +70,7 @@ msgstr ""
 "``Max`` / ``Min`` / ``Maximum`` / ``Minimum``, sin distinción entre "
 "mayúsculas y minúsculas)."
 
-#: ../../modules/core/core_lp_parser.rst:44
+#: ../../modules/core/core_lp_parser.rst:59
 msgid ""
 "**Section keywords**: ``Subject To`` (also ``subj to``, ``s.t.``, "
 "``st``), ``Bounds``, ``General``, ``Binary``, ``End``."
@@ -67,23 +78,22 @@ msgstr ""
 "**Palabras clave de sección**: ``Subject To`` (también ``subj to``, "
 "``s.t.``, ``st``), ``Bounds``, ``General``, ``Binary``, ``End``."
 
-#: ../../modules/core/core_lp_parser.rst:46
+#: ../../modules/core/core_lp_parser.rst:61
 msgid ""
-"**Objective expressions**: linear and quadratic terms, including "
-"bilinear monomials such as ``x1 * x2`` and parenthesised sub-expressions"
-" like ``- [x + 1]``. Repeated occurrences of the same variable are "
-"aggregated automatically (``x + x`` becomes ``2*x``)."
+"**Objective expressions**: linear and quadratic terms, including bilinear"
+" monomials such as ``x1 * x2`` and parenthesised sub-expressions like ``-"
+" [x + 1]``. Repeated occurrences of the same variable are aggregated "
+"automatically (``x + x`` becomes ``2*x``)."
 msgstr ""
-"**Expresiones del objetivo**: términos lineales y cuadráticos, "
-"incluyendo monomios bilineales como ``x1 * x2`` y subexpresiones entre "
-"corchetes como ``- [x + 1]``. Las apariciones repetidas de una misma "
-"variable se agregan automáticamente (``x + x`` se convierte en "
-"``2*x``)."
+"**Expresiones del objetivo**: términos lineales y cuadráticos, incluyendo"
+" monomios bilineales como ``x1 * x2`` y subexpresiones entre corchetes "
+"como ``- [x + 1]``. Las apariciones repetidas de una misma variable se "
+"agregan automáticamente (``x + x`` se convierte en ``2*x``)."
 
-#: ../../modules/core/core_lp_parser.rst:50
+#: ../../modules/core/core_lp_parser.rst:65
 msgid ""
-"**Constraint senses**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — each maps "
-"to the corresponding :class:`~qilisdk.core.variables.ComparisonTerm`. "
+"**Constraint senses**: ``<``, ``<=``, ``=``, ``>=``, ``>`` — each maps to"
+" the corresponding :class:`~qilisdk.core.variables.ComparisonTerm`. "
 "Constraint labels are optional; missing labels are auto-generated as "
 "``c1``, ``c2``, …"
 msgstr ""
@@ -93,21 +103,21 @@ msgstr ""
 "cuando no se proporcionan, se generan automáticamente como ``c1``, "
 "``c2``, …"
 
-#: ../../modules/core/core_lp_parser.rst:53
+#: ../../modules/core/core_lp_parser.rst:68
 msgid ""
 "**Bounds**: two-sided ranges (``-2.5 <= x <= 7.5``), open sides via "
 "``+inf`` / ``-infinity``, and the ``free`` shorthand for unbounded "
 "variables."
 msgstr ""
-"**Cotas**: rangos de dos lados (``-2.5 <= x <= 7.5``), extremos "
-"abiertos mediante ``+inf`` / ``-infinity``, y el atajo ``free`` para "
-"variables sin restricciones."
+"**Cotas**: rangos de dos lados (``-2.5 <= x <= 7.5``), extremos abiertos "
+"mediante ``+inf`` / ``-infinity``, y el atajo ``free`` para variables sin"
+" restricciones."
 
-#: ../../modules/core/core_lp_parser.rst:55
+#: ../../modules/core/core_lp_parser.rst:70
 msgid "**Variable domains**:"
 msgstr "**Dominios de variables**:"
 
-#: ../../modules/core/core_lp_parser.rst:57
+#: ../../modules/core/core_lp_parser.rst:72
 msgid ""
 "Variables listed in ``Binary`` are "
 ":class:`~qilisdk.core.variables.BinaryVariable`."
@@ -115,7 +125,7 @@ msgstr ""
 "Las variables listadas en ``Binary`` son "
 ":class:`~qilisdk.core.variables.BinaryVariable`."
 
-#: ../../modules/core/core_lp_parser.rst:58
+#: ../../modules/core/core_lp_parser.rst:73
 msgid ""
 "Variables listed in ``General`` are integer "
 ":class:`~qilisdk.core.variables.Variable` with "
@@ -124,10 +134,10 @@ msgid ""
 msgstr ""
 "Las variables listadas en ``General`` son "
 ":class:`~qilisdk.core.variables.Variable` enteras con "
-":attr:`~qilisdk.core.variables.Domain.INTEGER`. Las cotas declaradas "
-"en la sección ``Bounds`` se conservan."
+":attr:`~qilisdk.core.variables.Domain.INTEGER`. Las cotas declaradas en "
+"la sección ``Bounds`` se conservan."
 
-#: ../../modules/core/core_lp_parser.rst:61
+#: ../../modules/core/core_lp_parser.rst:76
 msgid ""
 "Variables that appear only in the ``Bounds`` section are continuous "
 "(``Domain.REAL``) with the declared bounds."
@@ -135,71 +145,139 @@ msgstr ""
 "Las variables que solo aparecen en la sección ``Bounds`` son continuas "
 "(``Domain.REAL``) con las cotas declaradas."
 
-#: ../../modules/core/core_lp_parser.rst:63
+#: ../../modules/core/core_lp_parser.rst:78
 msgid ""
 "Variables that appear only inside expressions are auto-created as "
 "continuous with the LP-format default bounds ``[0, +inf)``."
 msgstr ""
 "Las variables que solo aparecen dentro de expresiones se crean "
-"automáticamente como continuas con las cotas por defecto del formato "
-"LP, ``[0, +inf)``."
+"automáticamente como continuas con las cotas por defecto del formato LP, "
+"``[0, +inf)``."
 
-#: ../../modules/core/core_lp_parser.rst:66
+#: ../../modules/core/core_lp_parser.rst:81
 msgid ""
-"**Comments**: backslash (``\\\\``) starts a line comment that runs to "
-"the end of the line."
+"**Comments**: backslash (``\\\\``) starts a line comment that runs to the"
+" end of the line."
 msgstr ""
 "**Comentarios**: la barra invertida (``\\\\``) inicia un comentario de "
 "línea que se extiende hasta el final de la misma."
 
-#: ../../modules/core/core_lp_parser.rst:70
+#: ../../modules/core/core_lp_parser.rst:85
+msgid "Serialization conventions"
+msgstr "Convenciones de serialización"
+
+#: ../../modules/core/core_lp_parser.rst:87
+msgid ""
+":func:`~qilisdk.utils.lp_parser.to_lp` produces grammar-compliant output "
+"that :func:`~qilisdk.utils.lp_parser.from_lp` can read back. Notable "
+"conventions:"
+msgstr ""
+":func:`~qilisdk.utils.lp_parser.to_lp` produce una salida conforme a la "
+"gramàtica que :func:`~qilisdk.utils.lp_parser.from_lp` puede volver a "
+"leer. Convenciones destacadas:"
+
+#: ../../modules/core/core_lp_parser.rst:90
+msgid ""
+"Quadratic and bilinear monomials are expanded into explicit products (``x"
+" * x``, ``x * y``) since the LP grammar accepted by the parser has no "
+"``^`` operator."
+msgstr ""
+"Los monomios cuadráticos y bilineales se expanden en productos explícitos "
+"(``x * x``, ``x * y``) ya que la gramática LP aceptada por el analizador "
+"no tiene el operador ``^``."
+
+#: ../../modules/core/core_lp_parser.rst:93
+msgid ""
+"A unit coefficient is omitted (``x`` rather than ``1 x``); a ``-1`` "
+"coefficient becomes a leading ``- x``."
+msgstr ""
+"Un coeficiente unitario se omite (``x`` en lugar de ``1 x``); un "
+"coeficiente ``-1`` se convierte en un ``- x`` inicial."
+
+#: ../../modules/core/core_lp_parser.rst:95
+msgid ""
+"Constraint right-hand sides are emitted as a single constant — any "
+"constant appearing on the left-hand side is folded into the rhs first."
+msgstr ""
+"Los lados derechos de las restricciones se emiten como una única constante"
+" — cualquier constante que aparezca en el lado izquierdo se pliega al rhs "
+"primero."
+
+#: ../../modules/core/core_lp_parser.rst:97
+msgid ""
+"Unbounded continuous variables are emitted as ``var free``; one-sided "
+"bounds use ``var >= lo`` or ``-infinity <= var <= up``. Variables "
+"matching the LP default of ``[0, +inf)`` are omitted from the ``Bounds`` "
+"section entirely."
+msgstr ""
+"Las variables continuas sin acotar se emiten como ``var free``; las cotas "
+"unilaterales usan ``var >= lo`` o ``-infinity <= var <= up``. Las "
+"variables que coinciden con el valor por defecto LP de ``[0, +inf)`` se "
+"omiten completamente de la sección ``Bounds``."
+
+#: ../../modules/core/core_lp_parser.rst:100
+msgid ""
+":class:`~qilisdk.core.variables.BinaryVariable` variables are listed in "
+"the ``Binary`` section; integer ones in ``General`` (with their bounds, "
+"if any)."
+msgstr ""
+"Las variables :class:`~qilisdk.core.variables.BinaryVariable` se listan "
+"en la sección ``Binary``; las enteras en ``General`` (con sus cotas, si "
+"las hay)."
+
+#: ../../modules/core/core_lp_parser.rst:104
 msgid "Worked example"
 msgstr "Ejemplo desarrollado"
 
-#: ../../modules/core/core_lp_parser.rst:96
-msgid ""
-"Parsing it returns a :class:`~qilisdk.core.model.Model` with:"
-msgstr ""
-"Su análisis devuelve un :class:`~qilisdk.core.model.Model` con:"
+#: ../../modules/core/core_lp_parser.rst:129
+msgid "Parsing it returns a :class:`~qilisdk.core.model.Model` with:"
+msgstr "Su análisis devuelve un :class:`~qilisdk.core.model.Model` con:"
 
-#: ../../modules/core/core_lp_parser.rst:98
+#: ../../modules/core/core_lp_parser.rst:131
 msgid ""
 "five real-valued variables (``x1``, ``x2``, ``x3``, ``x4`` plus auto-"
 "typed ones, plus integer ``y``),"
 msgstr ""
-"cinco variables de valor real (``x1``, ``x2``, ``x3``, ``x4`` además "
-"de las creadas automáticamente, junto con la entera ``y``),"
+"cinco variables de valor real (``x1``, ``x2``, ``x3``, ``x4`` además de "
+"las creadas automáticamente, junto con la entera ``y``),"
 
-#: ../../modules/core/core_lp_parser.rst:100
+#: ../../modules/core/core_lp_parser.rst:133
 msgid "two binary variables (``b1``, ``b2``),"
 msgstr "dos variables binarias (``b1``, ``b2``),"
 
-#: ../../modules/core/core_lp_parser.rst:101
-msgid ""
-"a maximization objective with linear, bilinear, and parenthesised "
-"terms,"
+#: ../../modules/core/core_lp_parser.rst:134
+msgid "a maximization objective with linear, bilinear, and parenthesised terms,"
 msgstr ""
-"un objetivo de maximización con términos lineales, bilineales y "
-"agrupados entre corchetes,"
+"un objetivo de maximización con términos lineales, bilineales y agrupados"
+" entre corchetes,"
 
-#: ../../modules/core/core_lp_parser.rst:102
-msgid ""
-"three labelled constraints covering the ``<=``, ``>=``, and ``=`` "
-"senses."
+#: ../../modules/core/core_lp_parser.rst:135
+msgid "three labelled constraints covering the ``<=``, ``>=``, and ``=`` senses."
 msgstr ""
-"tres restricciones etiquetadas que cubren los sentidos ``<=``, ``>=`` "
-"y ``=``."
+"tres restricciones etiquetadas que cubren los sentidos ``<=``, ``>=`` y "
+"``=``."
 
-#: ../../modules/core/core_lp_parser.rst:104
+#: ../../modules/core/core_lp_parser.rst:137
 msgid ""
 "The resulting model can be inspected, evaluated against a sample with "
-":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, or "
-"converted to a QUBO via :meth:`Model.to_qubo "
-"<qilisdk.core.model.Model.to_qubo>` like any other model built directly "
-"with the symbolic API."
+":meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, or converted "
+"to a QUBO via :meth:`Model.to_qubo <qilisdk.core.model.Model.to_qubo>` "
+"like any other model built directly with the symbolic API. Passing the "
+"model to :func:`~qilisdk.utils.lp_parser.to_lp` yields an LP-format "
+"string that, when fed back through "
+":func:`~qilisdk.utils.lp_parser.from_lp`, reconstructs an equivalent "
+"model."
 msgstr ""
 "El modelo resultante puede inspeccionarse, evaluarse sobre una muestra "
 "con :meth:`Model.evaluate <qilisdk.core.model.Model.evaluate>`, o "
 "convertirse a QUBO mediante :meth:`Model.to_qubo "
-"<qilisdk.core.model.Model.to_qubo>` como cualquier otro modelo "
-"construido directamente con la API simbólica."
+"<qilisdk.core.model.Model.to_qubo>` como cualquier otro modelo construido"
+" directamente con la API simbólica. Pasar el modelo a "
+":func:`~qilisdk.utils.lp_parser.to_lp` produce una cadena en formato LP "
+"que, al ser procesada de nuevo por "
+":func:`~qilisdk.utils.lp_parser.from_lp`, reconstruye un modelo "
+"equivalente."
+
+#~ msgid "LP File Parser"
+#~ msgstr "Analizador de archivos LP"
+

--- a/docs/locale/es/LC_MESSAGES/modules/core/core_overview.po
+++ b/docs/locale/es/LC_MESSAGES/modules/core/core_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -34,8 +34,8 @@ msgstr ""
 "La capa :mod:`qilisdk.core` sustenta tanto la pila digital como la "
 "analógica. Proporciona variables simbólicas, modelos de optimización, "
 "tensores cuánticos dispersos y el mixin "
-":mod:`~qilisdk.core.parameterizable.Parameterizable` utilizado en todo "
-"el SDK."
+":mod:`~qilisdk.core.parameterizable.Parameterizable` utilizado en todo el"
+" SDK."
 
 #: ../../modules/core/core_overview.rst:8
 msgid "Highlights:"
@@ -61,20 +61,26 @@ msgstr ""
 
 #: ../../modules/core/core_overview.rst:12
 msgid ":doc:`core_model` to build constrained optimization programs."
-msgstr ":doc:`core_model` para construir programas de optimización con restricciones."
+msgstr ""
+":doc:`core_model` para construir programas de optimización con "
+"restricciones."
 
 #: ../../modules/core/core_overview.rst:13
-msgid ":doc:`core_lp_parser` to load models from LP-format files."
+#, fuzzy
+msgid ""
+":doc:`core_lp_parser` to load models from and write models to LP-format "
+"files."
 msgstr ":doc:`core_lp_parser` para cargar modelos desde archivos en formato LP."
 
 #: ../../modules/core/core_overview.rst:14
 msgid ":doc:`core_qubo` to convert models to QUBO format."
 msgstr ":doc:`core_qubo` para convertir modelos al formato QUBO."
 
-#: ../../modules/core/core_overview.rst:14
+#: ../../modules/core/core_overview.rst:15
 msgid ""
 ":doc:`core_qtensor` to manage sparse quantum objects, such as states and "
 "operators."
 msgstr ""
 ":doc:`core_qtensor` para gestionar objetos cuánticos dispersos, como "
 "estados y operadores."
+

--- a/docs/locale/es/LC_MESSAGES/modules/digital/digital_circuits.po
+++ b/docs/locale/es/LC_MESSAGES/modules/digital/digital_circuits.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -89,7 +89,9 @@ msgstr "**Salida:**"
 
 #: ../../modules/digital/digital_circuits.rst:95
 msgid "You can also retrieve a list containing only the current parameter values:"
-msgstr "También se puede obtener una lista que contenga solo los valores actuales de los parámetros:"
+msgstr ""
+"También se puede obtener una lista que contenga solo los valores actuales"
+" de los parámetros:"
 
 #: ../../modules/digital/digital_circuits.rst:109
 msgid "To update parameters by their keys:"
@@ -126,26 +128,28 @@ msgstr ""
 "integrado de la librería (incluida la fuente predeterminada incluida, si "
 "está disponible). Se pueden **omitir todos los valores predeterminados** "
 "pasando un :class:`~qilisdk.utils.visualization.style.CircuitStyle` "
-"personalizado, que limita el estilo a la llamada específica sin modificar "
-"la configuración global de Matplotlib."
+"personalizado, que limita el estilo a la llamada específica sin modificar"
+" la configuración global de Matplotlib."
 
 #: ../../modules/digital/digital_circuits.rst:145
 msgid "**Output**"
 msgstr "**Salida**"
 
-#: ../../modules/digital/digital_circuits.rst:148
+#: ../../modules/digital/digital_circuits.rst:147
 msgid "Example digital circuit rendered with Circuit.draw"
 msgstr "Ejemplo de circuito digital renderizado con Circuit.draw"
 
-#: ../../modules/digital/digital_circuits.rst:152
+#: ../../modules/digital/digital_circuits.rst:151
 msgid "Example circuit produced by ``circuit.draw()``."
 msgstr "Circuito de ejemplo producido por ``circuit.draw()``."
 
-#: ../../modules/digital/digital_circuits.rst:155
-msgid "Saving to a file"
-msgstr "Guardar en un archivo"
+#: ../../modules/digital/digital_circuits.rst:153
+msgid ""
+"The plot can also be saved to a file by providing a filepath to the draw "
+"method:"
+msgstr ""
 
-#: ../../modules/digital/digital_circuits.rst:163
+#: ../../modules/digital/digital_circuits.rst:161
 msgid ""
 "Custom styling with "
 ":class:`~qilisdk.utils.visualization.style.CircuitStyle`"
@@ -153,7 +157,7 @@ msgstr ""
 "Estilo personalizado con "
 ":class:`~qilisdk.utils.visualization.style.CircuitStyle`"
 
-#: ../../modules/digital/digital_circuits.rst:165
+#: ../../modules/digital/digital_circuits.rst:163
 msgid ""
 "Create a style object to control theme, fonts, spacing, DPI, labels, and "
 "more. Passing this object to "
@@ -163,15 +167,15 @@ msgid ""
 "as possible by changing the parameter **layout** to *\"normal\"* "
 "(default) or *\"compact\"* respectively."
 msgstr ""
-"Cree un objeto de estilo para controlar el tema, las fuentes, el espaciado, "
-"el DPI, las etiquetas y más. Pasar este objeto a "
+"Cree un objeto de estilo para controlar el tema, las fuentes, el "
+"espaciado, el DPI, las etiquetas y más. Pasar este objeto a "
 ":meth:`~qilisdk.digital.circuit.Circuit.draw` anula los valores "
-"predeterminados de la librería para esa llamada. También se puede cambiar "
-"si el orden del dibujo sigue el orden de adición o si compacta las capas "
-"al máximo cambiando el parámetro **layout** a *\"normal\"* (predeterminado) "
-"o *\"compact\"* respectivamente."
+"predeterminados de la librería para esa llamada. También se puede cambiar"
+" si el orden del dibujo sigue el orden de adición o si compacta las capas"
+" al máximo cambiando el parámetro **layout** a *\"normal\"* "
+"(predeterminado) o *\"compact\"* respectivamente."
 
-#: ../../modules/digital/digital_circuits.rst:209
+#: ../../modules/digital/digital_circuits.rst:207
 msgid ""
 "``CircuitStyle`` fields map directly to the renderer's layout and font "
 "configuration. In particular, you can switch fonts in two ways: (1) "
@@ -188,11 +192,11 @@ msgstr ""
 "``fontfamily=[...]`` para usar fuentes del sistema. Ambos enfoques solo "
 "afectan a la llamada de dibujo actual."
 
-#: ../../modules/digital/digital_circuits.rst:215
+#: ../../modules/digital/digital_circuits.rst:213
 msgid "Parameter Utilities"
 msgstr "Utilidades de parámetros"
 
-#: ../../modules/digital/digital_circuits.rst:217
+#: ../../modules/digital/digital_circuits.rst:215
 msgid ""
 "Circuits collect the symbolic parameters contributed by each gate. Beyond"
 " the quick examples above, you can query names, current values, and "
@@ -202,7 +206,7 @@ msgstr ""
 "puerta. Más allá de los ejemplos rápidos anteriores, se pueden consultar "
 "nombres, valores actuales y límites, o actualizarlos de forma selectiva:"
 
-#: ../../modules/digital/digital_circuits.rst:242
+#: ../../modules/digital/digital_circuits.rst:240
 msgid ""
 "These helpers make it straightforward to plug the circuit into classical "
 "optimization loops while keeping parameter metadata synchronized."
@@ -211,7 +215,7 @@ msgstr ""
 "optimización clásica manteniendo sincronizados los metadatos de los "
 "parámetros."
 
-#: ../../modules/digital/digital_circuits.rst:247
+#: ../../modules/digital/digital_circuits.rst:245
 msgid ""
 "Parameterized gates and circuits expose parameter information through "
 "``get_parameter_names``, ``get_parameters``, ``get_parameter_values``, "
@@ -223,3 +227,7 @@ msgstr ""
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Ir a un subtítulo específico de una página."
+
+#~ msgid "Saving to a file"
+#~ msgstr "Guardar en un archivo"
+

--- a/docs/locale/es/LC_MESSAGES/modules/digital/digital_overview.po
+++ b/docs/locale/es/LC_MESSAGES/modules/digital/digital_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -51,4 +51,13 @@ msgstr ""
 
 #: ../../modules/digital/digital_overview.rst:9
 msgid ":doc:`digital_ansatz`: Predefined circuits that can serve as Ansätze."
-msgstr ":doc:`digital_ansatz`: Circuitos predefinidos que pueden servir como Ansätze."
+msgstr ""
+":doc:`digital_ansatz`: Circuitos predefinidos que pueden servir como "
+"Ansätze."
+
+#: ../../modules/digital/digital_overview.rst:10
+msgid ""
+":doc:`digital_qir`: Import and export circuits to / from the QIR Base "
+"Profile."
+msgstr ""
+

--- a/docs/locale/es/LC_MESSAGES/modules/digital/digital_qasm.po
+++ b/docs/locale/es/LC_MESSAGES/modules/digital/digital_qasm.po
@@ -1,0 +1,476 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Qilimanjaro Quantum Tech
+# This file is distributed under the same license as the QiliSDK package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: QiliSDK \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../modules/digital/digital_qasm.rst:2
+msgid "OpenQASM Import and Export"
+msgstr "Importación y Exportación OpenQASM"
+
+#: ../../modules/digital/digital_qasm.rst:4
+msgid ""
+"QiliSDK can bridge :class:`~qilisdk.digital.Circuit` and both OpenQASM "
+"2.0 and OpenQASM 3.0 via the following entry-points in "
+":mod:`qilisdk.utils.openqasm`:"
+msgstr ""
+"QiliSDK puede conectar :class:`~qilisdk.digital.Circuit` tanto con "
+"OpenQASM 2.0 como con OpenQASM 3.0 a través de los siguientes puntos de "
+"entrada en :mod:`qilisdk.utils.openqasm`:"
+
+#: ../../modules/digital/digital_qasm.rst:7
+msgid "**OpenQASM 2.0**"
+msgstr "**OpenQASM 2.0**"
+
+#: ../../modules/digital/digital_qasm.rst:9
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2` — parse an OpenQASM "
+"2.0 string into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2` — analiza una cadena"
+" OpenQASM 2.0 en un Circuit."
+
+#: ../../modules/digital/digital_qasm.rst:10
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2_file` — read a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2_file` — lee un "
+"archivo ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:11
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2` — serialize a Circuit "
+"to an OpenQASM 2.0 string."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2` — serializa un Circuit"
+" a una cadena OpenQASM 2.0."
+
+#: ../../modules/digital/digital_qasm.rst:12
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2_file` — write a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2_file` — escribe un "
+"archivo ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:14
+msgid "**OpenQASM 3.0**"
+msgstr "**OpenQASM 3.0**"
+
+#: ../../modules/digital/digital_qasm.rst:16
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3` — parse an OpenQASM "
+"3.0 string into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3` — analiza una cadena"
+" OpenQASM 3.0 en un Circuit."
+
+#: ../../modules/digital/digital_qasm.rst:17
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3_file` — read a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3_file` — lee un "
+"archivo ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:18
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3` — serialize a Circuit "
+"to an OpenQASM 3.0 string."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3` — serializa un Circuit"
+" a una cadena OpenQASM 3.0."
+
+#: ../../modules/digital/digital_qasm.rst:19
+msgid ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3_file` — write a "
+"``.qasm`` file."
+msgstr ""
+":func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3_file` — escribe un "
+"archivo ``.qasm``."
+
+#: ../../modules/digital/digital_qasm.rst:21
+msgid ""
+"The ``openqasm3`` dependency is optional; install it with the "
+"``openqasm`` extra:"
+msgstr ""
+"La dependencia ``openqasm3`` es opcional; instálela con el extra "
+"``openqasm``:"
+
+#: ../../modules/digital/digital_qasm.rst:28
+msgid "Quick start"
+msgstr "Inicio rápido"
+
+#: ../../modules/digital/digital_qasm.rst:50
+msgid "Reading and writing files:"
+msgstr "Lectura y escritura de archivos:"
+
+#: ../../modules/digital/digital_qasm.rst:64
+msgid "OpenQASM 3.0 supported features"
+msgstr "Características soportadas de OpenQASM 3.0"
+
+#: ../../modules/digital/digital_qasm.rst:66
+msgid "✅: The feature is fully supported"
+msgstr "✅: La característica está totalmente soportada"
+
+#: ../../modules/digital/digital_qasm.rst:67
+msgid "🟡: The feature is partially supported, see the note for explanation"
+msgstr ""
+"🟡: La característica está parcialmente soportada, vea la nota para más "
+"explicación"
+
+#: ../../modules/digital/digital_qasm.rst:68
+msgid "❌: The feature is not supported"
+msgstr "❌: La característica no está soportada"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "OpenQASM 3 feature"
+msgstr "Característica OpenQASM 3"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "QiliSDK"
+msgstr "QiliSDK"
+
+#: ../../modules/digital/digital_qasm.rst:71
+msgid "Notes"
+msgstr "Notas"
+
+#: ../../modules/digital/digital_qasm.rst:73
+msgid "comments"
+msgstr "comentarios"
+
+#: ../../modules/digital/digital_qasm.rst:73
+#: ../../modules/digital/digital_qasm.rst:74
+#: ../../modules/digital/digital_qasm.rst:75
+#: ../../modules/digital/digital_qasm.rst:76
+#: ../../modules/digital/digital_qasm.rst:77
+#: ../../modules/digital/digital_qasm.rst:85
+#: ../../modules/digital/digital_qasm.rst:86
+#: ../../modules/digital/digital_qasm.rst:87
+#: ../../modules/digital/digital_qasm.rst:89
+#: ../../modules/digital/digital_qasm.rst:92
+#: ../../modules/digital/digital_qasm.rst:97
+#: ../../modules/digital/digital_qasm.rst:100
+#: ../../modules/digital/digital_qasm.rst:102
+msgid "✅"
+msgstr "✅"
+
+#: ../../modules/digital/digital_qasm.rst:74
+msgid "QASM version string"
+msgstr "Cadena de versión QASM"
+
+#: ../../modules/digital/digital_qasm.rst:75
+msgid "include"
+msgstr "include"
+
+#: ../../modules/digital/digital_qasm.rst:76
+msgid "unicode names"
+msgstr "nombres unicode"
+
+#: ../../modules/digital/digital_qasm.rst:77
+msgid "qubit"
+msgstr "qubit"
+
+#: ../../modules/digital/digital_qasm.rst:78
+msgid "bit"
+msgstr "bit"
+
+#: ../../modules/digital/digital_qasm.rst:78
+#: ../../modules/digital/digital_qasm.rst:79
+#: ../../modules/digital/digital_qasm.rst:80
+#: ../../modules/digital/digital_qasm.rst:81
+#: ../../modules/digital/digital_qasm.rst:82
+#: ../../modules/digital/digital_qasm.rst:83
+#: ../../modules/digital/digital_qasm.rst:84
+#: ../../modules/digital/digital_qasm.rst:90
+#: ../../modules/digital/digital_qasm.rst:93
+#: ../../modules/digital/digital_qasm.rst:98
+#: ../../modules/digital/digital_qasm.rst:101
+#: ../../modules/digital/digital_qasm.rst:103
+#: ../../modules/digital/digital_qasm.rst:105
+#: ../../modules/digital/digital_qasm.rst:106
+#: ../../modules/digital/digital_qasm.rst:107
+#: ../../modules/digital/digital_qasm.rst:108
+#: ../../modules/digital/digital_qasm.rst:109
+#: ../../modules/digital/digital_qasm.rst:110
+#: ../../modules/digital/digital_qasm.rst:111
+#: ../../modules/digital/digital_qasm.rst:112
+#: ../../modules/digital/digital_qasm.rst:113
+#: ../../modules/digital/digital_qasm.rst:114
+#: ../../modules/digital/digital_qasm.rst:115
+#: ../../modules/digital/digital_qasm.rst:116
+#: ../../modules/digital/digital_qasm.rst:117
+#: ../../modules/digital/digital_qasm.rst:119
+#: ../../modules/digital/digital_qasm.rst:120
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "🟡"
+msgstr "🟡"
+
+#: ../../modules/digital/digital_qasm.rst:78
+#: ../../modules/digital/digital_qasm.rst:79
+#: ../../modules/digital/digital_qasm.rst:80
+#: ../../modules/digital/digital_qasm.rst:81
+#: ../../modules/digital/digital_qasm.rst:82
+#: ../../modules/digital/digital_qasm.rst:83
+#: ../../modules/digital/digital_qasm.rst:84
+#: ../../modules/digital/digital_qasm.rst:90
+#: ../../modules/digital/digital_qasm.rst:93
+#: ../../modules/digital/digital_qasm.rst:98
+#: ../../modules/digital/digital_qasm.rst:101
+#: ../../modules/digital/digital_qasm.rst:106
+#: ../../modules/digital/digital_qasm.rst:107
+#: ../../modules/digital/digital_qasm.rst:108
+#: ../../modules/digital/digital_qasm.rst:109
+#: ../../modules/digital/digital_qasm.rst:110
+#: ../../modules/digital/digital_qasm.rst:111
+#: ../../modules/digital/digital_qasm.rst:112
+#: ../../modules/digital/digital_qasm.rst:113
+#: ../../modules/digital/digital_qasm.rst:114
+#: ../../modules/digital/digital_qasm.rst:115
+#: ../../modules/digital/digital_qasm.rst:116
+#: ../../modules/digital/digital_qasm.rst:117
+#: ../../modules/digital/digital_qasm.rst:119
+#: ../../modules/digital/digital_qasm.rst:120
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "1"
+msgstr "1"
+
+#: ../../modules/digital/digital_qasm.rst:79
+msgid "bool"
+msgstr "bool"
+
+#: ../../modules/digital/digital_qasm.rst:80
+msgid "int"
+msgstr "int"
+
+#: ../../modules/digital/digital_qasm.rst:81
+msgid "uint"
+msgstr "uint"
+
+#: ../../modules/digital/digital_qasm.rst:82
+msgid "float"
+msgstr "float"
+
+#: ../../modules/digital/digital_qasm.rst:83
+msgid "angle"
+msgstr "angle"
+
+#: ../../modules/digital/digital_qasm.rst:84
+msgid "complex"
+msgstr "complex"
+
+#: ../../modules/digital/digital_qasm.rst:85
+msgid "const"
+msgstr "const"
+
+#: ../../modules/digital/digital_qasm.rst:86
+msgid "pi/π/tau/τ/euler/ℇ"
+msgstr "pi/π/tau/τ/euler/ℇ"
+
+#: ../../modules/digital/digital_qasm.rst:87
+msgid "Aliasing: ``let``"
+msgstr "Alias: ``let``"
+
+#: ../../modules/digital/digital_qasm.rst:88
+msgid "register concatenation"
+msgstr "concatenación de registros"
+
+#: ../../modules/digital/digital_qasm.rst:88
+#: ../../modules/digital/digital_qasm.rst:91
+#: ../../modules/digital/digital_qasm.rst:94
+#: ../../modules/digital/digital_qasm.rst:95
+#: ../../modules/digital/digital_qasm.rst:96
+#: ../../modules/digital/digital_qasm.rst:99
+#: ../../modules/digital/digital_qasm.rst:104
+#: ../../modules/digital/digital_qasm.rst:118
+#: ../../modules/digital/digital_qasm.rst:122
+msgid "❌"
+msgstr "❌"
+
+#: ../../modules/digital/digital_qasm.rst:89
+msgid "casting (``expr.Cast``)"
+msgstr "conversión de tipo (``expr.Cast``)"
+
+#: ../../modules/digital/digital_qasm.rst:90
+msgid "duration"
+msgstr "duration"
+
+#: ../../modules/digital/digital_qasm.rst:91
+msgid "durationof"
+msgstr "durationof"
+
+#: ../../modules/digital/digital_qasm.rst:92
+msgid "ns/μs/us/ms/s/dt"
+msgstr "ns/μs/us/ms/s/dt"
+
+#: ../../modules/digital/digital_qasm.rst:93
+msgid "stretch (``expr.Stretch``)"
+msgstr "stretch (``expr.Stretch``)"
+
+#: ../../modules/digital/digital_qasm.rst:94
+msgid "delay"
+msgstr "delay"
+
+#: ../../modules/digital/digital_qasm.rst:95
+msgid "barrier"
+msgstr "barrier"
+
+#: ../../modules/digital/digital_qasm.rst:96
+msgid "box"
+msgstr "box"
+
+#: ../../modules/digital/digital_qasm.rst:97
+msgid "built-in ``U``"
+msgstr "``U`` integrada"
+
+#: ../../modules/digital/digital_qasm.rst:98
+msgid "gate definition"
+msgstr "definición de puerta"
+
+#: ../../modules/digital/digital_qasm.rst:99
+msgid "gphase"
+msgstr "gphase"
+
+#: ../../modules/digital/digital_qasm.rst:100
+msgid "``ctrl @``"
+msgstr "``ctrl @``"
+
+#: ../../modules/digital/digital_qasm.rst:101
+msgid "``negctrl @``"
+msgstr "``negctrl @``"
+
+#: ../../modules/digital/digital_qasm.rst:102
+msgid "``inv @``"
+msgstr "``inv @``"
+
+#: ../../modules/digital/digital_qasm.rst:103
+msgid "``pow(k) @``"
+msgstr "``pow(k) @``"
+
+#: ../../modules/digital/digital_qasm.rst:103
+msgid "1, 2"
+msgstr "1, 2"
+
+#: ../../modules/digital/digital_qasm.rst:104
+msgid "reset"
+msgstr "reset"
+
+#: ../../modules/digital/digital_qasm.rst:105
+msgid "measure"
+msgstr "measure"
+
+#: ../../modules/digital/digital_qasm.rst:105
+msgid "3"
+msgstr "3"
+
+#: ../../modules/digital/digital_qasm.rst:106
+msgid "bit operations"
+msgstr "operaciones de bits"
+
+#: ../../modules/digital/digital_qasm.rst:107
+msgid "boolean operations"
+msgstr "operaciones booleanas"
+
+#: ../../modules/digital/digital_qasm.rst:108
+msgid "arithmetic expressions"
+msgstr "expresiones aritméticas"
+
+#: ../../modules/digital/digital_qasm.rst:109
+msgid "comparisons"
+msgstr "comparaciones"
+
+#: ../../modules/digital/digital_qasm.rst:110
+msgid "``if``"
+msgstr "``if``"
+
+#: ../../modules/digital/digital_qasm.rst:111
+msgid "``else``"
+msgstr "``else``"
+
+#: ../../modules/digital/digital_qasm.rst:112
+msgid "``else if``"
+msgstr "``else if``"
+
+#: ../../modules/digital/digital_qasm.rst:113
+msgid "for loops"
+msgstr "bucles for"
+
+#: ../../modules/digital/digital_qasm.rst:114
+msgid "switch"
+msgstr "switch"
+
+#: ../../modules/digital/digital_qasm.rst:115
+msgid "while loops"
+msgstr "bucles while"
+
+#: ../../modules/digital/digital_qasm.rst:116
+msgid "``continue``"
+msgstr "``continue``"
+
+#: ../../modules/digital/digital_qasm.rst:117
+msgid "``break``"
+msgstr "``break``"
+
+#: ../../modules/digital/digital_qasm.rst:118
+msgid "extern"
+msgstr "extern"
+
+#: ../../modules/digital/digital_qasm.rst:119
+msgid "def subroutines"
+msgstr "subrutinas def"
+
+#: ../../modules/digital/digital_qasm.rst:120
+msgid "return"
+msgstr "return"
+
+#: ../../modules/digital/digital_qasm.rst:121
+msgid "input"
+msgstr "input"
+
+#: ../../modules/digital/digital_qasm.rst:122
+msgid "output"
+msgstr "output"
+
+#: ../../modules/digital/digital_qasm.rst:125
+msgid ""
+"Reading these constructs is fully supported, but the expressions are not "
+"stored in the :class:`~qilisdk.digital.Circuit` object and will not be "
+"written back out when converting to OpenQASM. For example, declaring "
+"``int x = 5;`` causes ``x`` to be evaluated and used during parsing, but "
+"the variable declaration will not appear in the resulting circuit object "
+"or in any re-exported QASM string."
+msgstr ""
+"La lectura de estas construcciones está totalmente soportada, pero las "
+"expresiones no se almacenan en el objeto :class:`~qilisdk.digital.Circuit`"
+" y no se escribirán al convertir a OpenQASM. Por ejemplo, declarar "
+"``int x = 5;`` hace que ``x`` sea evaluada y usada durante el análisis, "
+"pero la declaración de variable no aparecerá en el objeto de circuito "
+"resultante ni en ninguna cadena QASM reexportada."
+
+#: ../../modules/digital/digital_qasm.rst:132
+msgid ""
+"``pow(k) @`` is only supported when ``k`` is an integer; it is "
+"implemented by repeated gate application."
+msgstr ""
+"``pow(k) @`` solo está soportado cuando ``k`` es un entero; se implementa"
+" mediante aplicación repetida de la puerta."
+
+#: ../../modules/digital/digital_qasm.rst:135
+msgid "Mid-circuit measurements are not supported in QiliSDK."
+msgstr "Las mediciones a mitad de circuito no están soportadas en QiliSDK."

--- a/docs/locale/es/LC_MESSAGES/modules/digital/digital_qir.po
+++ b/docs/locale/es/LC_MESSAGES/modules/digital/digital_qir.po
@@ -1,0 +1,485 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Qilimanjaro Quantum Tech
+# This file is distributed under the same license as the QiliSDK package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: QiliSDK \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-20 15:11+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../modules/digital/digital_qir.rst:2
+msgid "QIR Import and Export"
+msgstr "Importación y Exportación QIR"
+
+#: ../../modules/digital/digital_qir.rst:4
+msgid ""
+"QiliSDK can bridge :class:`~qilisdk.digital.Circuit` and the `QIR Base "
+"Profile <https://github.com/qir-alliance/qir-"
+"spec/blob/main/specification/under_development/profiles/Base_Profile.md>`_"
+" via Microsoft's `pyqir <https://pypi.org/project/pyqir/>`_ library. Four"
+" entry-points live in :mod:`qilisdk.utils.qir`:"
+msgstr ""
+"QiliSDK puede conectar :class:`~qilisdk.digital.Circuit` con el `Perfil "
+"Base QIR <https://github.com/qir-alliance/qir-"
+"spec/blob/main/specification/under_development/profiles/Base_Profile.md>`_"
+" a través de la biblioteca `pyqir <https://pypi.org/project/pyqir/>`_ de "
+"Microsoft. Cuatro puntos de entrada se encuentran en "
+":mod:`qilisdk.utils.qir`:"
+
+#: ../../modules/digital/digital_qir.rst:9
+msgid ""
+":func:`~qilisdk.utils.qir.from_qir` — parse a QIR textual LLVM IR string "
+"into a Circuit."
+msgstr ""
+":func:`~qilisdk.utils.qir.from_qir` — analiza una cadena LLVM IR textual "
+"QIR en un Circuit."
+
+#: ../../modules/digital/digital_qir.rst:10
+msgid ""
+":func:`~qilisdk.utils.qir.from_qir_file` — read a ``.ll`` or ``.bc`` file"
+" (dispatched by extension)."
+msgstr ""
+":func:`~qilisdk.utils.qir.from_qir_file` — lee un archivo ``.ll`` o "
+"``.bc`` (según la extensión)."
+
+#: ../../modules/digital/digital_qir.rst:11
+msgid ":func:`~qilisdk.utils.qir.to_qir` — serialize a Circuit to QIR textual IR."
+msgstr ""
+":func:`~qilisdk.utils.qir.to_qir` — serializa un Circuit a IR textual QIR."
+
+#: ../../modules/digital/digital_qir.rst:12
+msgid ""
+":func:`~qilisdk.utils.qir.to_qir_file` — write a ``.ll`` or ``.bc`` file "
+"(dispatched by extension)."
+msgstr ""
+":func:`~qilisdk.utils.qir.to_qir_file` — escribe un archivo ``.ll`` o "
+"``.bc`` (según la extensión)."
+
+#: ../../modules/digital/digital_qir.rst:14
+msgid "The ``pyqir`` dependency is optional; install it with the ``qir`` extra:"
+msgstr "La dependencia ``pyqir`` es opcional; instálela con el extra ``qir``:"
+
+#: ../../modules/digital/digital_qir.rst:21
+msgid "Quick start"
+msgstr "Inicio rápido"
+
+#: ../../modules/digital/digital_qir.rst:38
+msgid ""
+"Reading and writing files dispatches on the extension — ``.ll`` is "
+"treated as textual LLVM IR, ``.bc`` as LLVM bitcode:"
+msgstr ""
+"La lectura y escritura de archivos se despacha según la extensión — "
+"``.ll`` se trata como IR LLVM textual, ``.bc`` como bitcode LLVM:"
+
+#: ../../modules/digital/digital_qir.rst:51
+msgid "Supported features"
+msgstr "Características soportadas"
+
+#: ../../modules/digital/digital_qir.rst:53
+msgid ""
+"QiliSDK targets the QIR Base Profile — a flat, statically-allocated "
+"subset of QIR with no classical control flow. The table below maps QIR "
+"features to their support status in QiliSDK:"
+msgstr ""
+"QiliSDK apunta al Perfil Base QIR — un subconjunto plano y estáticamente "
+"asignado de QIR sin flujo de control clásico. La tabla siguiente mapea las"
+" características QIR con su estado de soporte en QiliSDK:"
+
+#: ../../modules/digital/digital_qir.rst:57
+msgid "✅: The feature is fully supported"
+msgstr "✅: La característica está totalmente soportada"
+
+#: ../../modules/digital/digital_qir.rst:58
+msgid "🟡: The feature is partially supported, see the note for explanation"
+msgstr ""
+"🟡: La característica está parcialmente soportada, vea la nota para más "
+"explicación"
+
+#: ../../modules/digital/digital_qir.rst:59
+msgid "❌: The feature is not supported"
+msgstr "❌: La característica no está soportada"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "QIR feature"
+msgstr "Característica QIR"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "QiliSDK"
+msgstr "QiliSDK"
+
+#: ../../modules/digital/digital_qir.rst:62
+msgid "Notes"
+msgstr "Notas"
+
+#: ../../modules/digital/digital_qir.rst:64
+msgid "Base Profile module layout"
+msgstr "Estructura del módulo del Perfil Base"
+
+#: ../../modules/digital/digital_qir.rst:64
+#: ../../modules/digital/digital_qir.rst:65
+#: ../../modules/digital/digital_qir.rst:66
+#: ../../modules/digital/digital_qir.rst:67
+#: ../../modules/digital/digital_qir.rst:68
+#: ../../modules/digital/digital_qir.rst:69
+#: ../../modules/digital/digital_qir.rst:70
+#: ../../modules/digital/digital_qir.rst:71
+#: ../../modules/digital/digital_qir.rst:72
+#: ../../modules/digital/digital_qir.rst:73
+msgid "✅"
+msgstr "✅"
+
+#: ../../modules/digital/digital_qir.rst:65
+msgid "Entry-point function"
+msgstr "Función de punto de entrada"
+
+#: ../../modules/digital/digital_qir.rst:66
+msgid "Static qubit allocation"
+msgstr "Asignación estática de qubits"
+
+#: ../../modules/digital/digital_qir.rst:67
+msgid "Static result allocation"
+msgstr "Asignación estática de resultados"
+
+#: ../../modules/digital/digital_qir.rst:68
+msgid "``required_num_qubits`` / ``_num_results``"
+msgstr "``required_num_qubits`` / ``_num_results``"
+
+#: ../../modules/digital/digital_qir.rst:69
+msgid "Textual LLVM IR (``.ll``)"
+msgstr "IR LLVM textual (``.ll``)"
+
+#: ../../modules/digital/digital_qir.rst:70
+msgid "LLVM bitcode (``.bc``)"
+msgstr "Bitcode LLVM (``.bc``)"
+
+#: ../../modules/digital/digital_qir.rst:71
+msgid "Single-qubit QIS gates"
+msgstr "Puertas QIS de un solo qubit"
+
+#: ../../modules/digital/digital_qir.rst:71
+#: ../../modules/digital/digital_qir.rst:72
+msgid "1"
+msgstr "1"
+
+#: ../../modules/digital/digital_qir.rst:72
+msgid "Two-qubit QIS gates"
+msgstr "Puertas QIS de dos qubits"
+
+#: ../../modules/digital/digital_qir.rst:73
+msgid "Adjoint QIS gates (``s_adj`` / ``t_adj``)"
+msgstr "Puertas QIS adjuntas (``s_adj`` / ``t_adj``)"
+
+#: ../../modules/digital/digital_qir.rst:74
+msgid "Parameterized rotations"
+msgstr "Rotaciones parametrizadas"
+
+#: ../../modules/digital/digital_qir.rst:74
+#: ../../modules/digital/digital_qir.rst:75
+#: ../../modules/digital/digital_qir.rst:76
+msgid "🟡"
+msgstr "🟡"
+
+#: ../../modules/digital/digital_qir.rst:74
+msgid "2"
+msgstr "2"
+
+#: ../../modules/digital/digital_qir.rst:75
+msgid "Measurement (``mz``)"
+msgstr "Medición (``mz``)"
+
+#: ../../modules/digital/digital_qir.rst:75
+msgid "3"
+msgstr "3"
+
+#: ../../modules/digital/digital_qir.rst:76
+msgid "Multi-qubit measurement grouping"
+msgstr "Agrupación de mediciones multi-qubit"
+
+#: ../../modules/digital/digital_qir.rst:76
+msgid "4"
+msgstr "4"
+
+#: ../../modules/digital/digital_qir.rst:77
+msgid "``barrier`` / ``reset``"
+msgstr "``barrier`` / ``reset``"
+
+#: ../../modules/digital/digital_qir.rst:77
+#: ../../modules/digital/digital_qir.rst:78
+#: ../../modules/digital/digital_qir.rst:79
+#: ../../modules/digital/digital_qir.rst:80
+#: ../../modules/digital/digital_qir.rst:81
+#: ../../modules/digital/digital_qir.rst:82
+#: ../../modules/digital/digital_qir.rst:83
+#: ../../modules/digital/digital_qir.rst:84
+msgid "❌"
+msgstr "❌"
+
+#: ../../modules/digital/digital_qir.rst:78
+msgid "``ccx`` and other three-qubit intrinsics"
+msgstr "``ccx`` y otros intrínsecos de tres qubits"
+
+#: ../../modules/digital/digital_qir.rst:78
+#: ../../modules/digital/digital_qir.rst:83
+#: ../../modules/digital/digital_qir.rst:84
+msgid "5"
+msgstr "5"
+
+#: ../../modules/digital/digital_qir.rst:79
+msgid "Adaptive Profile / classical control"
+msgstr "Perfil Adaptativo / control clásico"
+
+#: ../../modules/digital/digital_qir.rst:80
+msgid "Branching on measurement results"
+msgstr "Bifurcación en resultados de medición"
+
+#: ../../modules/digital/digital_qir.rst:81
+msgid "Output recording calls (``rt__*``)"
+msgstr "Llamadas de grabación de salida (``rt__*``)"
+
+#: ../../modules/digital/digital_qir.rst:82
+msgid "Dynamic qubit / result management"
+msgstr "Gestión dinámica de qubits / resultados"
+
+#: ../../modules/digital/digital_qir.rst:83
+msgid "``U1`` / ``U2`` / ``U3``"
+msgstr "``U1`` / ``U2`` / ``U3``"
+
+#: ../../modules/digital/digital_qir.rst:84
+msgid "Arbitrary ``Controlled`` / ``Exponential``"
+msgstr "``Controlled`` / ``Exponential`` arbitrario"
+
+#: ../../modules/digital/digital_qir.rst:88
+msgid "See the \"Supported gates\" table below for the exact intrinsic mapping."
+msgstr ""
+"Consulte la tabla \"Puertas soportadas\" a continuación para el mapeo "
+"exacto de intrínsecos."
+
+#: ../../modules/digital/digital_qir.rst:90
+msgid ""
+"Rotation angles are exported as their currently-resolved numeric values. "
+"Base Profile does not support symbolic parameters, so rebind any "
+":class:`~qilisdk.core.Parameter` values to concrete numbers before "
+"calling :func:`~qilisdk.utils.qir.to_qir`."
+msgstr ""
+"Los ángulos de rotación se exportan como sus valores numéricos actualmente"
+" resueltos. El Perfil Base no admite parámetros simbólicos, por lo que "
+"vincule cualquier valor de :class:`~qilisdk.core.Parameter` a números "
+"concretos antes de llamar a :func:`~qilisdk.utils.qir.to_qir`."
+
+#: ../../modules/digital/digital_qir.rst:95
+msgid ""
+"Only ``mz`` is emitted; mid-circuit measurement followed by classical "
+"control is not supported (and is forbidden by the Base Profile)."
+msgstr ""
+"Solo se emite ``mz``; la medición a mitad de circuito seguida de control "
+"clásico no está soportada (y está prohibida por el Perfil Base)."
+
+#: ../../modules/digital/digital_qir.rst:98
+msgid ""
+"A multi-qubit :class:`~qilisdk.digital.gates.M` is serialized as one "
+"``mz`` call per target qubit. On reparse it comes back as one "
+":class:`~qilisdk.digital.gates.M` per measured qubit — the qubit set is "
+"preserved but the grouping is not."
+msgstr ""
+"Un :class:`~qilisdk.digital.gates.M` multi-qubit se serializa como una "
+"llamada ``mz`` por qubit destino. Al reanalizarlo, vuelve como un "
+":class:`~qilisdk.digital.gates.M` por qubit medido — el conjunto de "
+"qubits se conserva, pero no la agrupación."
+
+#: ../../modules/digital/digital_qir.rst:103
+msgid ""
+"These must be decomposed into supported primitives before export, "
+"otherwise :func:`~qilisdk.utils.qir.to_qir` raises "
+":class:`NotImplementedError`."
+msgstr ""
+"Estos deben descomponerse en primitivos soportados antes de exportar; de "
+"lo contrario, :func:`~qilisdk.utils.qir.to_qir` lanza "
+":class:`NotImplementedError`."
+
+#: ../../modules/digital/digital_qir.rst:107
+msgid "Supported gates"
+msgstr "Puertas soportadas"
+
+#: ../../modules/digital/digital_qir.rst:109
+msgid ""
+"The exporter maps the following gates onto the standard "
+"``__quantum__qis__*__body`` intrinsics; everything else raises "
+":class:`NotImplementedError` to surface the need for decomposition."
+msgstr ""
+"El exportador mapea las siguientes puertas a los intrínsecos estándar "
+"``__quantum__qis__*__body``; todo lo demás lanza "
+":class:`NotImplementedError` para indicar la necesidad de descomposición."
+
+#: ../../modules/digital/digital_qir.rst:114
+msgid "QiliSDK gate"
+msgstr "Puerta QiliSDK"
+
+#: ../../modules/digital/digital_qir.rst:114
+msgid "QIR intrinsic"
+msgstr "Intrínseco QIR"
+
+#: ../../modules/digital/digital_qir.rst:116
+msgid ":class:`~qilisdk.digital.gates.I`"
+msgstr ":class:`~qilisdk.digital.gates.I`"
+
+#: ../../modules/digital/digital_qir.rst:116
+msgid "*(no-op, emitted as nothing)*"
+msgstr "*(sin operación, no se emite nada)*"
+
+#: ../../modules/digital/digital_qir.rst:117
+msgid ":class:`~qilisdk.digital.gates.X` /"
+msgstr ":class:`~qilisdk.digital.gates.X` /"
+
+#: ../../modules/digital/digital_qir.rst:118
+msgid ":class:`~qilisdk.digital.gates.Y` /"
+msgstr ":class:`~qilisdk.digital.gates.Y` /"
+
+#: ../../modules/digital/digital_qir.rst:119
+msgid ":class:`~qilisdk.digital.gates.Z`"
+msgstr ":class:`~qilisdk.digital.gates.Z`"
+
+#: ../../modules/digital/digital_qir.rst:119
+msgid "``__quantum__qis__x/y/z__body``"
+msgstr "``__quantum__qis__x/y/z__body``"
+
+#: ../../modules/digital/digital_qir.rst:120
+msgid ":class:`~qilisdk.digital.gates.H`"
+msgstr ":class:`~qilisdk.digital.gates.H`"
+
+#: ../../modules/digital/digital_qir.rst:120
+msgid "``__quantum__qis__h__body``"
+msgstr "``__quantum__qis__h__body``"
+
+#: ../../modules/digital/digital_qir.rst:121
+msgid ":class:`~qilisdk.digital.gates.S` /"
+msgstr ":class:`~qilisdk.digital.gates.S` /"
+
+#: ../../modules/digital/digital_qir.rst:122
+msgid ":class:`~qilisdk.digital.gates.T`"
+msgstr ":class:`~qilisdk.digital.gates.T`"
+
+#: ../../modules/digital/digital_qir.rst:122
+msgid "``__quantum__qis__s/t__body``"
+msgstr "``__quantum__qis__s/t__body``"
+
+#: ../../modules/digital/digital_qir.rst:123
+msgid "``Adjoint(S)`` / ``Adjoint(T)``"
+msgstr "``Adjoint(S)`` / ``Adjoint(T)``"
+
+#: ../../modules/digital/digital_qir.rst:123
+msgid "``__quantum__qis__s/t__adj``"
+msgstr "``__quantum__qis__s/t__adj``"
+
+#: ../../modules/digital/digital_qir.rst:124
+msgid ":class:`~qilisdk.digital.gates.RX` /"
+msgstr ":class:`~qilisdk.digital.gates.RX` /"
+
+#: ../../modules/digital/digital_qir.rst:125
+msgid ":class:`~qilisdk.digital.gates.RY` /"
+msgstr ":class:`~qilisdk.digital.gates.RY` /"
+
+#: ../../modules/digital/digital_qir.rst:126
+msgid ":class:`~qilisdk.digital.gates.RZ`"
+msgstr ":class:`~qilisdk.digital.gates.RZ`"
+
+#: ../../modules/digital/digital_qir.rst:126
+msgid "``__quantum__qis__rx/ry/rz__body``"
+msgstr "``__quantum__qis__rx/ry/rz__body``"
+
+#: ../../modules/digital/digital_qir.rst:127
+msgid ":class:`~qilisdk.digital.gates.CNOT`"
+msgstr ":class:`~qilisdk.digital.gates.CNOT`"
+
+#: ../../modules/digital/digital_qir.rst:127
+msgid "``__quantum__qis__cnot__body``"
+msgstr "``__quantum__qis__cnot__body``"
+
+#: ../../modules/digital/digital_qir.rst:128
+msgid ":class:`~qilisdk.digital.gates.CZ`"
+msgstr ":class:`~qilisdk.digital.gates.CZ`"
+
+#: ../../modules/digital/digital_qir.rst:128
+msgid "``__quantum__qis__cz__body``"
+msgstr "``__quantum__qis__cz__body``"
+
+#: ../../modules/digital/digital_qir.rst:129
+msgid ":class:`~qilisdk.digital.gates.SWAP`"
+msgstr ":class:`~qilisdk.digital.gates.SWAP`"
+
+#: ../../modules/digital/digital_qir.rst:129
+msgid "``__quantum__qis__swap__body``"
+msgstr "``__quantum__qis__swap__body``"
+
+#: ../../modules/digital/digital_qir.rst:130
+msgid ":class:`~qilisdk.digital.gates.M`"
+msgstr ":class:`~qilisdk.digital.gates.M`"
+
+#: ../../modules/digital/digital_qir.rst:130
+msgid "one ``__quantum__qis__mz__body`` call per target qubit"
+msgstr "una llamada ``__quantum__qis__mz__body`` por qubit destino"
+
+#: ../../modules/digital/digital_qir.rst:134
+msgid ""
+"Gates outside this table (``U1`` / ``U2`` / ``U3``, three-qubit "
+"unitaries, arbitrary :class:`~qilisdk.digital.gates.Controlled` / "
+":class:`~qilisdk.digital.gates.Exponential` wrappers) need to be "
+"decomposed into the supported set before export."
+msgstr ""
+"Las puertas fuera de esta tabla (``U1`` / ``U2`` / ``U3``, unitarias de "
+"tres qubits, envoltorios arbitrarios de "
+":class:`~qilisdk.digital.gates.Controlled` / "
+":class:`~qilisdk.digital.gates.Exponential`) deben descomponerse en el "
+"conjunto soportado antes de exportar."
+
+#: ../../modules/digital/digital_qir.rst:140
+msgid "Profile and round-trip notes"
+msgstr "Notas sobre el perfil y el ciclo de ida y vuelta"
+
+#: ../../modules/digital/digital_qir.rst:142
+msgid ""
+"Modules are emitted with one entry-point function and statically "
+"allocated qubit and result registers (one result register per qubit), "
+"matching the Base Profile contract."
+msgstr ""
+"Los módulos se emiten con una función de punto de entrada y registros de "
+"qubits y resultados asignados estáticamente (un registro de resultado por "
+"qubit), siguiendo el contrato del Perfil Base."
+
+#: ../../modules/digital/digital_qir.rst:145
+msgid ""
+"Round-tripping preserves gate types, qubit indices, and rotation angles. "
+"A multi-qubit :class:`~qilisdk.digital.gates.M` instance is serialized as"
+" one ``mz`` call per target; on parse it comes back as one "
+":class:`~qilisdk.digital.gates.M` per measured qubit (i.e. the qubit set "
+"is preserved but the grouping is not)."
+msgstr ""
+"El ciclo de ida y vuelta preserva los tipos de puertas, los índices de "
+"qubits y los ángulos de rotación. Una instancia de "
+":class:`~qilisdk.digital.gates.M` multi-qubit se serializa como una "
+"llamada ``mz`` por destino; al analizar, vuelve como un "
+":class:`~qilisdk.digital.gates.M` por qubit medido (es decir, el conjunto"
+" de qubits se conserva, pero no la agrupación)."
+
+#: ../../modules/digital/digital_qir.rst:150
+msgid ""
+"Parameterized rotations are exported with their currently-resolved "
+"numeric angles; Base Profile does not support symbolic parameters, so "
+"rebind any :class:`~qilisdk.core.Parameter` values to concrete numbers "
+"before calling :func:`~qilisdk.utils.qir.to_qir`."
+msgstr ""
+"Las rotaciones parametrizadas se exportan con sus ángulos numéricos "
+"actualmente resueltos; el Perfil Base no admite parámetros simbólicos, "
+"por lo que vincule cualquier valor de :class:`~qilisdk.core.Parameter` a "
+"números concretos antes de llamar a :func:`~qilisdk.utils.qir.to_qir`."

--- a/docs/modules/core/core_lp_parser.rst
+++ b/docs/modules/core/core_lp_parser.rst
@@ -13,6 +13,7 @@ inverse pair, :func:`~qilisdk.utils.lp_parser.to_lp` and
 Quick start
 ^^^^^^^^^^^
 
+.. SKIP
 .. code-block:: python
 
     from qilisdk.utils.lp_parser import from_lp_file

--- a/docs/modules/digital/digital.rst
+++ b/docs/modules/digital/digital.rst
@@ -12,3 +12,4 @@ Digital
     digital_qaoa
     digital_trotter
     digital_qir
+    digital_qasm

--- a/docs/modules/digital/digital_circuits.rst
+++ b/docs/modules/digital/digital_circuits.rst
@@ -144,15 +144,13 @@ confines styling to the specific call without modifying global Matplotlib settin
 
 **Output**
 
-
 .. figure:: /_static/circuit.png
     :alt: Example digital circuit rendered with Circuit.draw
     :align: center
 
     Example circuit produced by ``circuit.draw()``.
 
-Saving to a file
-^^^^^^^^^^^^^^^^
+The plot can also be saved to a file by providing a filepath to the draw method:
 
 .. code-block:: python
 

--- a/docs/modules/digital/digital_qasm.rst
+++ b/docs/modules/digital/digital_qasm.rst
@@ -1,0 +1,135 @@
+OpenQASM Import and Export
+--------------------------
+
+QiliSDK can bridge :class:`~qilisdk.digital.Circuit` and both OpenQASM 2.0 and
+OpenQASM 3.0 via the following entry-points in :mod:`qilisdk.utils.openqasm`:
+
+**OpenQASM 2.0**
+
+- :func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2` — parse an OpenQASM 2.0 string into a Circuit.
+- :func:`~qilisdk.utils.openqasm.openqasm2.from_qasm2_file` — read a ``.qasm`` file.
+- :func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2` — serialize a Circuit to an OpenQASM 2.0 string.
+- :func:`~qilisdk.utils.openqasm.openqasm2.to_qasm2_file` — write a ``.qasm`` file.
+
+**OpenQASM 3.0**
+
+- :func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3` — parse an OpenQASM 3.0 string into a Circuit.
+- :func:`~qilisdk.utils.openqasm.openqasm3.from_qasm3_file` — read a ``.qasm`` file.
+- :func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3` — serialize a Circuit to an OpenQASM 3.0 string.
+- :func:`~qilisdk.utils.openqasm.openqasm3.to_qasm3_file` — write a ``.qasm`` file.
+
+The ``openqasm3`` dependency is optional; install it with the ``openqasm`` extra:
+
+.. code-block:: bash
+
+    pip install qilisdk[openqasm]
+
+Quick start
+^^^^^^^^^^^
+
+.. code-block:: python
+
+    from qilisdk.digital import CNOT, Circuit, H, M
+    from qilisdk.utils.openqasm import to_qasm2, from_qasm2, to_qasm3, from_qasm3
+
+    circuit = Circuit(2)
+    circuit.add(H(0))
+    circuit.add(CNOT(0, 1))
+    circuit.add(M(0, 1))
+
+    # OpenQASM 2.0
+    qasm2_text = to_qasm2(circuit)
+    print(qasm2_text)
+    reparsed = from_qasm2(qasm2_text)
+
+    # OpenQASM 3.0
+    qasm3_text = to_qasm3(circuit)
+    print(qasm3_text)
+    reparsed = from_qasm3(qasm3_text)
+
+Reading and writing files:
+
+.. code-block:: python
+
+    from qilisdk.utils.openqasm import to_qasm2_file, from_qasm2_file
+    from qilisdk.utils.openqasm import to_qasm3_file, from_qasm3_file
+
+    to_qasm2_file(circuit, "bell.qasm")
+    same_circuit = from_qasm2_file("bell.qasm")
+
+    to_qasm3_file(circuit, "bell3.qasm")
+    same_circuit = from_qasm3_file("bell3.qasm")
+
+OpenQASM 3.0 supported features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ✅: The feature is fully supported
+- 🟡: The feature is partially supported, see the note for explanation
+- ❌: The feature is not supported
+
+============================  ============  =====
+OpenQASM 3 feature            QiliSDK       Notes
+============================  ============  =====
+comments                      ✅
+QASM version string           ✅
+include                       ✅
+unicode names                 ✅
+qubit                         ✅
+bit                           🟡            1
+bool                          🟡            1
+int                           🟡            1
+uint                          🟡            1
+float                         🟡            1
+angle                         🟡            1
+complex                       🟡            1
+const                         ✅
+pi/π/tau/τ/euler/ℇ            ✅
+Aliasing: ``let``             ✅
+register concatenation        ❌
+casting (``expr.Cast``)       ✅
+duration                      🟡            1
+durationof                    ❌
+ns/μs/us/ms/s/dt              ✅
+stretch (``expr.Stretch``)    🟡            1
+delay                         ❌
+barrier                       ❌
+box                           ❌
+built-in ``U``                ✅
+gate definition               🟡            1
+gphase                        ❌
+``ctrl @``                    ✅
+``negctrl @``                 🟡            1
+``inv @``                     ✅
+``pow(k) @``                  🟡            1, 2
+reset                         ❌
+measure                       🟡            3
+bit operations                🟡            1
+boolean operations            🟡            1
+arithmetic expressions        🟡            1
+comparisons                   🟡            1
+``if``                        🟡            1
+``else``                      🟡            1
+``else if``                   🟡            1
+for loops                     🟡            1
+switch                        🟡            1
+while loops                   🟡            1
+``continue``                  🟡            1
+``break``                     🟡            1
+extern                        ❌
+def subroutines               🟡            1
+return                        🟡            1
+input                         🟡            1
+output                        ❌
+============================  ============  =====
+
+1) Reading these constructs is fully supported, but the expressions are not
+   stored in the :class:`~qilisdk.digital.Circuit` object and will not be
+   written back out when converting to OpenQASM. For example, declaring
+   ``int x = 5;`` causes ``x`` to be evaluated and used during parsing, but
+   the variable declaration will not appear in the resulting circuit object or
+   in any re-exported QASM string.
+
+2) ``pow(k) @`` is only supported when ``k`` is an integer; it is implemented
+   by repeated gate application.
+
+3) Mid-circuit measurements are not supported in QiliSDK.

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -16,11 +16,14 @@ ORIG_DIR=$(pwd)
 
 # Change to the root directory of the project
 cd "$(dirname "$(dirname "$(realpath "$0")")")"
+cd .tmp
+mkdir -p .docs_test
+cd .docs_test
 
 TMPFILE=$(mktemp /tmp/docs_test_XXXXXX.py)
 trap "rm -f $TMPFILE" EXIT
 
-for file in $( { find docs/ -name "*.rst"; find . -maxdepth 2 -name "*.md" -not -path './.venv/*' -not -path './node_modules/*'; } | sort ); do
+for file in $( { find ../../docs/ -name "*.rst"; find . -maxdepth 2 -name "*.md" -not -path './.venv/*' -not -path './node_modules/*'; } | sort ); do
 
     # Use Python to extract and concatenate all Python code blocks, then run them.
     # RST: code-block:: python, skip with '.. SKIP' on the preceding line.
@@ -147,6 +150,9 @@ done
 echo ""
 echo "Note: skip a code block by adding '.. SKIP' immediately before a '.. code-block:: python' directive (RST), or '<!-- SKIP -->' immediately before a '\`\`\`python' fence (MD)."
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+
+cd ../..
+rm -rf .tmp/.docs_test
 
 # Return to the original directory
 cd "$ORIG_DIR"

--- a/src/qilisdk/utils/openqasm/openqasm3.py
+++ b/src/qilisdk/utils/openqasm/openqasm3.py
@@ -598,15 +598,17 @@ class OpenQasmParser:
         qubits_without_controls = qubits[num_controls_total:]
 
         # The gate itself
-        if gate_name == "cx":
-            gates_to_return.append(CNOT(*qubits_without_controls))
+        if gate_name == "cx" or (gate_name == "x" and "ctrl" in modifiers):
+            gates_to_return.append(CNOT(*qubits))
+            modifiers = [modifier for modifier in modifiers if modifier != "ctrl"]
         elif gate_name == "cz":
-            gates_to_return.append(CZ(*qubits_without_controls))
+            gates_to_return.append(CZ(*qubits))
+            modifiers = [modifier for modifier in modifiers if modifier != "ctrl"]
         else:
             for qubit in qubits_without_controls:
                 gates_to_return.append(self._str_to_gate(gate_name, qubit, arguments))
 
-        # Add controls if we have them
+        # Apply modifiers if we have them
         main_gates = copy(gates_to_return)
         gates_to_return = []
         for j in range(len(main_gates)):
@@ -983,8 +985,7 @@ class OpenQasmParser:
     def _handle_statement_quantum_measurement(self, statement: QuantumMeasurementStatement) -> None:
         qubit_statement = statement.measure.qubit
         qubits_to_measure = self._evaluate_register(qubit_statement)
-        for qubit in qubits_to_measure:
-            self.gates_to_add.append(M(qubit))
+        self.gates_to_add.append(M(*qubits_to_measure))
         if hasattr(statement, "target") and statement.target is not None:
             raise ValueError("Measurement statements with targets are not currently supported")
 
@@ -1170,12 +1171,17 @@ class OpenQasmParser:
             qasm3 += f"qubit[{circuit.nqubits}] q;\n"
         for gate in circuit.gates:
             qasm_gate_name = gate.name.lower()
+            if gate.name == "CNOT":
+                qasm_gate_name = "x"
             qasm_parameter_str = ""
             if gate.is_parameterized:
                 qasm_parameter_str = "(" + ", ".join([str(param) for param in gate.get_parameter_values()]) + ")"
             qasm_control_str = "".join(["ctrl @ " for _ in gate.control_qubits])
             qasm_qubits_str = ", ".join([f"q[{qb}]" for qb in gate.qubits])
-            qasm_gate_string = f"{qasm_control_str} {qasm_gate_name}{qasm_parameter_str} {qasm_qubits_str}"
+            if gate.name == "M":
+                qasm_gate_name = "measure"
+                qasm_qubits_str = "q[" + ",".join([str(qb) for qb in gate.qubits]) + "]"
+            qasm_gate_string = f"{qasm_control_str}{qasm_gate_name}{qasm_parameter_str} {qasm_qubits_str}"
             qasm_gate_string = qasm_gate_string.strip()
             qasm3 += f"{qasm_gate_string};\n"
         return qasm3.strip()

--- a/src/qilisdk_cpp/backends/qilisim/analog/iterations_integrate.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/analog/iterations_integrate.cpp
@@ -18,7 +18,7 @@
 
 #ifndef _WIN32
 #if defined(_OPENMP)
-#pragma omp declare reduction(complex_double_reduction : std::complex <double> : omp_out += omp_in) initializer(omp_priv = std::complex <double>(0.0, 0.0))
+#pragma omp declare reduction(complex_double_reduction : std::complex<double> : omp_out += omp_in) initializer(omp_priv = std::complex<double>(0.0, 0.0))
 #endif
 #endif
 

--- a/src/qilisdk_cpp/core/qtensor.cpp
+++ b/src/qilisdk_cpp/core/qtensor.cpp
@@ -23,7 +23,7 @@
 
 #ifndef _WIN32
 #if defined(_OPENMP)
-#pragma omp declare reduction(complex_double_reduction : std::complex <double> : omp_out += omp_in) initializer(omp_priv = std::complex <double>(0.0, 0.0))
+#pragma omp declare reduction(complex_double_reduction : std::complex<double> : omp_out += omp_in) initializer(omp_priv = std::complex<double>(0.0, 0.0))
 #endif
 #endif
 

--- a/tests/unit_python/utils/test_openqasm3.py
+++ b/tests/unit_python/utils/test_openqasm3.py
@@ -1645,6 +1645,28 @@ h q[1];
     qasm = to_qasm3(c)
     assert qasm.strip() == original_qasm.strip()
 
+def test_circuit_with_measurements_roundtrip():
+    qasm = """
+    OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit[2] q;
+     h q[0];
+     ctrl @ x q[0], q[1];
+     measure q[0,1];
+    """
+    c = from_qasm3(qasm)
+    qasm = to_qasm3(c)
+    assert qasm.strip() == qasm.strip()
+
+def test_reverse_roundtrip():
+    c = Circuit(2)
+    c.add(X(0))
+    c.add(CNOT(0, 1))
+    c.add(CZ(0, 1))
+    c.add(M(0, 1))
+    qasm = to_qasm3(c)
+    circ = from_qasm3(qasm)
+    assert circ == c
 
 def test_to_file():
     c = from_qasm3("""

--- a/tests/unit_python/utils/test_openqasm3.py
+++ b/tests/unit_python/utils/test_openqasm3.py
@@ -1645,6 +1645,7 @@ h q[1];
     qasm = to_qasm3(c)
     assert qasm.strip() == original_qasm.strip()
 
+
 def test_circuit_with_measurements_roundtrip():
     qasm = """
     OPENQASM 3.0;
@@ -1658,6 +1659,7 @@ def test_circuit_with_measurements_roundtrip():
     qasm = to_qasm3(c)
     assert qasm.strip() == qasm.strip()
 
+
 def test_reverse_roundtrip():
     c = Circuit(2)
     c.add(X(0))
@@ -1667,6 +1669,7 @@ def test_reverse_roundtrip():
     qasm = to_qasm3(c)
     circ = from_qasm3(qasm)
     assert circ == c
+
 
 def test_to_file():
     c = from_qasm3("""


### PR DESCRIPTION
Added documentation for the OpenQASM 2.0 and 3.0 parsers.

Added missing translations for the QIR docs.

Improved the specificity of the platform build checker.

Fixed a bug when doing an OpenQASM3 round-trip with CNOT and measurement gates. 

