### PR TITLE
[SDK-291] Fix QTensor Zero

### DIFF
--- a/changes/223.misc.md
+++ b/changes/223.misc.md
@@ -1,0 +1,3 @@
+The behaviour of QTensor.zero(nqubits) has been fixed: rather than creating an immutable matrix of all zeros (which doesn't have much use), it now creates the |0...0> statevector as a user would expect.
+
+Similarly, QTensor.one(nqubits) has been added to allow easy initialization of the |1...1> state.

--- a/docs/modules/core/core_qtensor.rst
+++ b/docs/modules/core/core_qtensor.rst
@@ -62,7 +62,8 @@ There are also several constructors for common quantum objects:
  - :func:`~qilisdk.core.qtensor.bra` for computational basis bras
  - :func:`~qilisdk.core.qtensor.basis_state` for N-dimensional basis states with a single 1 at the specified index
  - :func:`~qilisdk.core.qtensor.identity` for identity operators of specified dimension
- - :func:`~qilisdk.core.qtensor.zero` for generating zero tensors of specified dimension
+ - :func:`~qilisdk.core.qtensor.zero` for generating statevectors in the all-zero state.
+ - :func:`~qilisdk.core.qtensor.one` for generating statevectors in the all-one state.
  - :func:`~qilisdk.core.qtensor.ghz` for generating GHZ states of specified number of qubits
  - :meth:`~qilisdk.core.qtensor.QTensor.uniform` for generating uniform superposition states of specified number of qubits
 
@@ -80,9 +81,8 @@ There are also several constructors for common quantum objects:
     # GHZ state for 2 qubits
     print("GHZ state for 2 qubits:\n", QTensor.ghz(2))
 
-    # Identity and zero operators
+    # Identity operators
     print("Identity (4x4):\n", QTensor.identity(2))
-    print("Zero (2x2):\n", QTensor.zero(2))
 
 **Output**
 

--- a/src/qilisdk/core/qtensor.py
+++ b/src/qilisdk/core/qtensor.py
@@ -530,18 +530,30 @@ class QTensor:
         return QTensor(QTensorCpp.bra_python(state))
 
     @classmethod
-    def zero(cls, nqubits: int, qtensor_type: QTensorType = "operator") -> QTensor:
+    def zero(cls, nqubits: int) -> QTensor:
         """
-        Create a QTensor representing the zero matrix of the specified shape.
+        Create a QTensor representing the |0..0> statevector.
 
         Args:
-            nqubits (int): The number of qubits, which determines the size of the zero matrix (2^nqubits x 2^nqubits).
-            qtensor_type (QTensorType): The type of QTensor to create ("ket", "bra", or "operator"), which determines the shape of the zero matrix.
+            nqubits (int): The number of qubits, which determines the size of the zero statevector (2^nqubits x 1).
 
         Returns:
-            QTensor: A new QTensor representing the zero matrix.
+            QTensor: A new QTensor representing the zero statevector.
         """
-        return QTensor(QTensorCpp.zero(nqubits, qtensor_type))
+        return QTensor(QTensorCpp.zero(nqubits))
+
+    @classmethod
+    def one(cls, nqubits: int) -> QTensor:
+        """
+        Create a QTensor representing the |1..1> statevector.
+
+        Args:
+            nqubits (int): The number of qubits, which determines the size of the one statevector (2^nqubits x 1).
+
+        Returns:
+            QTensor: A new QTensor representing the one statevector.
+        """
+        return QTensor(QTensorCpp.one(nqubits))
 
     @classmethod
     def identity(cls, nqubits: int) -> QTensor:
@@ -880,18 +892,17 @@ def reset_qubits(state: QTensor, qubits: list[int]) -> QTensor:
     return state.reset_qubits(set(qubits))
 
 
-def zero(nqubits: int, qtensor_type: QTensorType = "operator") -> QTensor:
+def zero(nqubits: int) -> QTensor:
     """
     Wrapper for backwards compatibility: see QTensor.zero().
 
     Args:
-        nqubits (int): The number of qubits, which determines the size of the zero matrix (2^nqubits x 2^nqubits).
-        qtensor_type (QTensorType): The type of QTensor to create ("ket", "bra", or "operator"), which determines the shape of the zero matrix.
+        nqubits (int): The number of qubits, which determines the size of the zero statevector (2^nqubits x 1).
 
     Returns:
-        QTensor: A new QTensor representing the zero matrix.
+        QTensor: A new QTensor representing the zero statevector.
     """
-    return QTensor.zero(nqubits, qtensor_type)
+    return QTensor.zero(nqubits)
 
 
 def basis_state(n: int, N: int) -> QTensor:

--- a/src/qilisdk_cpp/core/qtensor.cpp
+++ b/src/qilisdk_cpp/core/qtensor.cpp
@@ -748,30 +748,47 @@ QTensorCpp QTensorCpp::ket(const std::vector<int>& qubit_values) {
     return result;
 }
 
-QTensorCpp QTensorCpp::zero(int nqubits, std::string qtensor_type) {
+QTensorCpp QTensorCpp::zero(int nqubits) {
     /*
-    Construct a QTensor of the given shape filled with zeros. The number of rows and columns must be powers of 2.
+    Construct a |0..0> ket vector QTensor for a given number of qubits.
 
     Args:
-        nqubits (int): The number of qubits, which determines the shape of the QTensor. The number of rows and columns will be 2^nqubits.
-        qtensor_type (std::string): The type of QTensor to create, which can be "ket", "bra", or "operator".
+        nqubits (int): The number of qubits, which determines the size of the zero statevector (2^nqubits x 1).
 
     Returns:
-        QTensorCpp: A QTensor of the specified shape filled with zeros.
+        QTensorCpp: A QTensor representing the |0..0> ket vector for the specified number of qubits.
     */
     if (nqubits < 0) {
         throw py::value_error("Number of qubits must be non-negative");
     }
     int dim = 1 << nqubits;
-    if (qtensor_type == "ket") {
-        return QTensorCpp(dim, 1);
-    } else if (qtensor_type == "bra") {
-        return QTensorCpp(1, dim);
-    } else if (qtensor_type == "operator") {
-        return QTensorCpp(dim, dim);
-    } else {
-        throw py::value_error("Invalid qtensor type: " + qtensor_type + ". Must be 'ket', 'bra', or 'operator'");
+    QTensorCpp result(dim, 1);
+    result._data.reserve(1);
+    result._data.insert(0, 0) = 1.0;
+    result._data.makeCompressed();
+    return result;
+}
+
+QTensorCpp QTensorCpp::one(int nqubits) {
+    /*
+    Construct a |1..1> ket vector QTensor for a given number of qubits.
+
+    Args:
+        nqubits (int): The number of qubits, which determines the size of the one statevector (2^nqubits x 1).
+
+    Returns:
+        QTensorCpp: A QTensor representing the |1..1> ket vector for the specified number of qubits.
+    */
+    if (nqubits < 0) {
+        throw py::value_error("Number of qubits must be non-negative");
     }
+    int dim = 1 << nqubits;
+    QTensorCpp result(dim, 1);
+    int one_index = dim - 1;
+    result._data.reserve(1);
+    result._data.insert(one_index, 0) = 1.0;
+    result._data.makeCompressed();
+    return result;
 }
 
 QTensorCpp QTensorCpp::ket_python(const py::object& state) {

--- a/src/qilisdk_cpp/core/qtensor.h
+++ b/src/qilisdk_cpp/core/qtensor.h
@@ -132,7 +132,8 @@ class QTensorCpp {
 
     // Static initializers for common states
     static QTensorCpp identity(int nqubits);
-    static QTensorCpp zero(int nqubits, std::string qtensor_type = "operator");
+    static QTensorCpp zero(int nqubits);
+    static QTensorCpp one(int nqubits);
     static QTensorCpp ket_python(const py::object& state);
     static QTensorCpp ket(const std::vector<int>& qubit_values);
     static QTensorCpp bra_python(const py::object& state);

--- a/src/qilisdk_cpp/core/qtensor_bindings.cpp
+++ b/src/qilisdk_cpp/core/qtensor_bindings.cpp
@@ -41,6 +41,7 @@ PYBIND11_MODULE(qtensor_module, m) {
         .def("norm", &QTensorCpp::norm)
         .def("normalized", &QTensorCpp::normalized)
         .def("zero", &QTensorCpp::zero)
+        .def("one", &QTensorCpp::one)
         .def("ket_python", &QTensorCpp::ket_python)
         .def("bra_python", &QTensorCpp::bra_python)
         .def("expectation_value_python", &QTensorCpp::expectation_value_python)

--- a/tests/unit_cpp/core/test_qtensor.cpp
+++ b/tests/unit_cpp/core/test_qtensor.cpp
@@ -749,26 +749,23 @@ TEST(BraPythonTest, Valid) {
 }
 
 TEST(ZeroTest, NegativeNqubits_Throws) {
-    EXPECT_THROW(QTensorCpp::zero(-1, "ket"), py::value_error);
+    EXPECT_THROW(QTensorCpp::zero(-1), py::value_error);
 }
 
 TEST(ZeroTest, Ket_Type) {
-    QTensorCpp q = QTensorCpp::zero(1, "ket");
+    QTensorCpp q = QTensorCpp::zero(2);
     EXPECT_TRUE(q.is_ket());
+    EXPECT_NEAR(q.get_data().coeff(0, 0).real(), 1.0, 1e-10);
 }
 
-TEST(ZeroTest, Bra_Type) {
-    QTensorCpp q = QTensorCpp::zero(1, "bra");
-    EXPECT_TRUE(q.is_bra());
+TEST(OneTest, NegativeNqubits_Throws) {
+    EXPECT_THROW(QTensorCpp::one(-1), py::value_error);
 }
 
-TEST(ZeroTest, Operator_Type) {
-    QTensorCpp q = QTensorCpp::zero(1, "operator");
-    EXPECT_TRUE(q.is_operator());
-}
-
-TEST(ZeroTest, InvalidType_Throws) {
-    EXPECT_THROW(QTensorCpp::zero(1, "vector"), py::value_error);
+TEST(OneTest, Ket_Type) {
+    QTensorCpp q = QTensorCpp::one(2);
+    EXPECT_TRUE(q.is_ket());
+    EXPECT_NEAR(q.get_data().coeff(3, 0).real(), 1.0, 1e-10);
 }
 
 TEST(IdentityTest, Is2x2Identity) {
@@ -1210,7 +1207,7 @@ TEST(ExpectationValueTest, ExactOperator) {
 }
 
 TEST(ExpectationValueTest, SampledZeroState_Throws) {
-    QTensorCpp q(QTensorCpp::zero(2, "operator"));
+    QTensorCpp q(QTensorCpp(SparseMatrix(2, 2)));
     q.compute_eigendecomposition();
     QTensorCpp op(make_identity2());
     EXPECT_THROW(q.expectation_value(op, 10), py::value_error);
@@ -1592,7 +1589,7 @@ TEST(SqrtTest, NonOperator_Throws) {
 }
 
 TEST(SqrtTest, ZeroMatrix_SpecialCase) {
-    QTensorCpp zero = QTensorCpp::zero(2, "operator");
+    QTensorCpp zero = QTensorCpp(SparseMatrix(2, 2));
     ASSERT_NO_THROW(zero.sqrt());
 }
 

--- a/tests/unit_python/core/test_qtensor.py
+++ b/tests/unit_python/core/test_qtensor.py
@@ -788,15 +788,17 @@ def test_qtensor_identity():
 def test_qtensor_zero():
     qzero = QTensor.zero(2)
     qzero2 = zero(2)
-    qzero_ket = QTensor.zero(2, "ket")
-    qzero_bra = QTensor.zero(2, "bra")
-    expected = np.zeros((4, 4))
     expected_ket = np.zeros((4, 1))
-    expected_bra = np.zeros((1, 4))
-    np.testing.assert_array_equal(qzero.dense(), expected)
-    np.testing.assert_array_equal(qzero2.dense(), expected)
-    np.testing.assert_array_equal(qzero_ket.dense(), expected_ket)
-    np.testing.assert_array_equal(qzero_bra.dense(), expected_bra)
+    expected_ket[0, 0] = 1
+    np.testing.assert_array_equal(qzero.dense(), expected_ket)
+    np.testing.assert_array_equal(qzero2.dense(), expected_ket)
+
+
+def test_qtensor_one():
+    qone = QTensor.one(2)
+    expected_ket = np.zeros((4, 1))
+    expected_ket[3, 0] = 1
+    np.testing.assert_array_equal(qone.dense(), expected_ket)
 
 
 def test_qtensor_ghz():


### PR DESCRIPTION
The behaviour of QTensor.zero(nqubits) has been fixed: rather than creating an immutable matrix of all zeros (which doesn't have much use), it now creates the |0...0> statevector as a user would expect.

Similarly, QTensor.one(nqubits) has been added to allow easy initialization of the |1...1> state.