### PR TITLE
[SDK-287] Update Backend Docs

### DIFF
--- a/changes/216.doc.md
+++ b/changes/216.doc.md
@@ -1,0 +1,1 @@
+Expanded the Backends documentation: full QiliSim page with simulation-method descriptions, per-backend functional-support tables (with partial-support markers for QuantumReservoir on CUDA and Qutip), a sampling-methods table for the CUDA backend, noise-model notes, and unified section structure across the QiliSim, CUDA, and Qutip pages.

--- a/docs/locale/ca/LC_MESSAGES/modules/backends/backends_cuda.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/backends/backends_cuda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -25,93 +25,307 @@ msgstr "Backend CUDA"
 
 #: ../../modules/backends/backends_cuda.rst:4
 msgid ""
-"The **CUDA** backend leverages NVIDIA GPUs via the ``cuda-quantum`` "
-"framework for both digital and analog simulations. When no compatible GPU"
-" is detected it automatically falls back to cpu-based targets, so you can"
-" prototype on commodity hardware before moving to accelerated machines."
+"The **CUDA** backend leverages NVIDIA GPUs via the `cuda-quantum "
+"<https://github.com/NVIDIA/cuda-quantum>`_ framework. When no compatible "
+"GPU is detected it transparently falls back to a CPU target, so the same "
+"code prototyped on a laptop will also run on an accelerated machine."
 msgstr ""
-"El backend **CUDA** aprofita les GPU NVIDIA mitjançant el marc "
-"``cuda-quantum`` per a simulacions tant digitals com analògiques. Quan no "
-"es detecta cap GPU compatible, recorre automàticament a objectius basats en "
-"CPU, de manera que podeu fer prototips en maquinari convencional abans de "
-"passar a màquines accelerades."
+"El backend **CUDA** aprofita les GPU NVIDIA mitjançant el marc `cuda-"
+"quantum <https://github.com/NVIDIA/cuda-quantum>`_. Quan no es detecta "
+"cap GPU compatible, recau de manera transparent en un target de CPU, de "
+"manera que el mateix codi prototipat en un portàtil també funcionarà en "
+"una màquina accelerada."
 
-#: ../../modules/backends/backends_cuda.rst:9
+#: ../../modules/backends/backends_cuda.rst:10
 msgid "Installation"
 msgstr "Instal·lació"
 
-#: ../../modules/backends/backends_cuda.rst:16
-msgid "Initialization"
-msgstr "Inicialització"
-
-#: ../../modules/backends/backends_cuda.rst:27
-msgid "Capabilities"
-msgstr "Capacitats"
-
-#: ../../modules/backends/backends_cuda.rst:29
-msgid ""
-"Digital circuits through "
-":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`."
-msgstr ""
-"Circuits digitals mitjançant "
-":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`."
-
-#: ../../modules/backends/backends_cuda.rst:30
-msgid ""
-"Analog dynamics for "
-":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, powered "
-"by ``cudaq.evolve``."
-msgstr ""
-"Dinàmica analògica per a "
-":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, impulsada "
-"per ``cudaq.evolve``."
-
-#: ../../modules/backends/backends_cuda.rst:31
-msgid ""
-"Hybrid execution when paired with "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram`."
-msgstr ""
-"Execució híbrida quan s'emparella amb "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram`."
-
-#: ../../modules/backends/backends_cuda.rst:34
-msgid "Sampling methods"
-msgstr "Mètodes de mostreig"
-
-#: ../../modules/backends/backends_cuda.rst:36
-msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`: "
-"Full state-vector simulation (switches to CPU if a GPU is unavailable)."
-msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`: "
-"Simulació completa de vector d'estat (canvia a CPU si no hi ha una GPU "
-"disponible)."
+#: ../../modules/backends/backends_cuda.rst:17
+msgid "Quick start"
+msgstr "Inici ràpid"
 
 #: ../../modules/backends/backends_cuda.rst:37
+msgid "Functional support"
+msgstr "Suport de funcionals"
+
+#: ../../modules/backends/backends_cuda.rst:43
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_cuda.rst:44
+msgid "Support"
+msgstr "Suport"
+
+#: ../../modules/backends/backends_cuda.rst:45
+msgid "Notes"
+msgstr "Notes"
+
+#: ../../modules/backends/backends_cuda.rst:46
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_cuda.rst:47
+#: ../../modules/backends/backends_cuda.rst:50
+#: ../../modules/backends/backends_cuda.rst:56
+#: ../../modules/backends/backends_cuda.rst:80
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_cuda.rst:48
 msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`:"
-" Tensor-network contraction, suited for shallow yet wide circuits."
+"Native CUDA-Q kernel. Sampling method selected via "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod`. Intermediate "
+"measurements raise ``NotImplementedError``."
 msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`:"
-" Contracció de xarxa tensorial, adequada per a circuits poc profunds però "
-"amples."
+"Kernel CUDA-Q natiu. El mètode de mostreig se selecciona mitjançant "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod`. Les mesures "
+"intermèdies llancen ``NotImplementedError``."
 
-#: ../../modules/backends/backends_cuda.rst:38
+#: ../../modules/backends/backends_cuda.rst:49
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+
+#: ../../modules/backends/backends_cuda.rst:51
 msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`:"
-" Matrix-product-state simulation for low-entanglement workloads."
+"Driven by ``cudaq.evolve`` on the ``dynamics`` target (always GPU-"
+"accelerated when available, independent of the digital sampling method)."
 msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`:"
-" Simulació d'estat de producte matricial per a càrregues de treball amb "
-"baix entrelaçament."
+"Impulsada per ``cudaq.evolve`` sobre el target ``dynamics`` (sempre "
+"accelerada per GPU quan està disponible, independentment del mètode de "
+"mostreig digital)."
 
-#: ../../modules/backends/backends_cuda.rst:41
-msgid "Example"
-msgstr "Exemple"
+#: ../../modules/backends/backends_cuda.rst:52
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
 
-#: ../../modules/backends/backends_cuda.rst:65
-msgid "**Output**"
-msgstr "**Sortida**"
+#: ../../modules/backends/backends_cuda.rst:53
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_cuda.rst:54
+#, fuzzy
+msgid ""
+"The CudaBackend does not natively implement "
+":meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit "
+"steps inside the reservoir layer fall back to dense ``QTensor`` unitary "
+"multiplication on CPU; ``Schedule`` steps still use CUDA-Q's ``evolve``. "
+"Any attached noise model is ignored."
+msgstr ""
+"CudaBackend no implementa :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Els "
+"passos ``Circuit`` dins de la capa del reservori recauen en una "
+"multiplicació unitària ``QTensor`` densa a CPU; els passos ``Schedule`` "
+"segueixen utilitzant ``evolve`` de CUDA-Q. Qualsevol model de soroll "
+"adjuntat s'ignora."
+
+#: ../../modules/backends/backends_cuda.rst:55
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+
+#: ../../modules/backends/backends_cuda.rst:57
+msgid "Reuses the digital/analog handlers above for each optimization step."
+msgstr ""
+"Reutilitza els manejadors digital/analògic anteriors a cada pas "
+"d'optimització."
+
+#: ../../modules/backends/backends_cuda.rst:64
+msgid "Configuration"
+msgstr "Configuració"
+
+#: ../../modules/backends/backends_cuda.rst:66
+msgid ""
+"The CUDA backend exposes a single configuration knob — "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — that selects"
+" the underlying CUDA-Q target used for **digital** circuits. Analog "
+"evolution always runs on the ``dynamics`` target and ignores this "
+"setting."
+msgstr ""
+"El backend CUDA exposa un únic comandament de configuració — "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — que "
+"selecciona el target subjacent de CUDA-Q utilitzat per als circuits "
+"**digitals**. L'evolució analògica sempre s'executa sobre el target "
+"``dynamics`` i ignora aquesta opció."
+
+#: ../../modules/backends/backends_cuda.rst:75
+msgid "Method"
+msgstr "Mètode"
+
+#: ../../modules/backends/backends_cuda.rst:76
+msgid "CUDA-Q target (and fallback)"
+msgstr "Target de CUDA-Q (i fallback)"
+
+#: ../../modules/backends/backends_cuda.rst:77
+msgid "Default"
+msgstr "Per defecte"
+
+#: ../../modules/backends/backends_cuda.rst:78
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`"
+
+#: ../../modules/backends/backends_cuda.rst:79
+msgid ""
+"``nvidia`` (GPU) when a GPU is available, otherwise ``qpp-cpu``. "
+"Precision matches :class:`~qilisdk.settings.Precision`."
+msgstr ""
+"``nvidia`` (GPU) quan hi ha una GPU disponible; en cas contrari ``qpp-"
+"cpu``. La precisió coincideix amb :class:`~qilisdk.settings.Precision`."
+
+#: ../../modules/backends/backends_cuda.rst:81
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`"
+
+#: ../../modules/backends/backends_cuda.rst:82
+msgid "``tensornet``. Good for shallow, wide circuits."
+msgstr "``tensornet``. Adequat per a circuits poc profunds però amples."
+
+#: ../../modules/backends/backends_cuda.rst:84
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`"
+
+#: ../../modules/backends/backends_cuda.rst:85
+msgid "``tensornet-mps``. Good for low-entanglement, long circuits."
+msgstr "``tensornet-mps``. Adequat per a circuits llargs amb baix entrelaçament."
+
+#: ../../modules/backends/backends_cuda.rst:88
+msgid "Set the method at construction time:"
+msgstr "Definiu el mètode en el moment de la construcció:"
+
+#: ../../modules/backends/backends_cuda.rst:97
+msgid "Noise model support"
+msgstr "Suport de models de soroll"
+
+#: ../../modules/backends/backends_cuda.rst:99
+msgid ""
+"A :class:`~qilisdk.noise.NoiseModel` can be passed to "
+"``CudaBackend(noise_model=…)``:"
+msgstr ""
+"Es pot passar un :class:`~qilisdk.noise.NoiseModel` a "
+"``CudaBackend(noise_model=…)``:"
+
+#: ../../modules/backends/backends_cuda.rst:101
+msgid ""
+"For :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`,"
+" qilisdk noise channels are translated into a ``cudaq.NoiseModel`` (Kraus"
+" channels for static / time-derived noise, parameter perturbations "
+"applied to the circuit). With noise enabled, only a single "
+":class:`~qilisdk.readout.SamplingReadout` is supported."
+msgstr ""
+"Per a "
+":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`, els"
+" canals de soroll de qilisdk es tradueixen a un ``cudaq.NoiseModel`` "
+"(canals de Kraus per a soroll estàtic o derivat del temps, pertorbacions "
+"de paràmetres aplicades al circuit). Amb soroll activat, només s'admet "
+"una única :class:`~qilisdk.readout.SamplingReadout`."
+
+#: ../../modules/backends/backends_cuda.rst:105
+msgid ""
+"For :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, "
+"Lindblad-compatible noise channels become CUDA-Q jump operators and "
+"Hamiltonian deltas fed to ``cudaq.evolve``."
+msgstr ""
+"Per a :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, els"
+" canals de soroll compatibles amb Lindblad esdevenen operadors de salt de"
+" CUDA-Q i deltes del Hamiltonià que es passen a ``cudaq.evolve``."
+
+#: ../../modules/backends/backends_cuda.rst:107
+msgid ""
+"For :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
+"the fallback implementation drops the noise model (a warning is logged)."
+msgstr ""
+"Per a :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
+"la implementació de fallback descarta el model de soroll (s'emet un avís "
+"al registre)."
+
+#: ../../modules/backends/backends_cuda.rst:110
+msgid ""
+"Example: a depolarising channel applied to every gate of a digital "
+"circuit:"
+msgstr ""
+"Exemple: un canal despolaritzador aplicat a cada porta d'un circuit "
+"digital:"
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Aneu a un subapartat específic d'una pàgina."
+
+#~ msgid "Capabilities"
+#~ msgstr "Capacitats"
+
+#~ msgid "Example"
+#~ msgstr "Exemple"
+
+#~ msgid "**Output**"
+#~ msgstr "**Sortida**"
+
+#~ msgid "Sampling methods"
+#~ msgstr "Mètodes de mostreig"
+
+#~ msgid "How each sampling method covers the functionals"
+#~ msgstr "Com cada mètode de mostreig cobreix els funcionals"
+
+#~ msgid ""
+#~ "The table below shows which functionals"
+#~ " are affected by ``sampling_method``. Rows"
+#~ " marked |n| are unaffected — the "
+#~ "method is simply ignored for those "
+#~ "execution paths."
+#~ msgstr ""
+#~ "La taula següent mostra quins funcionals"
+#~ " es veuen afectats per ``sampling_method``."
+#~ " Les files marcades amb |n| no "
+#~ "es veuen afectades — el mètode "
+#~ "simplement s'ignora en aquestes rutes "
+#~ "d'execució."
+
+#~ msgid "Sampling method"
+#~ msgstr "Mètode de mostreig"
+
+#~ msgid "DigitalPropagation"
+#~ msgstr "DigitalPropagation"
+
+#~ msgid "AnalogEvolution"
+#~ msgstr "AnalogEvolution"
+
+#~ msgid "QuantumReservoir"
+#~ msgstr "QuantumReservoir"
+
+#~ msgid "VariationalProgram"
+#~ msgstr "VariationalProgram"
+
+#~ msgid "``STATE_VECTOR``"
+#~ msgstr "``STATE_VECTOR``"
+
+#~ msgid "|n| ``dynamics``"
+#~ msgstr "|n| ``dynamics``"
+
+#~ msgid "|p| Circuit steps via QTensor; Schedule steps via ``dynamics``"
+#~ msgstr "|p| Passos Circuit via QTensor; passos Schedule via ``dynamics``"
+
+#~ msgid "|y| (delegates to digital/analog)"
+#~ msgstr "|y| (delega en digital/analògic)"
+
+#~ msgid "``TENSOR_NETWORK``"
+#~ msgstr "``TENSOR_NETWORK``"
+
+#~ msgid "``MATRIX_PRODUCT_STATE``"
+#~ msgstr "``MATRIX_PRODUCT_STATE``"
+
+#~ msgid ""
+#~ "In short: ``sampling_method`` only changes "
+#~ "how a **digital** circuit is simulated."
+#~ " Analog evolution always uses "
+#~ "``cudaq.evolve`` on the ``dynamics`` target;"
+#~ " for reservoirs, only the analog "
+#~ "sub-step benefits from CUDA-Q (the "
+#~ "digital sub-circuits run on CPU "
+#~ "through ``QTensor``)."
+#~ msgstr ""
+#~ "En resum: ``sampling_method`` només canvia "
+#~ "com se simula un circuit **digital**."
+#~ " L'evolució analògica sempre utilitza "
+#~ "``cudaq.evolve`` sobre el target ``dynamics``;"
+#~ " en els reservoris, només el subpas"
+#~ " analògic es beneficia de CUDA-Q (els"
+#~ " subcircuits digitals s'executen en CPU "
+#~ "mitjançant ``QTensor``)."
+

--- a/docs/locale/ca/LC_MESSAGES/modules/backends/backends_overview.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/backends/backends_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -30,8 +30,8 @@ msgid ""
 "three backends are supported:"
 msgstr ""
 "El mòdul :mod:`~qilisdk.backends` proporciona motors d'execució concrets "
-"per executar :mod:`~qilisdk.functionals` (processos quàntics). Actualment, "
-"s'admeten tres backends:"
+"per executar :mod:`~qilisdk.functionals` (processos quàntics). "
+"Actualment, s'admeten tres backends:"
 
 #: ../../modules/backends/backends_overview.rst:7
 msgid ""
@@ -39,16 +39,16 @@ msgid ""
 "developed by Qilimanjaro, ideal for local development and testing."
 msgstr ""
 ":doc:`QiliSim <backends_qilisim>`: Un simulador d'alt rendiment basat en "
-"CPU desenvolupat per Qilimanjaro, ideal per al desenvolupament i les proves "
-"locals."
+"CPU desenvolupat per Qilimanjaro, ideal per al desenvolupament i les "
+"proves locals."
 
 #: ../../modules/backends/backends_overview.rst:8
 msgid ""
 ":doc:`CUDA <backends_cuda>`: A GPU-accelerated backend leveraging NVIDIA "
 "hardware for large-scale simulations."
 msgstr ""
-":doc:`CUDA <backends_cuda>`: Un backend accelerat per GPU que aprofita el "
-"maquinari NVIDIA per a simulacions a gran escala."
+":doc:`CUDA <backends_cuda>`: Un backend accelerat per GPU que aprofita el"
+" maquinari NVIDIA per a simulacions a gran escala."
 
 #: ../../modules/backends/backends_overview.rst:9
 msgid ""
@@ -82,9 +82,9 @@ msgid ""
 " the backend's :meth:`~qilisdk.backends.backend.Backend.execute` method "
 "along with readout specifications:"
 msgstr ""
-"Un cop instal·lat, qualsevol funcional primitiu es pot executar passant-lo "
-"al mètode :meth:`~qilisdk.backends.backend.Backend.execute` del backend "
-"juntament amb les especificacions de lectura:"
+"Un cop instal·lat, qualsevol funcional primitiu es pot executar passant-"
+"lo al mètode :meth:`~qilisdk.backends.backend.Backend.execute` del "
+"backend juntament amb les especificacions de lectura:"
 
 #: ../../modules/backends/backends_overview.rst:36
 msgid "Architecture Overview"
@@ -115,12 +115,12 @@ msgstr ""
 ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation` o "
 ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`) a la "
 "rutina de simulació adequada i retorna un "
-":class:`~qilisdk.functionals.functional_result.FunctionalResult` (vegeu el "
-"capítol :doc:`Functionals </modules/functionals/functionals>`). El mètode "
-"execute també accepta especificacions de lectura que defineixen com es "
-"mesura l'estat quàntic. El mètode execute també s'utilitza per optimitzar "
-"programes variacionals mitjançant crides repetides al funcional primitiu "
-"parametritzat subjacent."
+":class:`~qilisdk.functionals.functional_result.FunctionalResult` (vegeu "
+"el capítol :doc:`Functionals </modules/functionals/functionals>`). El "
+"mètode execute també accepta especificacions de lectura que defineixen "
+"com es mesura l'estat quàntic. El mètode execute també s'utilitza per "
+"optimitzar programes variacionals mitjançant crides repetides al "
+"funcional primitiu parametritzat subjacent."
 
 #: ../../modules/backends/backends_overview.rst:45
 msgid ""
@@ -145,11 +145,11 @@ msgid ""
 "the system."
 msgstr ""
 "La instal·lació d'un extra de backend incorpora la pila de biblioteques "
-"necessàries per a aquell simulador. Els backends de GPU també requereixen "
-"que hi hagi controladors compatibles al sistema."
+"necessàries per a aquell simulador. Els backends de GPU també requereixen"
+" que hi hagi controladors compatibles al sistema."
 
 #: ../../modules/backends/backends_overview.rst:58
-#: ../../modules/backends/backends_overview.rst:84
+#: ../../modules/backends/backends_overview.rst:90
 msgid "Backend"
 msgstr "Backend"
 
@@ -166,13 +166,13 @@ msgid "Notes"
 msgstr "Notes"
 
 #: ../../modules/backends/backends_overview.rst:62
-#: ../../modules/backends/backends_overview.rst:89
+#: ../../modules/backends/backends_overview.rst:95
 msgid ":class:`QiliSim <qilisdk.backends.qilisim.QiliSim>`"
 msgstr ":class:`QiliSim <qilisdk.backends.qilisim.QiliSim>`"
 
 #: ../../modules/backends/backends_overview.rst:63
-msgid "``qilisim``"
-msgstr "``qilisim``"
+msgid "--"
+msgstr "--"
 
 #: ../../modules/backends/backends_overview.rst:64
 msgid "None"
@@ -184,7 +184,7 @@ msgid "CPU based; no special hardware needs."
 msgstr "Basat en CPU; no requereix maquinari especial."
 
 #: ../../modules/backends/backends_overview.rst:66
-#: ../../modules/backends/backends_overview.rst:94
+#: ../../modules/backends/backends_overview.rst:100
 msgid ":class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`"
 msgstr ":class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`"
 
@@ -201,7 +201,7 @@ msgid "Requires NVIDIA hardware with recent drivers."
 msgstr "Requereix maquinari NVIDIA amb controladors recents."
 
 #: ../../modules/backends/backends_overview.rst:70
-#: ../../modules/backends/backends_overview.rst:99
+#: ../../modules/backends/backends_overview.rst:105
 msgid ":class:`QutipBackend <qilisdk.backends.qutip_backend.QutipBackend>`"
 msgstr ":class:`QutipBackend <qilisdk.backends.qutip_backend.QutipBackend>`"
 
@@ -222,36 +222,83 @@ msgid ""
 "The table below summarizes which primitive :mod:`~qilisdk.functionals` "
 "each backend can execute."
 msgstr ""
-"La taula següent resumeix quins :mod:`~qilisdk.functionals` primitius "
-"pot executar cada backend."
+"La taula següent resumeix quins :mod:`~qilisdk.functionals` primitius pot"
+" executar cada backend."
 
-#: ../../modules/backends/backends_overview.rst:85
+#: ../../modules/backends/backends_overview.rst:80
+msgid "Legend:"
+msgstr "Llegenda:"
+
+#: ../../modules/backends/backends_overview.rst:82
+msgid "|y| Fully supported by the backend's native simulator."
+msgstr "|y| Totalment suportat pel simulador natiu del backend."
+
+#: ../../modules/backends/backends_overview.rst:83
+msgid ""
+"|p| Partially supported — see the per-backend page for the exact "
+"limitation."
+msgstr ""
+"|p| Parcialment suportat — consulteu la pàgina de cada backend per a la "
+"limitació exacta."
+
+#: ../../modules/backends/backends_overview.rst:84
+msgid "|n| Not supported."
+msgstr "|n| No suportat."
+
+#: ../../modules/backends/backends_overview.rst:91
 msgid "DigitalPropagation"
 msgstr "DigitalPropagation"
 
-#: ../../modules/backends/backends_overview.rst:86
+#: ../../modules/backends/backends_overview.rst:92
 msgid "AnalogEvolution"
 msgstr "AnalogEvolution"
 
-#: ../../modules/backends/backends_overview.rst:87
+#: ../../modules/backends/backends_overview.rst:93
 msgid "QuantumReservoir"
 msgstr "QuantumReservoir"
 
-#: ../../modules/backends/backends_overview.rst:88
+#: ../../modules/backends/backends_overview.rst:94
 msgid "VariationalProgram"
 msgstr "VariationalProgram"
 
-#: ../../modules/backends/backends_overview.rst:90
-#: ../../modules/backends/backends_overview.rst:91
-#: ../../modules/backends/backends_overview.rst:92
-#: ../../modules/backends/backends_overview.rst:93
-#: ../../modules/backends/backends_overview.rst:95
 #: ../../modules/backends/backends_overview.rst:96
 #: ../../modules/backends/backends_overview.rst:97
 #: ../../modules/backends/backends_overview.rst:98
-#: ../../modules/backends/backends_overview.rst:100
+#: ../../modules/backends/backends_overview.rst:99
 #: ../../modules/backends/backends_overview.rst:101
 #: ../../modules/backends/backends_overview.rst:102
-#: ../../modules/backends/backends_overview.rst:103
+#: ../../modules/backends/backends_overview.rst:104
+#: ../../modules/backends/backends_overview.rst:106
+#: ../../modules/backends/backends_overview.rst:107
+#: ../../modules/backends/backends_overview.rst:109
 msgid "|y|"
 msgstr "|y|"
+
+#: ../../modules/backends/backends_overview.rst:103
+#: ../../modules/backends/backends_overview.rst:108
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_overview.rst:113
+#, fuzzy
+msgid ""
+"``QuantumReservoir`` is fully native only on QiliSim. On the "
+":class:`CudaBackend` and :class:`QutipBackend` the ``Circuit`` reservoir "
+"steps are evaluated as dense QTensor unitaries on CPU, while ``Schedule``"
+" steps still use the backend's native analog solver. Attaching a "
+":class:`~qilisdk.noise.NoiseModel` to a reservoir run is ignored on both "
+":class:`CudaBackend` and :class:`QutipBackend`. (a warning is logged)."
+msgstr ""
+"``QuantumReservoir`` només és totalment natiu a QiliSim. A "
+":class:`CudaBackend` i :class:`QutipBackend`, el reservori recau en la "
+"implementació per defecte de :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`: els "
+"passos ``Circuit`` del reservori s'avaluen com a unitaris QTensor densos "
+"a CPU, mentre que els passos ``Schedule`` segueixen utilitzant el solver "
+"analògic natiu del backend. Associar un "
+":class:`~qilisdk.noise.NoiseModel` a una execució de reservori s'ignora a"
+" tots els backends (s'emet un avís al registre)."
+
+#~ msgid "``qilisim``"
+#~ msgstr "``qilisim``"
+

--- a/docs/locale/ca/LC_MESSAGES/modules/backends/backends_qilisim.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/backends/backends_qilisim.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -20,93 +20,499 @@ msgstr ""
 "Generated-By: Babel 2.18.0\n"
 
 #: ../../modules/backends/backends_qilisim.rst:2
-msgid "QiliSim"
+#, fuzzy
+msgid "QiliSim Backend"
 msgstr "QiliSim"
 
 #: ../../modules/backends/backends_qilisim.rst:4
+#, fuzzy
 msgid ""
-"The **QiliSim** backend is a CPU-based simulator developed by Qilimanjaro"
-" and written in C++, providing efficient simulation of both digital and "
-"analog quantum functionals. It is designed for ease of use and does not "
-"require any special hardware or dependencies. There is no need to install"
-" QiliSim separately, as it is included with the core QILISDK "
-"installation."
+"The **QiliSim** backend is the default CPU simulator developed by "
+"Qilimanjaro and written in C++. It implements every primitive functional "
+"natively, supports a noise model on all execution paths, and is included "
+"with the core ``qilisdk`` installation — no extra dependency or hardware "
+"is required."
 msgstr ""
-"El backend **QiliSim** és un simulador basat en CPU desenvolupat per "
-"Qilimanjaro i escrit en C++, que proporciona una simulació eficient de "
-"funcionals quàntics tant digitals com analògics. Està dissenyat per ser "
-"fàcil d'utilitzar i no requereix cap maquinari ni dependències especials. "
-"No cal instal·lar QiliSim per separat, ja que s'inclou amb la instal·lació "
-"bàsica de QILISDK."
+"El backend **QiliSim** és el simulador de CPU per defecte desenvolupat "
+"per Qilimanjaro i escrit en C++ (exposat mitjançant ``pybind11``). "
+"Implementa tots els funcionals primitius de manera nativa, suporta un "
+"model de soroll en totes les rutes d'execució i s'inclou amb la "
+"instal·lació principal de ``qilisdk`` — no requereix cap dependència ni "
+"maquinari addicional."
 
-#: ../../modules/backends/backends_qilisim.rst:10
-msgid "Example"
-msgstr "Exemple"
+#: ../../modules/backends/backends_qilisim.rst:9
+msgid "Installation"
+msgstr "Instal·lació"
 
-#: ../../modules/backends/backends_qilisim.rst:34
-msgid "Configuration"
-msgstr "Configuració"
-
-#: ../../modules/backends/backends_qilisim.rst:36
+#: ../../modules/backends/backends_qilisim.rst:11
 msgid ""
-"QiliSim has a variety of configuration options to customize the "
-"simulation methods and performance characteristics. These can be set at "
-"initialization via the ``analog_simulation_method``, "
-"``digital_simulation_method``, and ``execution_config`` parameters:"
+"QiliSim is bundled with the core ``qilisdk`` installation, so no extra "
+"package is required:"
 msgstr ""
-"QiliSim té diverses opcions de configuració per personalitzar els mètodes "
-"de simulació i les característiques de rendiment. Aquestes es poden "
-"establir en la inicialització mitjançant els paràmetres "
-"``analog_simulation_method``, ``digital_simulation_method`` i "
-"``execution_config``:"
 
+#: ../../modules/backends/backends_qilisim.rst:15
+msgid "Quick start"
+msgstr "Inici ràpid"
+
+#: ../../modules/backends/backends_qilisim.rst:39
+msgid "Functional support"
+msgstr "Suport de funcionals"
+
+#: ../../modules/backends/backends_qilisim.rst:41
+msgid ""
+"QiliSim natively supports all primitive functionals through dedicated C++"
+" routines:"
+msgstr ""
+"QiliSim suporta de manera nativa tots els funcionals primitius mitjançant"
+" rutines dedicades en C++:"
+
+#: ../../modules/backends/backends_qilisim.rst:47
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_qilisim.rst:48
+msgid "Support"
+msgstr "Suport"
+
+#: ../../modules/backends/backends_qilisim.rst:49
+msgid "Notes"
+msgstr "Notes"
+
+#: ../../modules/backends/backends_qilisim.rst:50
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_qilisim.rst:51
 #: ../../modules/backends/backends_qilisim.rst:54
-msgid "Possible analog simulation methods:"
-msgstr "Mètodes de simulació analògica possibles:"
+#: ../../modules/backends/backends_qilisim.rst:57
+#: ../../modules/backends/backends_qilisim.rst:60
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_qilisim.rst:52
+msgid ""
+"Statevector-based simulation, configurable via "
+":class:`~qilisdk.backends.backend_config.DigitalMethod`."
+msgstr ""
+"Simulació basada en vector d'estat, configurable mitjançant "
+":class:`~qilisdk.backends.backend_config.DigitalMethod`."
+
+#: ../../modules/backends/backends_qilisim.rst:53
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+
+#: ../../modules/backends/backends_qilisim.rst:55
+msgid ""
+"Multiple integration schemes, configurable via "
+":class:`~qilisdk.backends.backend_config.AnalogMethod`."
+msgstr ""
+"Múltiples esquemes d'integració, configurables mitjançant "
+":class:`~qilisdk.backends.backend_config.AnalogMethod`."
 
 #: ../../modules/backends/backends_qilisim.rst:56
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.integrator`: "
-"General-purpose RK4 integrator."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.integrator`: "
-"Integrador RK4 de propòsit general."
-
-#: ../../modules/backends/backends_qilisim.rst:57
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
-" Adaptive RK45 integrator, faster for some systems."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
-" Integrador RK45 adaptatiu, més ràpid per a alguns sistemes."
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
 
 #: ../../modules/backends/backends_qilisim.rst:58
 msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.direct`: Matrix "
-"exponential method for small systems."
+"Native C++ implementation; supports both Circuit and Schedule reservoir "
+"steps."
 msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.direct`: Mètode "
-"d'exponencial de matriu per a sistemes petits."
+"Implementació nativa en C++; suporta tant passos Circuit com Schedule del"
+" reservori."
 
 #: ../../modules/backends/backends_qilisim.rst:59
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.arnoldi`: Krylov "
-"subspace method."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.arnoldi`: Mètode "
-"del subespai de Krylov."
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
 
 #: ../../modules/backends/backends_qilisim.rst:61
-msgid "Possible digital simulation methods:"
-msgstr "Mètodes de simulació digital possibles:"
-
-#: ../../modules/backends/backends_qilisim.rst:63
-msgid ""
-":class:`~qilisdk.backends.backend_config.DigitalMethod.statevector`: "
-"Exact state-vector simulation with optional caching."
+msgid "Reuses the primitive functional handlers above for each optimization step."
 msgstr ""
-":class:`~qilisdk.backends.backend_config.DigitalMethod.statevector`: "
-"Simulació exacta de vector d'estat amb memòria cau opcional."
+"Reutilitza els manejadors de funcionals primitius anteriors a cada pas "
+"d'optimització."
+
+#: ../../modules/backends/backends_qilisim.rst:68
+msgid "Configuration"
+msgstr "Configuració"
+
+#: ../../modules/backends/backends_qilisim.rst:70
+msgid ""
+"QiliSim is configured at construction time through three orthogonal "
+"sections, all defined in :mod:`qilisdk.backends.backend_config`:"
+msgstr ""
+"QiliSim es configura en el moment de la construcció mitjançant tres "
+"seccions ortogonals, totes definides a "
+":mod:`qilisdk.backends.backend_config`:"
+
+#: ../../modules/backends/backends_qilisim.rst:73
+msgid ""
+":class:`~qilisdk.backends.backend_config.AnalogMethod` — chooses the "
+"analog time-evolution scheme and its hyperparameters."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.AnalogMethod` — escull l'esquema"
+" d'evolució temporal analògica i els seus hiperparàmetres."
+
+#: ../../modules/backends/backends_qilisim.rst:75
+msgid ""
+":class:`~qilisdk.backends.backend_config.DigitalMethod` — chooses the "
+"digital simulation strategy and its caching / normalization options."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.DigitalMethod` — escull "
+"l'estratègia de simulació digital i les seves opcions de memòria cau / "
+"normalització."
+
+#: ../../modules/backends/backends_qilisim.rst:77
+msgid ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` — global "
+"execution controls (threads, random seed, Monte Carlo trajectories, "
+"measurement-collapse behaviour)."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` — controls "
+"globals d'execució (fils, llavor aleatòria, trajectòries de Monte Carlo, "
+"comportament del col·lapse de mesura)."
+
+#: ../../modules/backends/backends_qilisim.rst:105
+msgid "If any argument is omitted, QiliSim falls back to:"
+msgstr "Si s'omet qualsevol argument, QiliSim recau en:"
+
+#: ../../modules/backends/backends_qilisim.rst:107
+msgid ""
+":meth:`AnalogMethod.integrator() "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>` (matrix-free "
+"RK4),"
+msgstr ""
+":meth:`AnalogMethod.integrator() "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>` (RK4 sense "
+"matriu),"
+
+#: ../../modules/backends/backends_qilisim.rst:109
+msgid ""
+":meth:`DigitalMethod.statevector() "
+"<qilisdk.backends.backend_config.DigitalMethod.statevector>`,"
+msgstr ""
+":meth:`DigitalMethod.statevector() "
+"<qilisdk.backends.backend_config.DigitalMethod.statevector>`,"
+
+#: ../../modules/backends/backends_qilisim.rst:110
+msgid ""
+"a default :class:`~qilisdk.backends.backend_config.ExecutionConfig` (all "
+"cores, random seed, Monte Carlo disabled)."
+msgstr ""
+"un :class:`~qilisdk.backends.backend_config.ExecutionConfig` per defecte "
+"(tots els nuclis, llavor aleatòria, Monte Carlo desactivat)."
+
+#: ../../modules/backends/backends_qilisim.rst:114
+msgid "Analog simulation methods"
+msgstr "Mètodes de simulació analògica"
+
+#: ../../modules/backends/backends_qilisim.rst:116
+msgid ""
+"Use the classmethods of "
+":class:`~qilisdk.backends.backend_config.AnalogMethod` to choose how the "
+"schedule is integrated:"
+msgstr ""
+"Utilitzeu els mètodes de classe de "
+":class:`~qilisdk.backends.backend_config.AnalogMethod` per triar com "
+"s'integra el schedule:"
+
+#: ../../modules/backends/backends_qilisim.rst:123
+msgid "Constructor"
+msgstr "Constructor"
+
+#: ../../modules/backends/backends_qilisim.rst:124
+msgid "Underlying scheme"
+msgstr "Esquema subjacent"
+
+#: ../../modules/backends/backends_qilisim.rst:125
+msgid "When to use it"
+msgstr "Quan utilitzar-lo"
+
+#: ../../modules/backends/backends_qilisim.rst:126
+msgid ""
+":meth:`AnalogMethod.integrator(matrix_free=True) "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>`"
+msgstr ""
+":meth:`AnalogMethod.integrator(matrix_free=True) "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>`"
+
+#: ../../modules/backends/backends_qilisim.rst:127
+msgid "RK4"
+msgstr "RK4"
+
+#: ../../modules/backends/backends_qilisim.rst:128
+msgid ""
+"Default. Fixed-step Runge-Kutta 4; matrix-free is faster for sparse "
+"Hamiltonians."
+msgstr ""
+"Per defecte. Runge-Kutta 4 amb pas fix; sense matriu és més ràpid per a "
+"Hamiltonians dispersos."
+
+#: ../../modules/backends/backends_qilisim.rst:129
+msgid ""
+":meth:`AnalogMethod.adaptive_integrator(tol=1e-2) "
+"<qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator>`"
+msgstr ""
+":meth:`AnalogMethod.adaptive_integrator(tol=1e-2) "
+"<qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator>`"
+
+#: ../../modules/backends/backends_qilisim.rst:130
+msgid "Dormand-Prince RK4/5"
+msgstr "Dormand-Prince RK4/5"
+
+#: ../../modules/backends/backends_qilisim.rst:131
+msgid ""
+"Adaptive step size; ``tol`` bounds the fidelity error between the RK4 and"
+" RK5 estimates."
+msgstr ""
+"Mida de pas adaptativa; ``tol`` limita l'error de fidelitat entre les "
+"estimacions RK4 i RK5."
+
+#: ../../modules/backends/backends_qilisim.rst:132
+msgid ""
+":meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) "
+"<qilisdk.backends.backend_config.AnalogMethod.arnoldi>`"
+msgstr ""
+":meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) "
+"<qilisdk.backends.backend_config.AnalogMethod.arnoldi>`"
+
+#: ../../modules/backends/backends_qilisim.rst:133
+msgid "Krylov / Arnoldi"
+msgstr "Krylov / Arnoldi"
+
+#: ../../modules/backends/backends_qilisim.rst:134
+msgid ""
+"Better scaling for large sparse Hamiltonians; tune ``dim`` for the Krylov"
+" subspace size."
+msgstr ""
+"Millor escalabilitat per a Hamiltonians dispersos grans; ajusteu ``dim`` "
+"per a la mida del subespai de Krylov."
+
+#: ../../modules/backends/backends_qilisim.rst:135
+msgid ""
+":meth:`AnalogMethod.direct() "
+"<qilisdk.backends.backend_config.AnalogMethod.direct>`"
+msgstr ""
+":meth:`AnalogMethod.direct() "
+"<qilisdk.backends.backend_config.AnalogMethod.direct>`"
+
+#: ../../modules/backends/backends_qilisim.rst:136
+msgid "Matrix exponential"
+msgstr "Exponencial de matriu"
+
+#: ../../modules/backends/backends_qilisim.rst:137
+msgid "Reference scheme for small systems; cost grows quickly with qubit count."
+msgstr ""
+"Esquema de referència per a sistemes petits; el cost creix ràpidament amb"
+" el nombre de qubits."
+
+#: ../../modules/backends/backends_qilisim.rst:139
+msgid "Example, using the adaptive integrator for a stiffer schedule:"
+msgstr "Exemple, utilitzant l'integrador adaptatiu per a un schedule més rígid:"
+
+#: ../../modules/backends/backends_qilisim.rst:148
+msgid "Digital simulation methods"
+msgstr "Mètodes de simulació digital"
+
+#: ../../modules/backends/backends_qilisim.rst:150
+msgid ""
+"Digital execution is currently always state-vector based; the "
+":class:`~qilisdk.backends.backend_config.DigitalMethod` configuration "
+"tunes its performance characteristics rather than choosing a different "
+"algorithm:"
+msgstr ""
+"L'execució digital es basa actualment sempre en vector d'estat; la "
+"configuració :class:`~qilisdk.backends.backend_config.DigitalMethod` "
+"ajusta les seves característiques de rendiment en lloc de triar un "
+"algoritme diferent:"
+
+#: ../../modules/backends/backends_qilisim.rst:158
+msgid "Option"
+msgstr "Opció"
+
+#: ../../modules/backends/backends_qilisim.rst:159
+msgid "Meaning"
+msgstr "Significat"
+
+#: ../../modules/backends/backends_qilisim.rst:160
+msgid "``matrix_free``"
+msgstr "``matrix_free``"
+
+#: ../../modules/backends/backends_qilisim.rst:161
+msgid ""
+"Apply gates directly to the statevector instead of building dense "
+"matrices. Default ``True``."
+msgstr ""
+"Aplica les portes directament al vector d'estat en lloc de construir "
+"matrius denses. Per defecte ``True``."
+
+#: ../../modules/backends/backends_qilisim.rst:162
+msgid "``max_cache_size``"
+msgstr "``max_cache_size``"
+
+#: ../../modules/backends/backends_qilisim.rst:163
+msgid "Maximum number of precomputed gate matrices cached between executions."
+msgstr ""
+"Nombre màxim de matrius de porta precomputades emmagatzemades en memòria "
+"cau entre execucions."
+
+#: ../../modules/backends/backends_qilisim.rst:164
+msgid "``combine_single_qubit_gates``"
+msgstr "``combine_single_qubit_gates``"
+
+#: ../../modules/backends/backends_qilisim.rst:165
+msgid ""
+"Merge adjacent single-qubit gates into a single operation before "
+"propagating."
+msgstr ""
+"Fusiona portes d'un sol qubit adjacents en una única operació abans de "
+"propagar."
+
+#: ../../modules/backends/backends_qilisim.rst:166
+msgid "``normalize_after_each_gate``"
+msgstr "``normalize_after_each_gate``"
+
+#: ../../modules/backends/backends_qilisim.rst:167
+msgid ""
+"Renormalize the statevector after each gate to mitigate numerical drift, "
+"at a runtime cost."
+msgstr ""
+"Renormalitza el vector d'estat després de cada porta per mitigar la "
+"deriva numèrica, amb un cost de temps d'execució."
+
+#: ../../modules/backends/backends_qilisim.rst:181
+msgid "Execution and Monte Carlo"
+msgstr "Execució i Monte Carlo"
+
+#: ../../modules/backends/backends_qilisim.rst:183
+msgid ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` controls "
+"threading, randomness, and optional Monte Carlo trajectory sampling for "
+"open-system simulations."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` controla els "
+"fils, l'aleatorietat i el mostreig opcional de trajectòries de Monte "
+"Carlo per a simulacions de sistemes oberts."
+
+#: ../../modules/backends/backends_qilisim.rst:186
+msgid "``num_threads=0`` (default) lets the simulator use every physical core."
+msgstr ""
+"``num_threads=0`` (per defecte) permet al simulador utilitzar tots els "
+"nuclis físics."
+
+#: ../../modules/backends/backends_qilisim.rst:187
+msgid ""
+"``seed=None`` (default) draws a fresh random seed at construction time; "
+"pass an integer for reproducibility."
+msgstr ""
+"``seed=None`` (per defecte) genera una nova llavor aleatòria en el moment"
+" de la construcció; passeu un enter per a reproducibilitat."
+
+#: ../../modules/backends/backends_qilisim.rst:189
+msgid ""
+"``monte_carlo=MonteCarloConfig(trajectories=N)`` enables stochastic "
+"trajectory sampling for noise models that admit a Monte Carlo unraveling;"
+" leave it ``None`` for deterministic master-equation evolution."
+msgstr ""
+"``monte_carlo=MonteCarloConfig(trajectories=N)`` activa el mostreig "
+"estocàstic de trajectòries per a models de soroll que admeten un "
+"unraveling de Monte Carlo; deixeu-ho a ``None`` per a una evolució "
+"determinista de l'equació mestra."
+
+#: ../../modules/backends/backends_qilisim.rst:192
+msgid ""
+"``measurement_collapse`` controls whether measurements collapse the "
+"statevector in place (relevant for mid-circuit measurement and reservoir "
+"computing); defaults to ``False``."
+msgstr ""
+"``measurement_collapse`` controla si les mesures col·lapsen el vector "
+"d'estat in situ (rellevant per a mesures a mig circuit i computació de "
+"reservoris); per defecte ``False``."
+
+#: ../../modules/backends/backends_qilisim.rst:209
+#, fuzzy
+msgid "Noise model support"
+msgstr "Suport de funcionals"
+
+#: ../../modules/backends/backends_qilisim.rst:211
+msgid ""
+"Any :class:`~qilisdk.noise.NoiseModel` accepted by the SDK can be passed "
+"directly to the constructor; QiliSim applies it inside the C++ solver, so"
+" digital, analog, and reservoir runs all see the same noise channels:"
+msgstr ""
+"Qualsevol :class:`~qilisdk.noise.NoiseModel` acceptat pel SDK es pot "
+"passar directament al constructor; QiliSim l'aplica dins del solver de "
+"C++, de manera que les execucions digitals, analògiques i de reservori "
+"veuen totes els mateixos canals de soroll:"
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Aneu a un subapartat específic d'una pàgina."
+
+#~ msgid ""
+#~ "The **QiliSim** backend is a CPU-"
+#~ "based simulator developed by Qilimanjaro "
+#~ "and written in C++, providing efficient"
+#~ " simulation of both digital and "
+#~ "analog quantum functionals. It is "
+#~ "designed for ease of use and does"
+#~ " not require any special hardware or"
+#~ " dependencies. There is no need to"
+#~ " install QiliSim separately, as it is"
+#~ " included with the core QILISDK "
+#~ "installation."
+#~ msgstr ""
+#~ "El backend **QiliSim** és un simulador"
+#~ " basat en CPU desenvolupat per "
+#~ "Qilimanjaro i escrit en C++, que "
+#~ "proporciona una simulació eficient de "
+#~ "funcionals quàntics tant digitals com "
+#~ "analògics. Està dissenyat per ser fàcil"
+#~ " d'utilitzar i no requereix cap "
+#~ "maquinari ni dependències especials. No "
+#~ "cal instal·lar QiliSim per separat, ja"
+#~ " que s'inclou amb la instal·lació "
+#~ "bàsica de QILISDK."
+
+#~ msgid "Example"
+#~ msgstr "Exemple"
+
+#~ msgid ""
+#~ "QiliSim has a variety of configuration"
+#~ " options to customize the simulation "
+#~ "methods and performance characteristics. These"
+#~ " can be set at initialization via "
+#~ "the ``analog_simulation_method``, "
+#~ "``digital_simulation_method``, and ``execution_config``"
+#~ " parameters:"
+#~ msgstr ""
+#~ "QiliSim té diverses opcions de "
+#~ "configuració per personalitzar els mètodes "
+#~ "de simulació i les característiques de"
+#~ " rendiment. Aquestes es poden establir "
+#~ "en la inicialització mitjançant els "
+#~ "paràmetres ``analog_simulation_method``, "
+#~ "``digital_simulation_method`` i ``execution_config``:"
+
+#~ msgid ""
+#~ ":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
+#~ " Adaptive RK45 integrator, faster for "
+#~ "some systems."
+#~ msgstr ""
+#~ ":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
+#~ " Integrador RK45 adaptatiu, més ràpid "
+#~ "per a alguns sistemes."
+
+#~ msgid ""
+#~ "A :class:`~qilisdk.noise.NoiseModel` may be "
+#~ "attached to a QiliSim instance and "
+#~ "is honoured by every functional handler"
+#~ " (digital, analog, and reservoir)."
+#~ msgstr ""
+#~ "Es pot associar un "
+#~ ":class:`~qilisdk.noise.NoiseModel` a una instància"
+#~ " de QiliSim i serà respectat per "
+#~ "tots els manejadors de funcionals "
+#~ "(digital, analògic i reservori)."
+
+#~ msgid "Using a noise model"
+#~ msgstr "Ús d'un model de soroll"
+

--- a/docs/locale/ca/LC_MESSAGES/modules/backends/backends_qutip.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/backends/backends_qutip.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -25,56 +25,193 @@ msgstr "Backend QuTiP"
 
 #: ../../modules/backends/backends_qutip.rst:4
 msgid ""
-"The **Qutip** backend uses the ``qutip`` library for simulation on CPU, "
-"supporting both digital and analog functionals. It is the most "
-"lightweight option, ideal for local development or environments without "
-"NVIDIA GPUs."
+"The **Qutip** backend uses the `QuTiP <https://qutip.org/>`_ library for "
+"CPU-only simulation. It is the most lightweight optional backend — no "
+"GPU, no compiled extension — and is well suited to local development, CI "
+"pipelines and educational notebooks."
 msgstr ""
-"El backend **Qutip** utilitza la biblioteca ``qutip`` per a la simulació "
-"en CPU, admetent funcionals tant digitals com analògics. És l'opció més "
-"lleugera, ideal per al desenvolupament local o entorns sense GPU NVIDIA."
+"El backend **Qutip** utilitza la biblioteca `QuTiP <https://qutip.org/>`_"
+" per a simulació només a CPU. És el backend opcional més lleuger — sense "
+"GPU ni extensió compilada — i és adequat per al desenvolupament local, "
+"pipelines de CI i notebooks educatius."
 
-#: ../../modules/backends/backends_qutip.rst:8
+#: ../../modules/backends/backends_qutip.rst:9
 msgid "Installation"
 msgstr "Instal·lació"
 
-#: ../../modules/backends/backends_qutip.rst:15
-msgid "Initialization"
-msgstr "Inicialització"
+#: ../../modules/backends/backends_qutip.rst:16
+msgid "Quick start"
+msgstr "Inici ràpid"
 
-#: ../../modules/backends/backends_qutip.rst:24
-msgid "Capabilities"
-msgstr "Capacitats"
+#: ../../modules/backends/backends_qutip.rst:55
+msgid "Functional support"
+msgstr "Suport de funcionals"
 
-#: ../../modules/backends/backends_qutip.rst:26
+#: ../../modules/backends/backends_qutip.rst:61
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_qutip.rst:62
+msgid "Support"
+msgstr "Suport"
+
+#: ../../modules/backends/backends_qutip.rst:63
+msgid "Notes"
+msgstr "Notes"
+
+#: ../../modules/backends/backends_qutip.rst:64
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_qutip.rst:65
+#: ../../modules/backends/backends_qutip.rst:68
+#: ../../modules/backends/backends_qutip.rst:74
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_qutip.rst:66
 msgid ""
-"**DigitalPropagation** of digital circuits via QuTiP's state-vector "
-"solvers."
+"Statevector simulation via ``qutip_qip``'s :class:`CircuitSimulator`. "
+"Mid-circuit measurements raise ``ValueError``; all measurements must be "
+"at the end of the circuit."
 msgstr ""
-"**DigitalPropagation** de circuits digitals mitjançant els solucionadors "
-"de vector d'estat de QuTiP."
+"Simulació basada en vector d'estat mitjançant :class:`CircuitSimulator` "
+"de ``qutip_qip``. Les mesures a mig circuit llancen ``ValueError``; totes"
+" les mesures han d'estar al final del circuit."
 
-#: ../../modules/backends/backends_qutip.rst:27
-msgid "**AnalogEvolution** driven by :class:`~qilisdk.analog.schedule.Schedule`."
-msgstr "**AnalogEvolution** impulsada per :class:`~qilisdk.analog.schedule.Schedule`."
+#: ../../modules/backends/backends_qutip.rst:67
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
 
-#: ../../modules/backends/backends_qutip.rst:28
+#: ../../modules/backends/backends_qutip.rst:69
 msgid ""
-"Compatible with "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram` for "
-"fully classical optimization loops."
+"Master-equation integration via QuTiP's :func:`qutip.mesolve`. ``nsteps``"
+" (default ``10_000``) caps the internal ODE substeps."
 msgstr ""
-"Compatible amb "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram` per "
-"a bucles d'optimització totalment clàssics."
+"Integració de l'equació mestra mitjançant :func:`qutip.mesolve` de QuTiP."
+" ``nsteps`` (per defecte ``10_000``) limita els subpassos interns de "
+"l'integrador ODE."
 
-#: ../../modules/backends/backends_qutip.rst:32
-msgid "Example"
-msgstr "Exemple"
+#: ../../modules/backends/backends_qutip.rst:70
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
 
-#: ../../modules/backends/backends_qutip.rst:81
-msgid "**Output**"
-msgstr "**Sortida**"
+#: ../../modules/backends/backends_qutip.rst:71
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_qutip.rst:72
+#, fuzzy
+msgid ""
+"The QutipBackend does not natively implement "
+":meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit "
+"steps in the reservoir layer fall back to dense ``QTensor`` unitary "
+"multiplication on CPU; ``Schedule`` steps still use QuTiP's "
+":func:`mesolve`."
+msgstr ""
+"QutipBackend no implementa :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Els "
+"passos ``Circuit`` de la capa del reservori recauen en una multiplicació "
+"unitària ``QTensor`` densa a CPU; els passos ``Schedule`` segueixen "
+"utilitzant :func:`mesolve` de QuTiP."
+
+#: ../../modules/backends/backends_qutip.rst:73
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+
+#: ../../modules/backends/backends_qutip.rst:75
+msgid "Reuses the digital/analog handlers above for each optimization step."
+msgstr ""
+"Reutilitza els manejadors digital/analògic anteriors a cada pas "
+"d'optimització."
+
+#: ../../modules/backends/backends_qutip.rst:82
+msgid "Configuration"
+msgstr "Configuració"
+
+#: ../../modules/backends/backends_qutip.rst:84
+msgid "QutipBackend has a single constructor option:"
+msgstr "QutipBackend té una única opció de constructor:"
+
+#: ../../modules/backends/backends_qutip.rst:90
+msgid "Option"
+msgstr "Opció"
+
+#: ../../modules/backends/backends_qutip.rst:91
+msgid "Meaning"
+msgstr "Significat"
+
+#: ../../modules/backends/backends_qutip.rst:92
+msgid "``nsteps``"
+msgstr "``nsteps``"
+
+#: ../../modules/backends/backends_qutip.rst:93
+msgid ""
+"Upper bound on the number of internal ODE substeps used by "
+":func:`qutip.mesolve` per schedule interval. Increase it if a long or "
+"stiff schedule causes the QuTiP solver to fail with a \"max steps "
+"exceeded\" warning. Defaults to ``10_000``."
+msgstr ""
+"Límit superior del nombre de subpassos interns de l'integrador ODE "
+"utilitzats per :func:`qutip.mesolve` per interval del schedule. "
+"Augmenteu-lo si un schedule llarg o rígid fa que el solver de QuTiP falli"
+" amb un avís \"max steps exceeded\". Per defecte ``10_000``."
+
+#: ../../modules/backends/backends_qutip.rst:105
+msgid ""
+"QutipBackend does **not** accept a :class:`~qilisdk.noise.NoiseModel`. "
+"For noisy digital or analog simulations use "
+":class:`~qilisdk.backends.qilisim.QiliSim` or "
+":class:`~qilisdk.backends.cuda_backend.CudaBackend` instead."
+msgstr ""
+"QutipBackend **no** accepta cap :class:`~qilisdk.noise.NoiseModel`. Per a"
+" simulacions digitals o analògiques amb soroll utilitzeu en el seu lloc "
+":class:`~qilisdk.backends.qilisim.QiliSim` o "
+":class:`~qilisdk.backends.cuda_backend.CudaBackend`."
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Aneu a un subapartat específic d'una pàgina."
+
+#~ msgid ""
+#~ "The **Qutip** backend uses the ``qutip``"
+#~ " library for simulation on CPU, "
+#~ "supporting both digital and analog "
+#~ "functionals. It is the most lightweight"
+#~ " option, ideal for local development "
+#~ "or environments without NVIDIA GPUs."
+#~ msgstr ""
+#~ "El backend **Qutip** utilitza la "
+#~ "biblioteca ``qutip`` per a la simulació"
+#~ " en CPU, admetent funcionals tant "
+#~ "digitals com analògics. És l'opció més"
+#~ " lleugera, ideal per al desenvolupament "
+#~ "local o entorns sense GPU NVIDIA."
+
+#~ msgid "Initialization"
+#~ msgstr "Inicialització"
+
+#~ msgid "Capabilities"
+#~ msgstr "Capacitats"
+
+#~ msgid ""
+#~ "**DigitalPropagation** of digital circuits via"
+#~ " QuTiP's state-vector solvers."
+#~ msgstr ""
+#~ "**DigitalPropagation** de circuits digitals "
+#~ "mitjançant els solucionadors de vector "
+#~ "d'estat de QuTiP."
+
+#~ msgid ""
+#~ "**AnalogEvolution** driven by "
+#~ ":class:`~qilisdk.analog.schedule.Schedule`."
+#~ msgstr ""
+#~ "**AnalogEvolution** impulsada per "
+#~ ":class:`~qilisdk.analog.schedule.Schedule`."
+
+#~ msgid "Example"
+#~ msgstr "Exemple"
+
+#~ msgid "**Output**"
+#~ msgstr "**Sortida**"
+

--- a/docs/locale/es/LC_MESSAGES/modules/backends/backends_cuda.po
+++ b/docs/locale/es/LC_MESSAGES/modules/backends/backends_cuda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -25,92 +25,310 @@ msgstr "Backend CUDA"
 
 #: ../../modules/backends/backends_cuda.rst:4
 msgid ""
-"The **CUDA** backend leverages NVIDIA GPUs via the ``cuda-quantum`` "
-"framework for both digital and analog simulations. When no compatible GPU"
-" is detected it automatically falls back to cpu-based targets, so you can"
-" prototype on commodity hardware before moving to accelerated machines."
+"The **CUDA** backend leverages NVIDIA GPUs via the `cuda-quantum "
+"<https://github.com/NVIDIA/cuda-quantum>`_ framework. When no compatible "
+"GPU is detected it transparently falls back to a CPU target, so the same "
+"code prototyped on a laptop will also run on an accelerated machine."
 msgstr ""
 "El backend **CUDA** aprovecha las GPU de NVIDIA a través del framework "
-"``cuda-quantum`` para simulaciones tanto digitales como analógicas. Cuando "
-"no se detecta ninguna GPU compatible, recurre automáticamente a destinos "
-"basados en CPU, de modo que puede crear prototipos en hardware convencional "
-"antes de migrar a máquinas con aceleración."
+"`cuda-quantum <https://github.com/NVIDIA/cuda-quantum>`_. Cuando no se "
+"detecta ninguna GPU compatible recae de forma transparente en un destino "
+"de CPU, de modo que el mismo código creado en un portátil también "
+"funcionará en una máquina con aceleración."
 
-#: ../../modules/backends/backends_cuda.rst:9
+#: ../../modules/backends/backends_cuda.rst:10
 msgid "Installation"
 msgstr "Instalación"
 
-#: ../../modules/backends/backends_cuda.rst:16
-msgid "Initialization"
-msgstr "Inicialización"
-
-#: ../../modules/backends/backends_cuda.rst:27
-msgid "Capabilities"
-msgstr "Capacidades"
-
-#: ../../modules/backends/backends_cuda.rst:29
-msgid ""
-"Digital circuits through "
-":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`."
-msgstr ""
-"Circuitos digitales mediante "
-":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`."
-
-#: ../../modules/backends/backends_cuda.rst:30
-msgid ""
-"Analog dynamics for "
-":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, powered "
-"by ``cudaq.evolve``."
-msgstr ""
-"Dinámica analógica para "
-":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, impulsada "
-"por ``cudaq.evolve``."
-
-#: ../../modules/backends/backends_cuda.rst:31
-msgid ""
-"Hybrid execution when paired with "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram`."
-msgstr ""
-"Ejecución híbrida cuando se combina con "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram`."
-
-#: ../../modules/backends/backends_cuda.rst:34
-msgid "Sampling methods"
-msgstr "Métodos de muestreo"
-
-#: ../../modules/backends/backends_cuda.rst:36
-msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`: "
-"Full state-vector simulation (switches to CPU if a GPU is unavailable)."
-msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`: "
-"Simulación completa de vector de estado (cambia a CPU si no hay GPU disponible)."
+#: ../../modules/backends/backends_cuda.rst:17
+msgid "Quick start"
+msgstr "Inicio rápido"
 
 #: ../../modules/backends/backends_cuda.rst:37
-msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`:"
-" Tensor-network contraction, suited for shallow yet wide circuits."
-msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`:"
-" Contracción de redes tensoriales, adecuada para circuitos poco profundos "
-"pero anchos."
+msgid "Functional support"
+msgstr "Soporte de funcionales"
 
-#: ../../modules/backends/backends_cuda.rst:38
+#: ../../modules/backends/backends_cuda.rst:43
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_cuda.rst:44
+msgid "Support"
+msgstr "Soporte"
+
+#: ../../modules/backends/backends_cuda.rst:45
+msgid "Notes"
+msgstr "Notas"
+
+#: ../../modules/backends/backends_cuda.rst:46
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_cuda.rst:47
+#: ../../modules/backends/backends_cuda.rst:50
+#: ../../modules/backends/backends_cuda.rst:56
+#: ../../modules/backends/backends_cuda.rst:80
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_cuda.rst:48
 msgid ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`:"
-" Matrix-product-state simulation for low-entanglement workloads."
+"Native CUDA-Q kernel. Sampling method selected via "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod`. Intermediate "
+"measurements raise ``NotImplementedError``."
 msgstr ""
-":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`:"
-" Simulación de estado producto de matrices para cargas de trabajo con bajo "
+"Kernel CUDA-Q nativo. El método de muestreo se selecciona mediante "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod`. Las "
+"mediciones intermedias lanzan ``NotImplementedError``."
+
+#: ../../modules/backends/backends_cuda.rst:49
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+
+#: ../../modules/backends/backends_cuda.rst:51
+msgid ""
+"Driven by ``cudaq.evolve`` on the ``dynamics`` target (always GPU-"
+"accelerated when available, independent of the digital sampling method)."
+msgstr ""
+"Impulsada por ``cudaq.evolve`` sobre el target ``dynamics`` (siempre "
+"acelerada por GPU cuando está disponible, con independencia del método de"
+" muestreo digital)."
+
+#: ../../modules/backends/backends_cuda.rst:52
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+
+#: ../../modules/backends/backends_cuda.rst:53
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_cuda.rst:54
+#, fuzzy
+msgid ""
+"The CudaBackend does not natively implement "
+":meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit "
+"steps inside the reservoir layer fall back to dense ``QTensor`` unitary "
+"multiplication on CPU; ``Schedule`` steps still use CUDA-Q's ``evolve``. "
+"Any attached noise model is ignored."
+msgstr ""
+"CudaBackend no implementa :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Los pasos"
+" ``Circuit`` dentro de la capa del reservorio recaen en una "
+"multiplicación unitaria ``QTensor`` densa en CPU; los pasos ``Schedule`` "
+"siguen utilizando ``evolve`` de CUDA-Q. Cualquier modelo de ruido adjunto"
+" se ignora."
+
+#: ../../modules/backends/backends_cuda.rst:55
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+
+#: ../../modules/backends/backends_cuda.rst:57
+msgid "Reuses the digital/analog handlers above for each optimization step."
+msgstr ""
+"Reutiliza los manejadores digital/analógico anteriores en cada paso de "
+"optimización."
+
+#: ../../modules/backends/backends_cuda.rst:64
+msgid "Configuration"
+msgstr "Configuración"
+
+#: ../../modules/backends/backends_cuda.rst:66
+msgid ""
+"The CUDA backend exposes a single configuration knob — "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — that selects"
+" the underlying CUDA-Q target used for **digital** circuits. Analog "
+"evolution always runs on the ``dynamics`` target and ignores this "
+"setting."
+msgstr ""
+"El backend CUDA expone una única perilla de configuración — "
+":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — que "
+"selecciona el target subyacente de CUDA-Q utilizado para los circuitos "
+"**digitales**. La evolución analógica siempre se ejecuta sobre el target "
+"``dynamics`` e ignora esta opción."
+
+#: ../../modules/backends/backends_cuda.rst:75
+msgid "Method"
+msgstr "Método"
+
+#: ../../modules/backends/backends_cuda.rst:76
+msgid "CUDA-Q target (and fallback)"
+msgstr "Target de CUDA-Q (y fallback)"
+
+#: ../../modules/backends/backends_cuda.rst:77
+msgid "Default"
+msgstr "Por defecto"
+
+#: ../../modules/backends/backends_cuda.rst:78
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`"
+
+#: ../../modules/backends/backends_cuda.rst:79
+msgid ""
+"``nvidia`` (GPU) when a GPU is available, otherwise ``qpp-cpu``. "
+"Precision matches :class:`~qilisdk.settings.Precision`."
+msgstr ""
+"``nvidia`` (GPU) cuando hay una GPU disponible; en caso contrario ``qpp-"
+"cpu``. La precisión coincide con :class:`~qilisdk.settings.Precision`."
+
+#: ../../modules/backends/backends_cuda.rst:81
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`"
+
+#: ../../modules/backends/backends_cuda.rst:82
+msgid "``tensornet``. Good for shallow, wide circuits."
+msgstr "``tensornet``. Adecuado para circuitos poco profundos pero anchos."
+
+#: ../../modules/backends/backends_cuda.rst:84
+msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`"
+msgstr ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`"
+
+#: ../../modules/backends/backends_cuda.rst:85
+msgid "``tensornet-mps``. Good for low-entanglement, long circuits."
+msgstr ""
+"``tensornet-mps``. Adecuado para circuitos largos con bajo "
 "entrelazamiento."
 
-#: ../../modules/backends/backends_cuda.rst:41
-msgid "Example"
-msgstr "Ejemplo"
+#: ../../modules/backends/backends_cuda.rst:88
+msgid "Set the method at construction time:"
+msgstr "Defina el método en el momento de la construcción:"
 
-#: ../../modules/backends/backends_cuda.rst:65
-msgid "**Output**"
-msgstr "**Salida**"
+#: ../../modules/backends/backends_cuda.rst:97
+msgid "Noise model support"
+msgstr "Soporte de modelos de ruido"
+
+#: ../../modules/backends/backends_cuda.rst:99
+msgid ""
+"A :class:`~qilisdk.noise.NoiseModel` can be passed to "
+"``CudaBackend(noise_model=…)``:"
+msgstr ""
+"Puede pasarse un :class:`~qilisdk.noise.NoiseModel` a "
+"``CudaBackend(noise_model=…)``:"
+
+#: ../../modules/backends/backends_cuda.rst:101
+msgid ""
+"For :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`,"
+" qilisdk noise channels are translated into a ``cudaq.NoiseModel`` (Kraus"
+" channels for static / time-derived noise, parameter perturbations "
+"applied to the circuit). With noise enabled, only a single "
+":class:`~qilisdk.readout.SamplingReadout` is supported."
+msgstr ""
+"Para "
+":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`, los"
+" canales de ruido de qilisdk se traducen a un ``cudaq.NoiseModel`` "
+"(canales de Kraus para ruido estático o derivado del tiempo, "
+"perturbaciones de parámetros aplicadas al circuito). Con ruido activado, "
+"solo se admite una única :class:`~qilisdk.readout.SamplingReadout`."
+
+#: ../../modules/backends/backends_cuda.rst:105
+msgid ""
+"For :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, "
+"Lindblad-compatible noise channels become CUDA-Q jump operators and "
+"Hamiltonian deltas fed to ``cudaq.evolve``."
+msgstr ""
+"Para :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, los "
+"canales de ruido compatibles con Lindblad se convierten en operadores de "
+"salto de CUDA-Q y en deltas del Hamiltoniano que se pasan a "
+"``cudaq.evolve``."
+
+#: ../../modules/backends/backends_cuda.rst:107
+msgid ""
+"For :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
+"the fallback implementation drops the noise model (a warning is logged)."
+msgstr ""
+"Para :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
+"la implementación de fallback descarta el modelo de ruido (se emite un "
+"aviso en el log)."
+
+#: ../../modules/backends/backends_cuda.rst:110
+msgid ""
+"Example: a depolarising channel applied to every gate of a digital "
+"circuit:"
+msgstr ""
+"Ejemplo: un canal despolarizador aplicado a cada puerta de un circuito "
+"digital:"
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Ir a un subtítulo específico de una página."
+
+#~ msgid "Capabilities"
+#~ msgstr "Capacidades"
+
+#~ msgid "Example"
+#~ msgstr "Ejemplo"
+
+#~ msgid "**Output**"
+#~ msgstr "**Salida**"
+
+#~ msgid "Sampling methods"
+#~ msgstr "Métodos de muestreo"
+
+#~ msgid "How each sampling method covers the functionals"
+#~ msgstr "Cómo cada método de muestreo cubre los funcionales"
+
+#~ msgid ""
+#~ "The table below shows which functionals"
+#~ " are affected by ``sampling_method``. Rows"
+#~ " marked |n| are unaffected — the "
+#~ "method is simply ignored for those "
+#~ "execution paths."
+#~ msgstr ""
+#~ "La tabla siguiente muestra qué "
+#~ "funcionales se ven afectados por "
+#~ "``sampling_method``. Las filas marcadas con"
+#~ " |n| no se ven afectadas — el"
+#~ " método simplemente se ignora en esas"
+#~ " rutas de ejecución."
+
+#~ msgid "Sampling method"
+#~ msgstr "Método de muestreo"
+
+#~ msgid "DigitalPropagation"
+#~ msgstr "DigitalPropagation"
+
+#~ msgid "AnalogEvolution"
+#~ msgstr "AnalogEvolution"
+
+#~ msgid "QuantumReservoir"
+#~ msgstr "QuantumReservoir"
+
+#~ msgid "VariationalProgram"
+#~ msgstr "VariationalProgram"
+
+#~ msgid "``STATE_VECTOR``"
+#~ msgstr "``STATE_VECTOR``"
+
+#~ msgid "|n| ``dynamics``"
+#~ msgstr "|n| ``dynamics``"
+
+#~ msgid "|p| Circuit steps via QTensor; Schedule steps via ``dynamics``"
+#~ msgstr "|p| Pasos Circuit vía QTensor; pasos Schedule vía ``dynamics``"
+
+#~ msgid "|y| (delegates to digital/analog)"
+#~ msgstr "|y| (delega en digital/analógico)"
+
+#~ msgid "``TENSOR_NETWORK``"
+#~ msgstr "``TENSOR_NETWORK``"
+
+#~ msgid "``MATRIX_PRODUCT_STATE``"
+#~ msgstr "``MATRIX_PRODUCT_STATE``"
+
+#~ msgid ""
+#~ "In short: ``sampling_method`` only changes "
+#~ "how a **digital** circuit is simulated."
+#~ " Analog evolution always uses "
+#~ "``cudaq.evolve`` on the ``dynamics`` target;"
+#~ " for reservoirs, only the analog "
+#~ "sub-step benefits from CUDA-Q (the "
+#~ "digital sub-circuits run on CPU "
+#~ "through ``QTensor``)."
+#~ msgstr ""
+#~ "En resumen: ``sampling_method`` solo cambia"
+#~ " cómo se simula un circuito "
+#~ "**digital**. La evolución analógica siempre"
+#~ " usa ``cudaq.evolve`` sobre el target "
+#~ "``dynamics``; en los reservorios, solo "
+#~ "el subpaso analógico se beneficia de "
+#~ "CUDA-Q (los subcircuitos digitales se "
+#~ "ejecutan en CPU mediante ``QTensor``)."
+

--- a/docs/locale/es/LC_MESSAGES/modules/backends/backends_overview.po
+++ b/docs/locale/es/LC_MESSAGES/modules/backends/backends_overview.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -30,24 +30,25 @@ msgid ""
 "three backends are supported:"
 msgstr ""
 "El módulo :mod:`~qilisdk.backends` proporciona motores de ejecución "
-"concretos para ejecutar :mod:`~qilisdk.functionals` (procesos cuánticos). "
-"Actualmente se admiten tres backends:"
+"concretos para ejecutar :mod:`~qilisdk.functionals` (procesos cuánticos)."
+" Actualmente se admiten tres backends:"
 
 #: ../../modules/backends/backends_overview.rst:7
 msgid ""
 ":doc:`QiliSim <backends_qilisim>`: A high-performance CPU simulator "
 "developed by Qilimanjaro, ideal for local development and testing."
 msgstr ""
-":doc:`QiliSim <backends_qilisim>`: Un simulador de CPU de alto rendimiento "
-"desarrollado por Qilimanjaro, ideal para el desarrollo y las pruebas locales."
+":doc:`QiliSim <backends_qilisim>`: Un simulador de CPU de alto "
+"rendimiento desarrollado por Qilimanjaro, ideal para el desarrollo y las "
+"pruebas locales."
 
 #: ../../modules/backends/backends_overview.rst:8
 msgid ""
 ":doc:`CUDA <backends_cuda>`: A GPU-accelerated backend leveraging NVIDIA "
 "hardware for large-scale simulations."
 msgstr ""
-":doc:`CUDA <backends_cuda>`: Un backend con aceleración GPU que aprovecha "
-"el hardware de NVIDIA para simulaciones a gran escala."
+":doc:`CUDA <backends_cuda>`: Un backend con aceleración GPU que aprovecha"
+" el hardware de NVIDIA para simulaciones a gran escala."
 
 #: ../../modules/backends/backends_overview.rst:9
 msgid ""
@@ -82,8 +83,8 @@ msgid ""
 "along with readout specifications:"
 msgstr ""
 "Una vez instalado, cualquier funcional primitivo puede ejecutarse "
-"pasándolo al método :meth:`~qilisdk.backends.backend.Backend.execute` del "
-"backend junto con las especificaciones de lectura:"
+"pasándolo al método :meth:`~qilisdk.backends.backend.Backend.execute` del"
+" backend junto con las especificaciones de lectura:"
 
 #: ../../modules/backends/backends_overview.rst:36
 msgid "Architecture Overview"
@@ -114,12 +115,12 @@ msgstr ""
 ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation` o "
 ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`) a la "
 "rutina de simulación apropiada y devuelve un "
-":class:`~qilisdk.functionals.functional_result.FunctionalResult` (véase el "
-"capítulo :doc:`Functionals </modules/functionals/functionals>`). El método "
-"execute también acepta especificaciones de lectura que definen cómo se mide "
-"el estado cuántico. Asimismo, se utiliza para optimizar programas "
-"variacionales mediante llamadas repetidas al funcional primitivo "
-"parametrizado subyacente."
+":class:`~qilisdk.functionals.functional_result.FunctionalResult` (véase "
+"el capítulo :doc:`Functionals </modules/functionals/functionals>`). El "
+"método execute también acepta especificaciones de lectura que definen "
+"cómo se mide el estado cuántico. Asimismo, se utiliza para optimizar "
+"programas variacionales mediante llamadas repetidas al funcional "
+"primitivo parametrizado subyacente."
 
 #: ../../modules/backends/backends_overview.rst:45
 msgid ""
@@ -131,7 +132,8 @@ msgstr ""
 "Los backends registran manejadores para los funcionales que soportan. Si "
 "un funcional no está implementado, "
 ":meth:`~qilisdk.backends.backend.Backend.execute` lanza "
-"``NotImplementedError`` para detectar la incompatibilidad de forma temprana."
+"``NotImplementedError`` para detectar la incompatibilidad de forma "
+"temprana."
 
 #: ../../modules/backends/backends_overview.rst:49
 msgid "Hardware & Dependencies"
@@ -148,7 +150,7 @@ msgstr ""
 "controladores compatibles presentes en el sistema."
 
 #: ../../modules/backends/backends_overview.rst:58
-#: ../../modules/backends/backends_overview.rst:84
+#: ../../modules/backends/backends_overview.rst:90
 msgid "Backend"
 msgstr "Backend"
 
@@ -165,13 +167,13 @@ msgid "Notes"
 msgstr "Notas"
 
 #: ../../modules/backends/backends_overview.rst:62
-#: ../../modules/backends/backends_overview.rst:89
+#: ../../modules/backends/backends_overview.rst:95
 msgid ":class:`QiliSim <qilisdk.backends.qilisim.QiliSim>`"
 msgstr ":class:`QiliSim <qilisdk.backends.qilisim.QiliSim>`"
 
 #: ../../modules/backends/backends_overview.rst:63
-msgid "``qilisim``"
-msgstr "``qilisim``"
+msgid "--"
+msgstr "--"
 
 #: ../../modules/backends/backends_overview.rst:64
 msgid "None"
@@ -183,7 +185,7 @@ msgid "CPU based; no special hardware needs."
 msgstr "Basado en CPU; no requiere hardware especial."
 
 #: ../../modules/backends/backends_overview.rst:66
-#: ../../modules/backends/backends_overview.rst:94
+#: ../../modules/backends/backends_overview.rst:100
 msgid ":class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`"
 msgstr ":class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`"
 
@@ -200,7 +202,7 @@ msgid "Requires NVIDIA hardware with recent drivers."
 msgstr "Requiere hardware NVIDIA con controladores recientes."
 
 #: ../../modules/backends/backends_overview.rst:70
-#: ../../modules/backends/backends_overview.rst:99
+#: ../../modules/backends/backends_overview.rst:105
 msgid ":class:`QutipBackend <qilisdk.backends.qutip_backend.QutipBackend>`"
 msgstr ":class:`QutipBackend <qilisdk.backends.qutip_backend.QutipBackend>`"
 
@@ -224,33 +226,80 @@ msgstr ""
 "La tabla siguiente resume qué :mod:`~qilisdk.functionals` primitivos "
 "puede ejecutar cada backend."
 
-#: ../../modules/backends/backends_overview.rst:85
+#: ../../modules/backends/backends_overview.rst:80
+msgid "Legend:"
+msgstr "Leyenda:"
+
+#: ../../modules/backends/backends_overview.rst:82
+msgid "|y| Fully supported by the backend's native simulator."
+msgstr "|y| Totalmente soportado por el simulador nativo del backend."
+
+#: ../../modules/backends/backends_overview.rst:83
+msgid ""
+"|p| Partially supported — see the per-backend page for the exact "
+"limitation."
+msgstr ""
+"|p| Parcialmente soportado — consulta la página de cada backend para ver "
+"la limitación exacta."
+
+#: ../../modules/backends/backends_overview.rst:84
+msgid "|n| Not supported."
+msgstr "|n| No soportado."
+
+#: ../../modules/backends/backends_overview.rst:91
 msgid "DigitalPropagation"
 msgstr "DigitalPropagation"
 
-#: ../../modules/backends/backends_overview.rst:86
+#: ../../modules/backends/backends_overview.rst:92
 msgid "AnalogEvolution"
 msgstr "AnalogEvolution"
 
-#: ../../modules/backends/backends_overview.rst:87
+#: ../../modules/backends/backends_overview.rst:93
 msgid "QuantumReservoir"
 msgstr "QuantumReservoir"
 
-#: ../../modules/backends/backends_overview.rst:88
+#: ../../modules/backends/backends_overview.rst:94
 msgid "VariationalProgram"
 msgstr "VariationalProgram"
 
-#: ../../modules/backends/backends_overview.rst:90
-#: ../../modules/backends/backends_overview.rst:91
-#: ../../modules/backends/backends_overview.rst:92
-#: ../../modules/backends/backends_overview.rst:93
-#: ../../modules/backends/backends_overview.rst:95
 #: ../../modules/backends/backends_overview.rst:96
 #: ../../modules/backends/backends_overview.rst:97
 #: ../../modules/backends/backends_overview.rst:98
-#: ../../modules/backends/backends_overview.rst:100
+#: ../../modules/backends/backends_overview.rst:99
 #: ../../modules/backends/backends_overview.rst:101
 #: ../../modules/backends/backends_overview.rst:102
-#: ../../modules/backends/backends_overview.rst:103
+#: ../../modules/backends/backends_overview.rst:104
+#: ../../modules/backends/backends_overview.rst:106
+#: ../../modules/backends/backends_overview.rst:107
+#: ../../modules/backends/backends_overview.rst:109
 msgid "|y|"
 msgstr "|y|"
+
+#: ../../modules/backends/backends_overview.rst:103
+#: ../../modules/backends/backends_overview.rst:108
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_overview.rst:113
+#, fuzzy
+msgid ""
+"``QuantumReservoir`` is fully native only on QiliSim. On the "
+":class:`CudaBackend` and :class:`QutipBackend` the ``Circuit`` reservoir "
+"steps are evaluated as dense QTensor unitaries on CPU, while ``Schedule``"
+" steps still use the backend's native analog solver. Attaching a "
+":class:`~qilisdk.noise.NoiseModel` to a reservoir run is ignored on both "
+":class:`CudaBackend` and :class:`QutipBackend`. (a warning is logged)."
+msgstr ""
+"``QuantumReservoir`` solo es totalmente nativo en QiliSim. En "
+":class:`CudaBackend` y :class:`QutipBackend`, el reservorio recurre a la "
+"implementación por defecto en :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`: los pasos"
+" ``Circuit`` del reservorio se evalúan como unitarios QTensor densos en "
+"CPU, mientras que los pasos ``Schedule`` siguen utilizando el solver "
+"analógico nativo del backend. Asociar un "
+":class:`~qilisdk.noise.NoiseModel` a una ejecución de reservorio se "
+"ignora en todos los backends (se emite un aviso en el log)."
+
+#~ msgid "``qilisim``"
+#~ msgstr "``qilisim``"
+

--- a/docs/locale/es/LC_MESSAGES/modules/backends/backends_qilisim.po
+++ b/docs/locale/es/LC_MESSAGES/modules/backends/backends_qilisim.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -20,93 +20,498 @@ msgstr ""
 "Generated-By: Babel 2.18.0\n"
 
 #: ../../modules/backends/backends_qilisim.rst:2
-msgid "QiliSim"
+#, fuzzy
+msgid "QiliSim Backend"
 msgstr "QiliSim"
 
 #: ../../modules/backends/backends_qilisim.rst:4
+#, fuzzy
 msgid ""
-"The **QiliSim** backend is a CPU-based simulator developed by Qilimanjaro"
-" and written in C++, providing efficient simulation of both digital and "
-"analog quantum functionals. It is designed for ease of use and does not "
-"require any special hardware or dependencies. There is no need to install"
-" QiliSim separately, as it is included with the core QILISDK "
-"installation."
+"The **QiliSim** backend is the default CPU simulator developed by "
+"Qilimanjaro and written in C++. It implements every primitive functional "
+"natively, supports a noise model on all execution paths, and is included "
+"with the core ``qilisdk`` installation — no extra dependency or hardware "
+"is required."
 msgstr ""
-"El backend **QiliSim** es un simulador basado en CPU desarrollado por "
-"Qilimanjaro y escrito en C++, que proporciona una simulación eficiente de "
-"funcionales cuánticos tanto digitales como analógicos. Está diseñado para "
-"facilitar su uso y no requiere hardware ni dependencias especiales. No es "
-"necesario instalar QiliSim por separado, ya que se incluye con la "
-"instalación principal de QILISDK."
+"El backend **QiliSim** es el simulador de CPU por defecto desarrollado "
+"por Qilimanjaro y escrito en C++ (expuesto mediante ``pybind11``). "
+"Implementa todos los funcionales primitivos de forma nativa, soporta un "
+"modelo de ruido en todas las rutas de ejecución y se incluye con la "
+"instalación principal de ``qilisdk`` — no requiere dependencias ni "
+"hardware adicionales."
 
-#: ../../modules/backends/backends_qilisim.rst:10
-msgid "Example"
-msgstr "Ejemplo"
+#: ../../modules/backends/backends_qilisim.rst:9
+msgid "Installation"
+msgstr "Instalación"
 
-#: ../../modules/backends/backends_qilisim.rst:34
-msgid "Configuration"
-msgstr "Configuración"
-
-#: ../../modules/backends/backends_qilisim.rst:36
+#: ../../modules/backends/backends_qilisim.rst:11
 msgid ""
-"QiliSim has a variety of configuration options to customize the "
-"simulation methods and performance characteristics. These can be set at "
-"initialization via the ``analog_simulation_method``, "
-"``digital_simulation_method``, and ``execution_config`` parameters:"
+"QiliSim is bundled with the core ``qilisdk`` installation, so no extra "
+"package is required:"
 msgstr ""
-"QiliSim dispone de diversas opciones de configuración para personalizar "
-"los métodos de simulación y las características de rendimiento. Estas "
-"pueden establecerse en la inicialización mediante los parámetros "
-"``analog_simulation_method``, ``digital_simulation_method`` y "
-"``execution_config``:"
 
+#: ../../modules/backends/backends_qilisim.rst:15
+msgid "Quick start"
+msgstr "Inicio rápido"
+
+#: ../../modules/backends/backends_qilisim.rst:39
+msgid "Functional support"
+msgstr "Soporte de funcionales"
+
+#: ../../modules/backends/backends_qilisim.rst:41
+msgid ""
+"QiliSim natively supports all primitive functionals through dedicated C++"
+" routines:"
+msgstr ""
+"QiliSim soporta de forma nativa todos los funcionales primitivos mediante"
+" rutinas dedicadas en C++:"
+
+#: ../../modules/backends/backends_qilisim.rst:47
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_qilisim.rst:48
+msgid "Support"
+msgstr "Soporte"
+
+#: ../../modules/backends/backends_qilisim.rst:49
+msgid "Notes"
+msgstr "Notas"
+
+#: ../../modules/backends/backends_qilisim.rst:50
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_qilisim.rst:51
 #: ../../modules/backends/backends_qilisim.rst:54
-msgid "Possible analog simulation methods:"
-msgstr "Métodos de simulación analógica posibles:"
+#: ../../modules/backends/backends_qilisim.rst:57
+#: ../../modules/backends/backends_qilisim.rst:60
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_qilisim.rst:52
+msgid ""
+"Statevector-based simulation, configurable via "
+":class:`~qilisdk.backends.backend_config.DigitalMethod`."
+msgstr ""
+"Simulación basada en vector de estado, configurable mediante "
+":class:`~qilisdk.backends.backend_config.DigitalMethod`."
+
+#: ../../modules/backends/backends_qilisim.rst:53
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+
+#: ../../modules/backends/backends_qilisim.rst:55
+msgid ""
+"Multiple integration schemes, configurable via "
+":class:`~qilisdk.backends.backend_config.AnalogMethod`."
+msgstr ""
+"Múltiples esquemas de integración, configurables mediante "
+":class:`~qilisdk.backends.backend_config.AnalogMethod`."
 
 #: ../../modules/backends/backends_qilisim.rst:56
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.integrator`: "
-"General-purpose RK4 integrator."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.integrator`: "
-"Integrador RK4 de propósito general."
-
-#: ../../modules/backends/backends_qilisim.rst:57
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
-" Adaptive RK45 integrator, faster for some systems."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
-" Integrador RK45 adaptativo, más rápido para algunos sistemas."
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
 
 #: ../../modules/backends/backends_qilisim.rst:58
 msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.direct`: Matrix "
-"exponential method for small systems."
+"Native C++ implementation; supports both Circuit and Schedule reservoir "
+"steps."
 msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.direct`: Método de "
-"exponencial matricial para sistemas pequeños."
+"Implementación nativa en C++; soporta tanto pasos Circuit como Schedule "
+"del reservorio."
 
 #: ../../modules/backends/backends_qilisim.rst:59
-msgid ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.arnoldi`: Krylov "
-"subspace method."
-msgstr ""
-":class:`~qilisdk.backends.backend_config.AnalogMethod.arnoldi`: Método de "
-"subespacio de Krylov."
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
 
 #: ../../modules/backends/backends_qilisim.rst:61
-msgid "Possible digital simulation methods:"
-msgstr "Métodos de simulación digital posibles:"
-
-#: ../../modules/backends/backends_qilisim.rst:63
-msgid ""
-":class:`~qilisdk.backends.backend_config.DigitalMethod.statevector`: "
-"Exact state-vector simulation with optional caching."
+msgid "Reuses the primitive functional handlers above for each optimization step."
 msgstr ""
-":class:`~qilisdk.backends.backend_config.DigitalMethod.statevector`: "
-"Simulación exacta de vector de estado con caché opcional."
+"Reutiliza los manejadores de funcionales primitivos anteriores en cada "
+"paso de optimización."
+
+#: ../../modules/backends/backends_qilisim.rst:68
+msgid "Configuration"
+msgstr "Configuración"
+
+#: ../../modules/backends/backends_qilisim.rst:70
+msgid ""
+"QiliSim is configured at construction time through three orthogonal "
+"sections, all defined in :mod:`qilisdk.backends.backend_config`:"
+msgstr ""
+"QiliSim se configura en el momento de la construcción a través de tres "
+"secciones ortogonales, todas definidas en "
+":mod:`qilisdk.backends.backend_config`:"
+
+#: ../../modules/backends/backends_qilisim.rst:73
+msgid ""
+":class:`~qilisdk.backends.backend_config.AnalogMethod` — chooses the "
+"analog time-evolution scheme and its hyperparameters."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.AnalogMethod` — elige el esquema"
+" de evolución temporal analógica y sus hiperparámetros."
+
+#: ../../modules/backends/backends_qilisim.rst:75
+msgid ""
+":class:`~qilisdk.backends.backend_config.DigitalMethod` — chooses the "
+"digital simulation strategy and its caching / normalization options."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.DigitalMethod` — elige la "
+"estrategia de simulación digital y sus opciones de caché / normalización."
+
+#: ../../modules/backends/backends_qilisim.rst:77
+msgid ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` — global "
+"execution controls (threads, random seed, Monte Carlo trajectories, "
+"measurement-collapse behaviour)."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` — controles "
+"globales de ejecución (hilos, semilla aleatoria, trayectorias de Monte "
+"Carlo, comportamiento del colapso de medición)."
+
+#: ../../modules/backends/backends_qilisim.rst:105
+msgid "If any argument is omitted, QiliSim falls back to:"
+msgstr "Si se omite algún argumento, QiliSim recurre a:"
+
+#: ../../modules/backends/backends_qilisim.rst:107
+msgid ""
+":meth:`AnalogMethod.integrator() "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>` (matrix-free "
+"RK4),"
+msgstr ""
+":meth:`AnalogMethod.integrator() "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>` (RK4 sin "
+"matriz),"
+
+#: ../../modules/backends/backends_qilisim.rst:109
+msgid ""
+":meth:`DigitalMethod.statevector() "
+"<qilisdk.backends.backend_config.DigitalMethod.statevector>`,"
+msgstr ""
+":meth:`DigitalMethod.statevector() "
+"<qilisdk.backends.backend_config.DigitalMethod.statevector>`,"
+
+#: ../../modules/backends/backends_qilisim.rst:110
+msgid ""
+"a default :class:`~qilisdk.backends.backend_config.ExecutionConfig` (all "
+"cores, random seed, Monte Carlo disabled)."
+msgstr ""
+"un :class:`~qilisdk.backends.backend_config.ExecutionConfig` por defecto "
+"(todos los núcleos, semilla aleatoria, Monte Carlo desactivado)."
+
+#: ../../modules/backends/backends_qilisim.rst:114
+msgid "Analog simulation methods"
+msgstr "Métodos de simulación analógica"
+
+#: ../../modules/backends/backends_qilisim.rst:116
+msgid ""
+"Use the classmethods of "
+":class:`~qilisdk.backends.backend_config.AnalogMethod` to choose how the "
+"schedule is integrated:"
+msgstr ""
+"Utilice los métodos de clase de "
+":class:`~qilisdk.backends.backend_config.AnalogMethod` para elegir cómo "
+"se integra el schedule:"
+
+#: ../../modules/backends/backends_qilisim.rst:123
+msgid "Constructor"
+msgstr "Constructor"
+
+#: ../../modules/backends/backends_qilisim.rst:124
+msgid "Underlying scheme"
+msgstr "Esquema subyacente"
+
+#: ../../modules/backends/backends_qilisim.rst:125
+msgid "When to use it"
+msgstr "Cuándo utilizarlo"
+
+#: ../../modules/backends/backends_qilisim.rst:126
+msgid ""
+":meth:`AnalogMethod.integrator(matrix_free=True) "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>`"
+msgstr ""
+":meth:`AnalogMethod.integrator(matrix_free=True) "
+"<qilisdk.backends.backend_config.AnalogMethod.integrator>`"
+
+#: ../../modules/backends/backends_qilisim.rst:127
+msgid "RK4"
+msgstr "RK4"
+
+#: ../../modules/backends/backends_qilisim.rst:128
+msgid ""
+"Default. Fixed-step Runge-Kutta 4; matrix-free is faster for sparse "
+"Hamiltonians."
+msgstr ""
+"Por defecto. Runge-Kutta 4 con paso fijo; sin matriz es más rápido para "
+"Hamiltonianos dispersos."
+
+#: ../../modules/backends/backends_qilisim.rst:129
+msgid ""
+":meth:`AnalogMethod.adaptive_integrator(tol=1e-2) "
+"<qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator>`"
+msgstr ""
+":meth:`AnalogMethod.adaptive_integrator(tol=1e-2) "
+"<qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator>`"
+
+#: ../../modules/backends/backends_qilisim.rst:130
+msgid "Dormand-Prince RK4/5"
+msgstr "Dormand-Prince RK4/5"
+
+#: ../../modules/backends/backends_qilisim.rst:131
+msgid ""
+"Adaptive step size; ``tol`` bounds the fidelity error between the RK4 and"
+" RK5 estimates."
+msgstr ""
+"Tamaño de paso adaptativo; ``tol`` acota el error de fidelidad entre las "
+"estimaciones RK4 y RK5."
+
+#: ../../modules/backends/backends_qilisim.rst:132
+msgid ""
+":meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) "
+"<qilisdk.backends.backend_config.AnalogMethod.arnoldi>`"
+msgstr ""
+":meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) "
+"<qilisdk.backends.backend_config.AnalogMethod.arnoldi>`"
+
+#: ../../modules/backends/backends_qilisim.rst:133
+msgid "Krylov / Arnoldi"
+msgstr "Krylov / Arnoldi"
+
+#: ../../modules/backends/backends_qilisim.rst:134
+msgid ""
+"Better scaling for large sparse Hamiltonians; tune ``dim`` for the Krylov"
+" subspace size."
+msgstr ""
+"Mejor escalabilidad para Hamiltonianos dispersos grandes; ajuste ``dim`` "
+"para el tamaño del subespacio de Krylov."
+
+#: ../../modules/backends/backends_qilisim.rst:135
+msgid ""
+":meth:`AnalogMethod.direct() "
+"<qilisdk.backends.backend_config.AnalogMethod.direct>`"
+msgstr ""
+":meth:`AnalogMethod.direct() "
+"<qilisdk.backends.backend_config.AnalogMethod.direct>`"
+
+#: ../../modules/backends/backends_qilisim.rst:136
+msgid "Matrix exponential"
+msgstr "Exponencial de matriz"
+
+#: ../../modules/backends/backends_qilisim.rst:137
+msgid "Reference scheme for small systems; cost grows quickly with qubit count."
+msgstr ""
+"Esquema de referencia para sistemas pequeños; el coste crece rápidamente "
+"con el número de qubits."
+
+#: ../../modules/backends/backends_qilisim.rst:139
+msgid "Example, using the adaptive integrator for a stiffer schedule:"
+msgstr "Ejemplo, utilizando el integrador adaptativo para un schedule más rígido:"
+
+#: ../../modules/backends/backends_qilisim.rst:148
+msgid "Digital simulation methods"
+msgstr "Métodos de simulación digital"
+
+#: ../../modules/backends/backends_qilisim.rst:150
+msgid ""
+"Digital execution is currently always state-vector based; the "
+":class:`~qilisdk.backends.backend_config.DigitalMethod` configuration "
+"tunes its performance characteristics rather than choosing a different "
+"algorithm:"
+msgstr ""
+"La ejecución digital se basa actualmente siempre en vector de estado; la "
+"configuración :class:`~qilisdk.backends.backend_config.DigitalMethod` "
+"ajusta sus características de rendimiento en lugar de elegir un algoritmo"
+" distinto:"
+
+#: ../../modules/backends/backends_qilisim.rst:158
+msgid "Option"
+msgstr "Opción"
+
+#: ../../modules/backends/backends_qilisim.rst:159
+msgid "Meaning"
+msgstr "Significado"
+
+#: ../../modules/backends/backends_qilisim.rst:160
+msgid "``matrix_free``"
+msgstr "``matrix_free``"
+
+#: ../../modules/backends/backends_qilisim.rst:161
+msgid ""
+"Apply gates directly to the statevector instead of building dense "
+"matrices. Default ``True``."
+msgstr ""
+"Aplica las puertas directamente al vector de estado en lugar de construir"
+" matrices densas. Por defecto ``True``."
+
+#: ../../modules/backends/backends_qilisim.rst:162
+msgid "``max_cache_size``"
+msgstr "``max_cache_size``"
+
+#: ../../modules/backends/backends_qilisim.rst:163
+msgid "Maximum number of precomputed gate matrices cached between executions."
+msgstr ""
+"Número máximo de matrices de puerta precomputadas almacenadas en caché "
+"entre ejecuciones."
+
+#: ../../modules/backends/backends_qilisim.rst:164
+msgid "``combine_single_qubit_gates``"
+msgstr "``combine_single_qubit_gates``"
+
+#: ../../modules/backends/backends_qilisim.rst:165
+msgid ""
+"Merge adjacent single-qubit gates into a single operation before "
+"propagating."
+msgstr ""
+"Fusiona puertas de un solo qubit adyacentes en una única operación antes "
+"de propagar."
+
+#: ../../modules/backends/backends_qilisim.rst:166
+msgid "``normalize_after_each_gate``"
+msgstr "``normalize_after_each_gate``"
+
+#: ../../modules/backends/backends_qilisim.rst:167
+msgid ""
+"Renormalize the statevector after each gate to mitigate numerical drift, "
+"at a runtime cost."
+msgstr ""
+"Renormaliza el vector de estado tras cada puerta para mitigar la deriva "
+"numérica, con un coste de tiempo de ejecución."
+
+#: ../../modules/backends/backends_qilisim.rst:181
+msgid "Execution and Monte Carlo"
+msgstr "Ejecución y Monte Carlo"
+
+#: ../../modules/backends/backends_qilisim.rst:183
+msgid ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` controls "
+"threading, randomness, and optional Monte Carlo trajectory sampling for "
+"open-system simulations."
+msgstr ""
+":class:`~qilisdk.backends.backend_config.ExecutionConfig` controla los "
+"hilos, la aleatoriedad y el muestreo opcional de trayectorias Monte Carlo"
+" para simulaciones de sistemas abiertos."
+
+#: ../../modules/backends/backends_qilisim.rst:186
+msgid "``num_threads=0`` (default) lets the simulator use every physical core."
+msgstr ""
+"``num_threads=0`` (por defecto) permite al simulador utilizar todos los "
+"núcleos físicos."
+
+#: ../../modules/backends/backends_qilisim.rst:187
+msgid ""
+"``seed=None`` (default) draws a fresh random seed at construction time; "
+"pass an integer for reproducibility."
+msgstr ""
+"``seed=None`` (por defecto) genera una semilla aleatoria nueva en el "
+"momento de la construcción; pase un entero para reproducibilidad."
+
+#: ../../modules/backends/backends_qilisim.rst:189
+msgid ""
+"``monte_carlo=MonteCarloConfig(trajectories=N)`` enables stochastic "
+"trajectory sampling for noise models that admit a Monte Carlo unraveling;"
+" leave it ``None`` for deterministic master-equation evolution."
+msgstr ""
+"``monte_carlo=MonteCarloConfig(trajectories=N)`` activa el muestreo "
+"estocástico de trayectorias para modelos de ruido que admiten un "
+"unraveling de Monte Carlo; déjelo en ``None`` para una evolución "
+"determinista de la ecuación maestra."
+
+#: ../../modules/backends/backends_qilisim.rst:192
+msgid ""
+"``measurement_collapse`` controls whether measurements collapse the "
+"statevector in place (relevant for mid-circuit measurement and reservoir "
+"computing); defaults to ``False``."
+msgstr ""
+"``measurement_collapse`` controla si las mediciones colapsan el vector de"
+" estado in situ (relevante para mediciones en mitad del circuito y "
+"computación de reservorios); por defecto ``False``."
+
+#: ../../modules/backends/backends_qilisim.rst:209
+#, fuzzy
+msgid "Noise model support"
+msgstr "Soporte de funcionales"
+
+#: ../../modules/backends/backends_qilisim.rst:211
+msgid ""
+"Any :class:`~qilisdk.noise.NoiseModel` accepted by the SDK can be passed "
+"directly to the constructor; QiliSim applies it inside the C++ solver, so"
+" digital, analog, and reservoir runs all see the same noise channels:"
+msgstr ""
+"Cualquier :class:`~qilisdk.noise.NoiseModel` aceptado por el SDK se puede"
+" pasar directamente al constructor; QiliSim lo aplica dentro del solver "
+"de C++, de modo que las ejecuciones digitales, analógicas y de reservorio"
+" ven todos los mismos canales de ruido:"
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Ir a un subtítulo específico de una página."
+
+#~ msgid ""
+#~ "The **QiliSim** backend is a CPU-"
+#~ "based simulator developed by Qilimanjaro "
+#~ "and written in C++, providing efficient"
+#~ " simulation of both digital and "
+#~ "analog quantum functionals. It is "
+#~ "designed for ease of use and does"
+#~ " not require any special hardware or"
+#~ " dependencies. There is no need to"
+#~ " install QiliSim separately, as it is"
+#~ " included with the core QILISDK "
+#~ "installation."
+#~ msgstr ""
+#~ "El backend **QiliSim** es un simulador"
+#~ " basado en CPU desarrollado por "
+#~ "Qilimanjaro y escrito en C++, que "
+#~ "proporciona una simulación eficiente de "
+#~ "funcionales cuánticos tanto digitales como "
+#~ "analógicos. Está diseñado para facilitar "
+#~ "su uso y no requiere hardware ni"
+#~ " dependencias especiales. No es necesario"
+#~ " instalar QiliSim por separado, ya "
+#~ "que se incluye con la instalación "
+#~ "principal de QILISDK."
+
+#~ msgid "Example"
+#~ msgstr "Ejemplo"
+
+#~ msgid ""
+#~ "QiliSim has a variety of configuration"
+#~ " options to customize the simulation "
+#~ "methods and performance characteristics. These"
+#~ " can be set at initialization via "
+#~ "the ``analog_simulation_method``, "
+#~ "``digital_simulation_method``, and ``execution_config``"
+#~ " parameters:"
+#~ msgstr ""
+#~ "QiliSim dispone de diversas opciones de"
+#~ " configuración para personalizar los "
+#~ "métodos de simulación y las "
+#~ "características de rendimiento. Estas pueden"
+#~ " establecerse en la inicialización mediante"
+#~ " los parámetros ``analog_simulation_method``, "
+#~ "``digital_simulation_method`` y ``execution_config``:"
+
+#~ msgid ""
+#~ ":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
+#~ " Adaptive RK45 integrator, faster for "
+#~ "some systems."
+#~ msgstr ""
+#~ ":class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`:"
+#~ " Integrador RK45 adaptativo, más rápido "
+#~ "para algunos sistemas."
+
+#~ msgid ""
+#~ "A :class:`~qilisdk.noise.NoiseModel` may be "
+#~ "attached to a QiliSim instance and "
+#~ "is honoured by every functional handler"
+#~ " (digital, analog, and reservoir)."
+#~ msgstr ""
+#~ "Puede asociarse un "
+#~ ":class:`~qilisdk.noise.NoiseModel` a una instancia"
+#~ " de QiliSim y será respetado por "
+#~ "todos los manejadores de funcionales "
+#~ "(digital, analógico y reservorio)."
+
+#~ msgid "Using a noise model"
+#~ msgstr "Uso de un modelo de ruido"
+

--- a/docs/locale/es/LC_MESSAGES/modules/backends/backends_qutip.po
+++ b/docs/locale/es/LC_MESSAGES/modules/backends/backends_qutip.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 15:18+0200\n"
+"POT-Creation-Date: 2026-05-21 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -25,57 +25,194 @@ msgstr "Backend QuTiP"
 
 #: ../../modules/backends/backends_qutip.rst:4
 msgid ""
-"The **Qutip** backend uses the ``qutip`` library for simulation on CPU, "
-"supporting both digital and analog functionals. It is the most "
-"lightweight option, ideal for local development or environments without "
-"NVIDIA GPUs."
+"The **Qutip** backend uses the `QuTiP <https://qutip.org/>`_ library for "
+"CPU-only simulation. It is the most lightweight optional backend — no "
+"GPU, no compiled extension — and is well suited to local development, CI "
+"pipelines and educational notebooks."
 msgstr ""
-"El backend **Qutip** utiliza la biblioteca ``qutip`` para la simulación "
-"en CPU, con soporte para funcionales tanto digitales como analógicos. Es "
-"la opción más ligera, ideal para el desarrollo local o entornos sin GPUs "
-"de NVIDIA."
+"El backend **Qutip** utiliza la biblioteca `QuTiP <https://qutip.org/>`_ "
+"para simulación únicamente en CPU. Es el backend opcional más ligero — "
+"sin GPU ni extensión compilada — y resulta idóneo para el desarrollo "
+"local, pipelines de CI y notebooks educativos."
 
-#: ../../modules/backends/backends_qutip.rst:8
+#: ../../modules/backends/backends_qutip.rst:9
 msgid "Installation"
 msgstr "Instalación"
 
-#: ../../modules/backends/backends_qutip.rst:15
-msgid "Initialization"
-msgstr "Inicialización"
+#: ../../modules/backends/backends_qutip.rst:16
+msgid "Quick start"
+msgstr "Inicio rápido"
 
-#: ../../modules/backends/backends_qutip.rst:24
-msgid "Capabilities"
-msgstr "Capacidades"
+#: ../../modules/backends/backends_qutip.rst:55
+msgid "Functional support"
+msgstr "Soporte de funcionales"
 
-#: ../../modules/backends/backends_qutip.rst:26
+#: ../../modules/backends/backends_qutip.rst:61
+msgid "Functional"
+msgstr "Funcional"
+
+#: ../../modules/backends/backends_qutip.rst:62
+msgid "Support"
+msgstr "Soporte"
+
+#: ../../modules/backends/backends_qutip.rst:63
+msgid "Notes"
+msgstr "Notas"
+
+#: ../../modules/backends/backends_qutip.rst:64
+msgid ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+msgstr ":class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`"
+
+#: ../../modules/backends/backends_qutip.rst:65
+#: ../../modules/backends/backends_qutip.rst:68
+#: ../../modules/backends/backends_qutip.rst:74
+msgid "|y|"
+msgstr "|y|"
+
+#: ../../modules/backends/backends_qutip.rst:66
 msgid ""
-"**DigitalPropagation** of digital circuits via QuTiP's state-vector "
-"solvers."
+"Statevector simulation via ``qutip_qip``'s :class:`CircuitSimulator`. "
+"Mid-circuit measurements raise ``ValueError``; all measurements must be "
+"at the end of the circuit."
 msgstr ""
-"**DigitalPropagation** de circuitos digitales mediante los solucionadores "
-"de vector de estado de QuTiP."
+"Simulación basada en vector de estado mediante :class:`CircuitSimulator` "
+"de ``qutip_qip``. Las mediciones en mitad del circuito lanzan "
+"``ValueError``; todas las mediciones deben estar al final del circuito."
 
-#: ../../modules/backends/backends_qutip.rst:27
-msgid "**AnalogEvolution** driven by :class:`~qilisdk.analog.schedule.Schedule`."
-msgstr "**AnalogEvolution** impulsada por :class:`~qilisdk.analog.schedule.Schedule`."
+#: ../../modules/backends/backends_qutip.rst:67
+msgid ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
+msgstr ":class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`"
 
-#: ../../modules/backends/backends_qutip.rst:28
+#: ../../modules/backends/backends_qutip.rst:69
 msgid ""
-"Compatible with "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram` for "
-"fully classical optimization loops."
+"Master-equation integration via QuTiP's :func:`qutip.mesolve`. ``nsteps``"
+" (default ``10_000``) caps the internal ODE substeps."
 msgstr ""
-"Compatible con "
-":class:`~qilisdk.functionals.variational_program.VariationalProgram` para "
-"bucles de optimización totalmente clásicos."
+"Integración de la ecuación maestra mediante :func:`qutip.mesolve` de "
+"QuTiP. ``nsteps`` (por defecto ``10_000``) limita los subpasos internos "
+"del integrador ODE."
 
-#: ../../modules/backends/backends_qutip.rst:32
-msgid "Example"
-msgstr "Ejemplo"
+#: ../../modules/backends/backends_qutip.rst:70
+msgid ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
+msgstr ":class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`"
 
-#: ../../modules/backends/backends_qutip.rst:81
-msgid "**Output**"
-msgstr "**Salida**"
+#: ../../modules/backends/backends_qutip.rst:71
+msgid "|p|"
+msgstr "|p|"
+
+#: ../../modules/backends/backends_qutip.rst:72
+#, fuzzy
+msgid ""
+"The QutipBackend does not natively implement "
+":meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit "
+"steps in the reservoir layer fall back to dense ``QTensor`` unitary "
+"multiplication on CPU; ``Schedule`` steps still use QuTiP's "
+":func:`mesolve`."
+msgstr ""
+"QutipBackend no implementa :meth:`Backend._execute_quantum_reservoir "
+"<qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Los pasos"
+" ``Circuit`` de la capa del reservorio recaen en una multiplicación "
+"unitaria ``QTensor`` densa en CPU; los pasos ``Schedule`` siguen "
+"utilizando :func:`mesolve` de QuTiP."
+
+#: ../../modules/backends/backends_qutip.rst:73
+msgid ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+msgstr ":class:`~qilisdk.functionals.variational_program.VariationalProgram`"
+
+#: ../../modules/backends/backends_qutip.rst:75
+msgid "Reuses the digital/analog handlers above for each optimization step."
+msgstr ""
+"Reutiliza los manejadores digital/analógico anteriores en cada paso de "
+"optimización."
+
+#: ../../modules/backends/backends_qutip.rst:82
+msgid "Configuration"
+msgstr "Configuración"
+
+#: ../../modules/backends/backends_qutip.rst:84
+msgid "QutipBackend has a single constructor option:"
+msgstr "QutipBackend tiene una única opción de constructor:"
+
+#: ../../modules/backends/backends_qutip.rst:90
+msgid "Option"
+msgstr "Opción"
+
+#: ../../modules/backends/backends_qutip.rst:91
+msgid "Meaning"
+msgstr "Significado"
+
+#: ../../modules/backends/backends_qutip.rst:92
+msgid "``nsteps``"
+msgstr "``nsteps``"
+
+#: ../../modules/backends/backends_qutip.rst:93
+msgid ""
+"Upper bound on the number of internal ODE substeps used by "
+":func:`qutip.mesolve` per schedule interval. Increase it if a long or "
+"stiff schedule causes the QuTiP solver to fail with a \"max steps "
+"exceeded\" warning. Defaults to ``10_000``."
+msgstr ""
+"Cota superior del número de subpasos internos del integrador ODE "
+"utilizados por :func:`qutip.mesolve` por intervalo del schedule. "
+"Auméntelo si un schedule largo o rígido provoca que el solver de QuTiP "
+"falle con un aviso \"max steps exceeded\". Por defecto ``10_000``."
+
+#: ../../modules/backends/backends_qutip.rst:105
+msgid ""
+"QutipBackend does **not** accept a :class:`~qilisdk.noise.NoiseModel`. "
+"For noisy digital or analog simulations use "
+":class:`~qilisdk.backends.qilisim.QiliSim` or "
+":class:`~qilisdk.backends.cuda_backend.CudaBackend` instead."
+msgstr ""
+"QutipBackend **no** acepta un :class:`~qilisdk.noise.NoiseModel`. Para "
+"simulaciones digitales o analógicas con ruido utilice en su lugar "
+":class:`~qilisdk.backends.qilisim.QiliSim` o "
+":class:`~qilisdk.backends.cuda_backend.CudaBackend`."
 
 #~ msgid "Go to a specific subheading of a page."
 #~ msgstr "Ir a un subtítulo específico de una página."
+
+#~ msgid ""
+#~ "The **Qutip** backend uses the ``qutip``"
+#~ " library for simulation on CPU, "
+#~ "supporting both digital and analog "
+#~ "functionals. It is the most lightweight"
+#~ " option, ideal for local development "
+#~ "or environments without NVIDIA GPUs."
+#~ msgstr ""
+#~ "El backend **Qutip** utiliza la "
+#~ "biblioteca ``qutip`` para la simulación "
+#~ "en CPU, con soporte para funcionales "
+#~ "tanto digitales como analógicos. Es la"
+#~ " opción más ligera, ideal para el "
+#~ "desarrollo local o entornos sin GPUs "
+#~ "de NVIDIA."
+
+#~ msgid "Initialization"
+#~ msgstr "Inicialización"
+
+#~ msgid "Capabilities"
+#~ msgstr "Capacidades"
+
+#~ msgid ""
+#~ "**DigitalPropagation** of digital circuits via"
+#~ " QuTiP's state-vector solvers."
+#~ msgstr ""
+#~ "**DigitalPropagation** de circuitos digitales "
+#~ "mediante los solucionadores de vector de"
+#~ " estado de QuTiP."
+
+#~ msgid ""
+#~ "**AnalogEvolution** driven by "
+#~ ":class:`~qilisdk.analog.schedule.Schedule`."
+#~ msgstr ""
+#~ "**AnalogEvolution** impulsada por "
+#~ ":class:`~qilisdk.analog.schedule.Schedule`."
+
+#~ msgid "Example"
+#~ msgstr "Ejemplo"
+
+#~ msgid "**Output**"
+#~ msgstr "**Salida**"
+

--- a/docs/modules/backends/backends_cuda.rst
+++ b/docs/modules/backends/backends_cuda.rst
@@ -63,7 +63,7 @@ Functional support
 Configuration
 =============
 
-The CUDA backend exposes a single configuration knob —
+The CUDA backend exposes a single configuration parameter —
 :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — that selects the underlying CUDA-Q
 target used for **digital** circuits. Analog evolution always runs on the ``dynamics`` target and
 ignores this setting.

--- a/docs/modules/backends/backends_cuda.rst
+++ b/docs/modules/backends/backends_cuda.rst
@@ -112,9 +112,12 @@ Example: a depolarising channel applied to every gate of a digital circuit:
 .. code-block:: python
 
     from qilisdk.backends import CudaBackend, CudaSamplingMethod
-    from qilisdk.noise import NoiseModel, Depolarizing
+    from qilisdk.noise import NoiseModel, Depolarizing 
+
+    nm = NoiseModel()
+    nm.add(Depolarizing(probability=1e-3))
 
     backend = CudaBackend(
         sampling_method=CudaSamplingMethod.STATE_VECTOR,
-        noise_model=NoiseModel(global_noise=[Depolarizing(probability=1e-3)]),
+        noise_model=nm,
     )

--- a/docs/modules/backends/backends_cuda.rst
+++ b/docs/modules/backends/backends_cuda.rst
@@ -1,44 +1,20 @@
 CUDA Backend
 ------------
 
-The **CUDA** backend leverages NVIDIA GPUs via the ``cuda-quantum`` framework for both digital and analog simulations.
-When no compatible GPU is detected it automatically falls back to cpu-based targets, so you can prototype on
-commodity hardware before moving to accelerated machines.
+The **CUDA** backend leverages NVIDIA GPUs via the
+`cuda-quantum <https://github.com/NVIDIA/cuda-quantum>`_ framework. When no compatible GPU is
+detected it transparently falls back to a CPU target, so the same code prototyped on a laptop will
+also run on an accelerated machine.
 
 Installation
-================
+============
 
 .. code-block:: console
 
-    pip install qilisdk[cuda]
+    pip install qilisdk[cuda12]   # or [cuda13]
 
-Initialization
-=================
-
-.. code-block:: python
-
-    from qilisdk.backends import CudaBackend, CudaSamplingMethod
-
-    backend = CudaBackend(
-        sampling_method=CudaSamplingMethod.STATE_VECTOR
-    )
-
-Capabilities
-================
-
-- Digital circuits through :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`.
-- Analog dynamics for :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, powered by ``cudaq.evolve``.
-- Hybrid execution when paired with :class:`~qilisdk.functionals.variational_program.VariationalProgram`.
-
-Sampling methods
-==================
-
-- :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`: Full state-vector simulation (switches to CPU if a GPU is unavailable).
-- :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`: Tensor-network contraction, suited for shallow yet wide circuits.
-- :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`: Matrix-product-state simulation for low-entanglement workloads.
-
-Example
-============
+Quick start
+===========
 
 .. code-block:: python
 
@@ -48,23 +24,97 @@ Example
     from qilisdk.functionals import DigitalPropagation
     from qilisdk.readout import Readout
 
-    # Build a simple circuit
     circuit = Circuit(2)
     circuit.add(RX(0, theta=np.pi / 4))
     circuit.add(H(0))
     circuit.add(CNOT(0, 1))
 
-    # Create DigitalPropagation functional
-    functional = DigitalPropagation(circuit)
-
-    # Execute with the chosen sampling method (GPU if available)
-    cuda_backend = CudaBackend(sampling_method=CudaSamplingMethod.STATE_VECTOR)
-    result = cuda_backend.execute(functional, Readout().with_sampling(nshots=500))
+    backend = CudaBackend(sampling_method=CudaSamplingMethod.STATE_VECTOR)
+    result = backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=500))
     print(result.get_samples())
 
-**Output**
+Functional support
+==================
 
-::
+.. list-table::
+   :header-rows: 1
+   :widths: 35 12 53
 
-    {'11': 237, '00': 263}
+   * - Functional
+     - Support
+     - Notes
+   * - :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`
+     - |y|
+     - Native CUDA-Q kernel. Sampling method selected via :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod`. Intermediate measurements raise ``NotImplementedError``.
+   * - :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`
+     - |y|
+     - Driven by ``cudaq.evolve`` on the ``dynamics`` target (always GPU-accelerated when available, independent of the digital sampling method).
+   * - :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`
+     - |p|
+     - The CudaBackend does not natively implement :meth:`Backend._execute_quantum_reservoir <qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit steps inside the reservoir layer fall back to dense ``QTensor`` unitary multiplication on CPU; ``Schedule`` steps still use CUDA-Q's ``evolve``. Any attached noise model is ignored.
+   * - :class:`~qilisdk.functionals.variational_program.VariationalProgram`
+     - |y|
+     - Reuses the digital/analog handlers above for each optimization step.
 
+.. |y| unicode:: U+2705
+.. |p| unicode:: U+1F7E1
+.. |n| unicode:: U+274C
+
+Configuration
+=============
+
+The CUDA backend exposes a single configuration knob —
+:class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — that selects the underlying CUDA-Q
+target used for **digital** circuits. Analog evolution always runs on the ``dynamics`` target and
+ignores this setting.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 60 15
+
+   * - Method
+     - CUDA-Q target (and fallback)
+     - Default
+   * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`
+     - ``nvidia`` (GPU) when a GPU is available, otherwise ``qpp-cpu``. Precision matches :class:`~qilisdk.settings.Precision`.
+     - |y|
+   * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`
+     - ``tensornet``. Good for shallow, wide circuits.
+     -
+   * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`
+     - ``tensornet-mps``. Good for low-entanglement, long circuits.
+     -
+
+Set the method at construction time:
+
+.. code-block:: python
+
+    from qilisdk.backends import CudaBackend, CudaSamplingMethod
+
+    backend = CudaBackend(sampling_method=CudaSamplingMethod.MATRIX_PRODUCT_STATE)
+
+Noise model support
+===================
+
+A :class:`~qilisdk.noise.NoiseModel` can be passed to ``CudaBackend(noise_model=…)``:
+
+- For :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`, qilisdk noise channels
+  are translated into a ``cudaq.NoiseModel`` (Kraus channels for static / time-derived noise,
+  parameter perturbations applied to the circuit). With noise enabled, only a single
+  :class:`~qilisdk.readout.SamplingReadout` is supported.
+- For :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, Lindblad-compatible noise
+  channels become CUDA-Q jump operators and Hamiltonian deltas fed to ``cudaq.evolve``.
+- For :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, the fallback
+  implementation drops the noise model (a warning is logged).
+
+Example: a depolarising channel applied to every gate of a digital circuit:
+
+.. code-block:: python
+
+    from qilisdk.backends import CudaBackend, CudaSamplingMethod
+    from qilisdk.noise import NoiseModel, Depolarizing
+
+    backend = CudaBackend(
+        sampling_method=CudaSamplingMethod.STATE_VECTOR,
+        noise_model=NoiseModel(global_noise=[Depolarizing(probability=1e-3)]),
+    )

--- a/docs/modules/backends/backends_overview.rst
+++ b/docs/modules/backends/backends_overview.rst
@@ -60,7 +60,7 @@ drivers to be present on the system.
      - Key dependency
      - Notes
    * - :class:`QiliSim <qilisdk.backends.qilisim.QiliSim>`
-     - ``qilisim``
+     - --
      - None
      - CPU based; no special hardware needs.
    * - :class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`
@@ -76,6 +76,12 @@ Functional Support
 ------------------
 
 The table below summarizes which primitive :mod:`~qilisdk.functionals` each backend can execute.
+
+Legend:
+
+- |y| Fully supported by the backend's native simulator.
+- |p| Partially supported — see the per-backend page for the exact limitation.
+- |n| Not supported.
 
 .. list-table::
    :header-rows: 1
@@ -94,12 +100,23 @@ The table below summarizes which primitive :mod:`~qilisdk.functionals` each back
    * - :class:`CudaBackend <qilisdk.backends.cuda_backend.CudaBackend>`
      - |y|
      - |y|
-     - |y|
+     - |p|
      - |y|
    * - :class:`QutipBackend <qilisdk.backends.qutip_backend.QutipBackend>`
      - |y|
      - |y|
-     - |y|
+     - |p|
      - |y|
 
-.. |y| unicode:: U+2713
+.. note::
+
+   ``QuantumReservoir`` is fully native only on QiliSim. On the :class:`CudaBackend` and
+   :class:`QutipBackend` the ``Circuit`` reservoir steps are evaluated as dense QTensor unitaries on CPU, while
+   ``Schedule`` steps still use the backend's native analog solver. Attaching a
+   :class:`~qilisdk.noise.NoiseModel` to a reservoir run is ignored on both :class:`CudaBackend` and
+   :class:`QutipBackend`.
+   (a warning is logged).
+
+.. |y| unicode:: U+2705
+.. |p| unicode:: U+1F7E1
+.. |n| unicode:: U+274C

--- a/docs/modules/backends/backends_qilisim.rst
+++ b/docs/modules/backends/backends_qilisim.rst
@@ -1,13 +1,18 @@
-QiliSim
-----------------
+QiliSim Backend
+---------------
 
-The **QiliSim** backend is a CPU-based simulator developed by Qilimanjaro and written in C++, providing
-efficient simulation of both digital and analog quantum functionals.
-It is designed for ease of use and does not require any special hardware or dependencies.
-There is no need to install QiliSim separately, as it is included with the core QILISDK installation.
+The **QiliSim** backend is the default CPU simulator developed by Qilimanjaro and written in C++.
+It implements every primitive functional natively, supports a noise model on all execution paths,
+and is included with the core ``qilisdk`` installation — no extra dependency or hardware is required.
 
-Example
-==================
+Installation
+============
+
+QiliSim is bundled with the core ``qilisdk`` installation, so no extra package is required.
+
+
+Quick start
+===========
 
 .. code-block:: python
 
@@ -30,35 +35,187 @@ Example
     result = backend.execute(functional, Readout().with_sampling(nshots=500))
     print(result.get_samples())
 
-Configuration
-================
+Functional support
+==================
 
-QiliSim has a variety of configuration options to customize the simulation methods and performance characteristics.
-These can be set at initialization via the ``analog_simulation_method``, ``digital_simulation_method``, and ``execution_config`` parameters:
+QiliSim natively supports all primitive functionals through dedicated C++ routines:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 12 53
+
+   * - Functional
+     - Support
+     - Notes
+   * - :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`
+     - |y|
+     - Statevector-based simulation, configurable via :class:`~qilisdk.backends.backend_config.DigitalMethod`.
+   * - :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`
+     - |y|
+     - Multiple integration schemes, configurable via :class:`~qilisdk.backends.backend_config.AnalogMethod`.
+   * - :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`
+     - |y|
+     - Native C++ implementation; supports both Circuit and Schedule reservoir steps.
+   * - :class:`~qilisdk.functionals.variational_program.VariationalProgram`
+     - |y|
+     - Reuses the primitive functional handlers above for each optimization step.
+
+.. |y| unicode:: U+2705
+.. |p| unicode:: U+1F7E1
+.. |n| unicode:: U+274C
+
+Configuration
+=============
+
+QiliSim is configured at construction time through three orthogonal sections, all defined in
+:mod:`qilisdk.backends.backend_config`:
+
+- :class:`~qilisdk.backends.backend_config.AnalogMethod` — chooses the analog time-evolution scheme
+  and its hyperparameters.
+- :class:`~qilisdk.backends.backend_config.DigitalMethod` — chooses the digital simulation strategy
+  and its caching / normalization options.
+- :class:`~qilisdk.backends.backend_config.ExecutionConfig` — global execution controls (threads,
+  random seed, Monte Carlo trajectories, measurement-collapse behaviour).
+
+.. code-block:: python
+
+    from qilisdk.backends import (
+        AnalogMethod,
+        DigitalMethod,
+        ExecutionConfig,
+        MonteCarloConfig,
+        QiliSim,
+    )
+
+    backend = QiliSim(
+        analog_simulation_method=AnalogMethod.arnoldi(dim=16, num_substeps=2),
+        digital_simulation_method=DigitalMethod.statevector(
+            matrix_free=True,
+            max_cache_size=2_000,
+            combine_single_qubit_gates=True,
+        ),
+        execution_config=ExecutionConfig(
+            num_threads=4,
+            seed=42,
+            monte_carlo=MonteCarloConfig(trajectories=200),
+            measurement_collapse=False,
+        ),
+    )
+
+If any argument is omitted, QiliSim falls back to:
+
+- :meth:`AnalogMethod.integrator() <qilisdk.backends.backend_config.AnalogMethod.integrator>`
+  (matrix-free RK4),
+- :meth:`DigitalMethod.statevector() <qilisdk.backends.backend_config.DigitalMethod.statevector>`,
+- a default :class:`~qilisdk.backends.backend_config.ExecutionConfig` (all cores, random seed,
+  Monte Carlo disabled).
+
+Analog simulation methods
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the classmethods of :class:`~qilisdk.backends.backend_config.AnalogMethod` to choose how the
+schedule is integrated:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 12 60
+
+   * - Constructor
+     - Underlying scheme
+     - When to use it
+   * - :meth:`AnalogMethod.integrator(matrix_free=True) <qilisdk.backends.backend_config.AnalogMethod.integrator>`
+     - RK4
+     - Default. Fixed-step Runge-Kutta 4; matrix-free is faster for sparse Hamiltonians.
+   * - :meth:`AnalogMethod.adaptive_integrator(tol=1e-2) <qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator>`
+     - Dormand-Prince RK4/5
+     - Adaptive step size; ``tol`` bounds the fidelity error between the RK4 and RK5 estimates.
+   * - :meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) <qilisdk.backends.backend_config.AnalogMethod.arnoldi>`
+     - Krylov / Arnoldi
+     - Better scaling for large sparse Hamiltonians; tune ``dim`` for the Krylov subspace size.
+   * - :meth:`AnalogMethod.direct() <qilisdk.backends.backend_config.AnalogMethod.direct>`
+     - Matrix exponential
+     - Reference scheme for small systems; cost grows quickly with qubit count.
+
+Example, using the adaptive integrator for a stiffer schedule:
+
+.. code-block:: python
+
+    from qilisdk.backends import AnalogMethod, QiliSim
+
+    backend = QiliSim(analog_simulation_method=AnalogMethod.adaptive_integrator(tol=1e-4))
+
+Digital simulation methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Digital execution is currently always state-vector based; the
+:class:`~qilisdk.backends.backend_config.DigitalMethod` configuration tunes its performance
+characteristics rather than choosing a different algorithm:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Option
+     - Meaning
+   * - ``matrix_free``
+     - Apply gates directly to the statevector instead of building dense matrices. Default ``True``.
+   * - ``max_cache_size``
+     - Maximum number of precomputed gate matrices cached between executions.
+   * - ``combine_single_qubit_gates``
+     - Merge adjacent single-qubit gates into a single operation before propagating.
+   * - ``normalize_after_each_gate``
+     - Renormalize the statevector after each gate to mitigate numerical drift, at a runtime cost.
+
+.. code-block:: python
+
+    from qilisdk.backends import DigitalMethod, QiliSim
+
+    backend = QiliSim(
+        digital_simulation_method=DigitalMethod.statevector(
+            matrix_free=False,
+            normalize_after_each_gate=True,
+        ),
+    )
+
+Execution and Monte Carlo
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`~qilisdk.backends.backend_config.ExecutionConfig` controls threading, randomness, and
+optional Monte Carlo trajectory sampling for open-system simulations.
+
+- ``num_threads=0`` (default) lets the simulator use every physical core.
+- ``seed=None`` (default) draws a fresh random seed at construction time; pass an integer for
+  reproducibility.
+- ``monte_carlo=MonteCarloConfig(trajectories=N)`` enables stochastic trajectory sampling for
+  noise models that admit a Monte Carlo unraveling; leave it ``None`` for deterministic master-equation
+  evolution.
+- ``measurement_collapse`` controls whether measurements collapse the statevector in place
+  (relevant for mid-circuit measurement and reservoir computing); defaults to ``False``.
+
+.. code-block:: python
+
+    from qilisdk.backends import ExecutionConfig, MonteCarloConfig, QiliSim
+
+    backend = QiliSim(
+        execution_config=ExecutionConfig(
+            num_threads=8,
+            seed=1234,
+            monte_carlo=MonteCarloConfig(trajectories=500),
+            measurement_collapse=True,
+        ),
+    )
+
+Noise model support
+===================
+
+Any :class:`~qilisdk.noise.NoiseModel` accepted by the SDK can be passed directly to the constructor;
+QiliSim applies it inside the C++ solver, so digital, analog, and reservoir runs all see the same
+noise channels:
 
 .. code-block:: python
 
     from qilisdk.backends import QiliSim
-    from qilisdk.backends import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
+    from qilisdk.noise import NoiseModel, Depolarizing
 
-    backend = QiliSim(
-        analog_simulation_method=AnalogMethod.integrator(),
-        digital_simulation_method=DigitalMethod.statevector(),
-        execution_config=ExecutionConfig(
-            num_threads=4, 
-            seed=42, 
-            monte_carlo=MonteCarloConfig(trajectories=200)
-        ),
-    )
-
-Possible analog simulation methods:
-
-- :class:`~qilisdk.backends.backend_config.AnalogMethod.integrator`: General-purpose RK4 integrator.
-- :class:`~qilisdk.backends.backend_config.AnalogMethod.adaptive_integrator`: Adaptive RK45 integrator, faster for some systems.
-- :class:`~qilisdk.backends.backend_config.AnalogMethod.direct`: Matrix exponential method for small systems.
-- :class:`~qilisdk.backends.backend_config.AnalogMethod.arnoldi`: Krylov subspace method.
-
-Possible digital simulation methods:
-
-- :class:`~qilisdk.backends.backend_config.DigitalMethod.statevector`: Exact state-vector simulation with optional caching.
-
+    noise = NoiseModel(global_noise=[Depolarizing(probability=1e-3)])
+    backend = QiliSim(noise_model=noise)

--- a/docs/modules/backends/backends_qilisim.rst
+++ b/docs/modules/backends/backends_qilisim.rst
@@ -215,7 +215,9 @@ noise channels:
 .. code-block:: python
 
     from qilisdk.backends import QiliSim
-    from qilisdk.noise import NoiseModel, Depolarizing
+    from qilisdk.noise import NoiseModel, Depolarizing 
 
-    noise = NoiseModel(global_noise=[Depolarizing(probability=1e-3)])
-    backend = QiliSim(noise_model=noise)
+    nm = NoiseModel()
+    nm.add(Depolarizing(probability=1e-3))
+
+    backend = QiliSim(noise_model=nm)

--- a/docs/modules/backends/backends_qilisim.rst
+++ b/docs/modules/backends/backends_qilisim.rst
@@ -73,7 +73,7 @@ QiliSim is configured at construction time through three orthogonal sections, al
 - :class:`~qilisdk.backends.backend_config.AnalogMethod` — chooses the analog time-evolution scheme
   and its hyperparameters.
 - :class:`~qilisdk.backends.backend_config.DigitalMethod` — chooses the digital simulation strategy
-  and its caching / normalization options.
+  and its hyperparameters.
 - :class:`~qilisdk.backends.backend_config.ExecutionConfig` — global execution controls (threads,
   random seed, Monte Carlo trajectories, measurement-collapse behaviour).
 
@@ -131,7 +131,7 @@ schedule is integrated:
      - Adaptive step size; ``tol`` bounds the fidelity error between the RK4 and RK5 estimates.
    * - :meth:`AnalogMethod.arnoldi(dim=10, num_substeps=1) <qilisdk.backends.backend_config.AnalogMethod.arnoldi>`
      - Krylov / Arnoldi
-     - Better scaling for large sparse Hamiltonians; tune ``dim`` for the Krylov subspace size.
+     - Can offer decent scaling for large sparse Hamiltonians; tune ``dim`` for the Krylov subspace size.
    * - :meth:`AnalogMethod.direct() <qilisdk.backends.backend_config.AnalogMethod.direct>`
      - Matrix exponential
      - Reference scheme for small systems; cost grows quickly with qubit count.
@@ -142,7 +142,7 @@ Example, using the adaptive integrator for a stiffer schedule:
 
     from qilisdk.backends import AnalogMethod, QiliSim
 
-    backend = QiliSim(analog_simulation_method=AnalogMethod.adaptive_integrator(tol=1e-4))
+    backend = QiliSim(analog_simulation_method=AnalogMethod.adaptive_integrator(tol=1e-2))
 
 Digital simulation methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ characteristics rather than choosing a different algorithm:
    * - ``max_cache_size``
      - Maximum number of precomputed gate matrices cached between executions.
    * - ``combine_single_qubit_gates``
-     - Merge adjacent single-qubit gates into a single operation before propagating.
+     - Merge adjacent single-qubit gates into a single operation before propagating. Disabled if gate-specific noise is used.
    * - ``normalize_after_each_gate``
      - Renormalize the statevector after each gate to mitigate numerical drift, at a runtime cost.
 

--- a/docs/modules/backends/backends_qutip.rst
+++ b/docs/modules/backends/backends_qutip.rst
@@ -1,35 +1,19 @@
 Qutip Backend
 -------------
 
-The **Qutip** backend uses the ``qutip`` library for simulation on CPU, supporting both digital and analog functionals.
-It is the most lightweight option, ideal for local development or environments without NVIDIA GPUs.
+The **Qutip** backend uses the `QuTiP <https://qutip.org/>`_ library for CPU-only simulation. It is
+the most lightweight optional backend — no GPU, no compiled extension — and is well suited to local
+development, CI pipelines and educational notebooks.
 
 Installation
-===============
+============
 
 .. code-block:: console
 
     pip install qilisdk[qutip]
 
-Initialization
-=================
-
-.. code-block:: python
-
-    from qilisdk.backends import QutipBackend
-
-    backend = QutipBackend()
-
-Capabilities
-==============
-
-- **DigitalPropagation** of digital circuits via QuTiP's state-vector solvers.
-- **AnalogEvolution** driven by :class:`~qilisdk.analog.schedule.Schedule`.
-- Compatible with :class:`~qilisdk.functionals.variational_program.VariationalProgram` for fully classical
-  optimization loops.
-
-Example
-==========
+Quick start
+===========
 
 .. code-block:: python
 
@@ -41,16 +25,13 @@ Example
     from qilisdk.functionals import AnalogEvolution
     from qilisdk.readout import Readout
 
-    # Define total time and timestep
     T = 10.0
     dt = 0.5
     nqubits = 1
 
-    # Define Hamiltonians
     Hx = sum(X(i) for i in range(nqubits))
     Hz = sum(Z(i) for i in range(nqubits))
 
-    # Build a time-dependent schedule
     schedule = Schedule(
         hamiltonians={"driver": Hx, "problem": Hz},
         coefficients={
@@ -61,30 +42,66 @@ Example
         interpolation=Interpolation.LINEAR,
     )
 
-    # Prepare an equal superposition initial state
     initial_state = tensor_prod([(ket(0) - ket(1)).unit() for _ in range(nqubits)]).unit()
 
-    # Create the AnalogEvolution functional
-    analog_evolution = AnalogEvolution(
-        schedule=schedule,
-        initial_state=initial_state,
-    )
-
-    # Execute on Qutip backend and inspect results
     backend = QutipBackend()
     results = backend.execute(
-        analog_evolution,
+        AnalogEvolution(schedule=schedule, initial_state=initial_state),
         Readout().with_expectation(observables=[Z(0), X(0), Y(0)]).with_state_tomography(),
     )
     print(results)
 
-**Output**
+Functional support
+==================
 
-::
+.. list-table::
+   :header-rows: 1
+   :widths: 35 12 53
 
-    FunctionalResult(
-        expectation_values=array([-0.99388223,  0.0467696 , -0.10005353]),
-        final_state=QTensor(shape=2x1, nnz=2, format='csr')
-        [[0.05506547-0.00516502j]
-        [0.3364973 -0.94005887j]]
-    )
+   * - Functional
+     - Support
+     - Notes
+   * - :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`
+     - |y|
+     - Statevector simulation via ``qutip_qip``'s :class:`CircuitSimulator`. Mid-circuit measurements raise ``ValueError``; all measurements must be at the end of the circuit.
+   * - :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`
+     - |y|
+     - Master-equation integration via QuTiP's :func:`qutip.mesolve`. ``nsteps`` (default ``10_000``) caps the internal ODE substeps.
+   * - :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`
+     - |p|
+     - The QutipBackend does not natively implement :meth:`Backend._execute_quantum_reservoir <qilisdk.backends.backend.Backend._execute_quantum_reservoir>`. Circuit steps in the reservoir layer fall back to dense ``QTensor`` unitary multiplication on CPU; ``Schedule`` steps still use QuTiP's :func:`mesolve`.
+   * - :class:`~qilisdk.functionals.variational_program.VariationalProgram`
+     - |y|
+     - Reuses the digital/analog handlers above for each optimization step.
+
+.. |y| unicode:: U+2705
+.. |p| unicode:: U+1F7E1
+.. |n| unicode:: U+274C
+
+Configuration
+=============
+
+QutipBackend has a single constructor option:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Option
+     - Meaning
+   * - ``nsteps``
+     - Upper bound on the number of internal ODE substeps used by
+       :func:`qutip.mesolve` per schedule interval. Increase it if a long or stiff schedule causes
+       the QuTiP solver to fail with a "max steps exceeded" warning. Defaults to ``10_000``.
+
+.. code-block:: python
+
+    from qilisdk.backends import QutipBackend
+
+    backend = QutipBackend(nsteps=50_000)
+
+.. note::
+
+   QutipBackend does **not** accept a :class:`~qilisdk.noise.NoiseModel`. For noisy digital or
+   analog simulations use :class:`~qilisdk.backends.qilisim.QiliSim` or
+   :class:`~qilisdk.backends.cuda_backend.CudaBackend` instead.


### PR DESCRIPTION
Expanded the Backends documentation: full QiliSim page with simulation-method descriptions, per-backend functional-support tables (with partial-support markers for QuantumReservoir on CUDA and Qutip), a sampling-methods table for the CUDA backend, noise-model notes, and unified section structure across the QiliSim, CUDA, and Qutip pages.
