### PR TITLE
[SDK-282] Fix MPS Expectation Values

### DIFF
--- a/changes/221.bugfix.md
+++ b/changes/221.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug in which the `CudaBackend` would crash if the user requested expectation values or a state from an MPS or tensor simulation. Now an error is correctly raised, telling the user to use sampling instead. This information has also been added to the docs.

--- a/docs/modules/backends/backends_cuda.rst
+++ b/docs/modules/backends/backends_cuda.rst
@@ -65,31 +65,43 @@ Configuration
 
 The CUDA backend exposes a single configuration parameter —
 :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — that selects the underlying CUDA-Q
-target used for **digital** circuits. Analog evolution always runs on the ``dynamics`` target and
-ignores this setting.
+target used for **digital** circuits. If no method is specified, ``STATE_VECTOR`` is used.
+Analog evolution always runs on the ``dynamics`` target and ignores this setting. 
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 60 15
+   :widths: 25 60 15 15 15
 
    * - Method
-     - CUDA-Q target (and fallback)
-     - Default
+     - CUDA-Q target
+     - Supports Sampling
+     - Supports Expectation Values
+     - Supports State Tomography
    * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR`
-     - ``nvidia`` (GPU) when a GPU is available, otherwise ``qpp-cpu``. Precision matches :class:`~qilisdk.settings.Precision`.
+     - ``nvidia`` when a GPU is available, otherwise ``qpp-cpu``. Precision matches :class:`~qilisdk.settings.Precision`.
+     - |y|
+     - |y|
      - |y|
    * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR_MGPU`
-     - ``nvidia-mgpu`` (multiple GPUs) when multiple GPUs are available, otherwise falls back to ``nvidia``.
-     - 
+     - ``nvidia-mgpu`` when multiple GPUs are available, otherwise falls back to ``nvidia``.
+     - |y|
+     - |y|
+     - |y|
    * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.TENSOR_NETWORK`
      - ``tensornet``. Good for shallow, wide circuits.
-     -
+     - |y|
+     - |n|
+     - |n|
    * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.MATRIX_PRODUCT_STATE`
      - ``tensornet-mps``. Good for low-entanglement, long circuits.
-     -
+     - |y|
+     - |n|
+     - |n|
    * - :class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.CPU`
      - ``cpu``. Force running on CPU. Mostly useful for benchmarking.
-     -
+     - |y|
+     - |y|
+     - |y|
 
 Set the method at construction time:
 

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -254,6 +254,15 @@ class CudaBackend(Backend):
         qubits = kernel.qalloc(functional.circuit.nqubits)
         og_param = None
 
+        # If it's MPS or TN, we can't get the state, only samples
+        if self.sampling_method in {
+            CudaSamplingMethod.TENSOR_NETWORK,
+            CudaSamplingMethod.MATRIX_PRODUCT_STATE,
+        } and not all(ro.is_sampling_readout() for ro in readout):
+            raise ValueError(
+                f"Only Sampling Readouts are supported for {self.sampling_method.value.upper()} simulation."
+            )
+
         # Apply parameter perturbations
         if self._noise_model:
             og_param = copy(functional.get_parameters())

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -922,7 +922,9 @@ def test_apply_digital_simulation_method_unsupported_method():
 
 
 @pytest.mark.parametrize("method", [CudaSamplingMethod.MATRIX_PRODUCT_STATE, CudaSamplingMethod.TENSOR_NETWORK])
-def test_expectation_for_methods_raises(method):
+def test_expectation_for_methods_raises(monkeypatch, method):
+    monkeypatch.setattr("cudaq.make_kernel", dummy_make_kernel)
+    monkeypatch.setattr("cudaq.set_target", lambda target: None)
     c = Circuit(nqubits=1)
     f = DigitalPropagation(circuit=c)
     r = Readout().with_expectation(observables=[pauli_z(0)])
@@ -932,7 +934,9 @@ def test_expectation_for_methods_raises(method):
 
 
 @pytest.mark.parametrize("method", [CudaSamplingMethod.MATRIX_PRODUCT_STATE, CudaSamplingMethod.TENSOR_NETWORK])
-def test_tomography_for_methods_raises(method):
+def test_tomography_for_methods_raises(monkeypatch, method):
+    monkeypatch.setattr("cudaq.make_kernel", dummy_make_kernel)
+    monkeypatch.setattr("cudaq.set_target", lambda target: None)
     c = Circuit(nqubits=1)
     f = DigitalPropagation(circuit=c)
     r = Readout().with_state_tomography()

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -919,3 +919,23 @@ def test_apply_digital_simulation_method_unsupported_method():
     backend = CudaBackend(sampling_method=FakeSamplingMethod.UNSUPPORTED_METHOD)
     with pytest.raises(ValueError, match="Unsupported sampling method: unsupported_method"):
         backend._apply_digital_simulation_method()
+
+
+@pytest.mark.parametrize("method", [CudaSamplingMethod.MATRIX_PRODUCT_STATE, CudaSamplingMethod.TENSOR_NETWORK])
+def test_expectation_for_methods_raises(method):
+    c = Circuit(nqubits=1)
+    f = DigitalPropagation(circuit=c)
+    r = Readout().with_expectation(observables=[pauli_z(0)])
+    backend = CudaBackend(sampling_method=method)
+    with pytest.raises(ValueError, match="Only Sampling"):
+        backend.execute(f, r)
+
+
+@pytest.mark.parametrize("method", [CudaSamplingMethod.MATRIX_PRODUCT_STATE, CudaSamplingMethod.TENSOR_NETWORK])
+def test_tomography_for_methods_raises(method):
+    c = Circuit(nqubits=1)
+    f = DigitalPropagation(circuit=c)
+    r = Readout().with_state_tomography()
+    backend = CudaBackend(sampling_method=method)
+    with pytest.raises(ValueError, match="Only Sampling"):
+        backend.execute(f, r)


### PR DESCRIPTION
Fixed a bug in which the `CudaBackend` would crash if the user requested expectation values or a state from an MPS or tensor simulation. Now an error is correctly raised, telling the user to use sampling instead. This information has also been added to the docs.