### PR TITLE
[SDK-310] Add Phase Plots

### DIFF
--- a/changes/235.misc.md
+++ b/changes/235.misc.md
@@ -1,0 +1,7 @@
+Phase plots for each experiment have been added, enabled via a new argument: `.plot(plot_type = "phase")`.
+
+dB plots are also back (since it was only a few lines extra), which can be enabled with `plot_type = "db"`.
+
+The default axis names have been changed from "|S21|" to "Amplitude (V)" to be more consistent.
+
+Note that when using any plot_type other than the default "amplitude", overrides are disabled, since they are supposed to scale the outcome of the amplitude calculation, not the raw data.

--- a/src/qilisdk/experiments/experiment_functional.py
+++ b/src/qilisdk/experiments/experiment_functional.py
@@ -64,11 +64,13 @@ class ExperimentFunctional(Functional, ABC, Generic[TResult_co]):
 
     @property
     def averages(self) -> int:
-        """The physical qubit index on which the experiment is performed.
+        """
+        Number of averages to acquire for the experiment.
 
         Returns:
-            int: Index of the qubit.
+            int: Number of averages.
         """
+
         return self._averages
 
 

--- a/src/qilisdk/experiments/experiment_result.py
+++ b/src/qilisdk/experiments/experiment_result.py
@@ -266,6 +266,7 @@ class ExperimentResult(FunctionalResult):
     def plot(
         self,
         save_to: str | None = None,
+        *,
         initial_guess: list[float] | None = None,
         fit: bool | None = None,
         connect_points: bool = False,

--- a/src/qilisdk/experiments/experiment_result.py
+++ b/src/qilisdk/experiments/experiment_result.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
-from typing import Callable, ClassVar
+from typing import Callable, ClassVar, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
+from loguru import logger
 from matplotlib.figure import Figure
 from scipy.optimize import curve_fit
 
@@ -42,6 +43,10 @@ class Dimension:
         self.labels = labels
         self.values = values
 
+
+_LABEL_AMPLITUDE = "Amplitude (V)"
+_LABEL_PHASE = "Phase (rad)"
+_LABEL_DB = "Amplitude (dB)"
 
 DimensionOverride = Callable[[Dimension], Dimension]
 """Callable that takes a Dimension and returns a transformed Dimension."""
@@ -104,6 +109,15 @@ class ExperimentResult(FunctionalResult):
         """
         return 20 * np.log10(self.s21_modulus)
 
+    @property
+    def s21_phase(self) -> np.ndarray:
+        """Phase of the S21 parameter in radians.
+
+        Returns:
+            np.ndarray: The angle of the complex S21 parameter.
+        """
+        return np.unwrap(np.angle(self.s21))
+
     @staticmethod
     def add_fit(x_values: np.ndarray, y_values: np.ndarray, initial_guess: list[float] | None = None) -> None:
         """
@@ -138,6 +152,8 @@ class ExperimentResult(FunctionalResult):
         save_to: str | None = None,
         initial_guess: list[float] | None = None,
         connect_points: bool = False,
+        default_y_label: str = _LABEL_AMPLITUDE,
+        apply_y_override: bool = True,
     ) -> None:
         """Plot 1D S21 data.
 
@@ -148,15 +164,16 @@ class ExperimentResult(FunctionalResult):
             save_to (str | None): Optional path or directory to save the figure.
             initial_guess (list[float] | None): Optional initial guess passed to `add_fit`.
             connect_points (bool): Whether to connect data points with a grey dashed line.
+            default_y_label (str): Default y-axis label used when no dims_override is set for the y dimension.
+            apply_y_override (bool): Whether to apply dims_override for the y dimension. Set to False for non-amplitude plot types.
         """
         x_dim = self.dims_override[0](dims[0]) if len(self.dims_override) > 0 and self.dims_override[0] else dims[0]
         x_labels, x_values = x_dim.labels, x_dim.values
-        y_override = self.dims_override[1] if len(self.dims_override) > 1 else None
+        y_override = self.dims_override[1] if apply_y_override and len(self.dims_override) > 1 else None
 
         fig, ax1 = plt.subplots()
         ax1.set_title(f"{self.plot_title} - Qubit {self.qubit}")
         ax1.set_xlabel(x_labels[0])
-        default_y_label = r"$|S_{21}|$ ∝ Voltage"
         y_dim_input = Dimension(labels=[default_y_label], values=[s21])
         ax1.set_ylabel(y_override(y_dim_input).labels[0] if y_override else default_y_label)
         if connect_points:
@@ -186,6 +203,8 @@ class ExperimentResult(FunctionalResult):
         fit: bool = False,
         save_to: str | None = None,
         initial_guess: list[float] | None = None,
+        default_z_label: str = _LABEL_AMPLITUDE,
+        apply_z_override: bool = True,
     ) -> None:
         """Plot 2D S21 data as a color mesh.
 
@@ -195,14 +214,16 @@ class ExperimentResult(FunctionalResult):
             fit (bool): Whether to perform and plot the fit using the `add_fit` method.
             save_to (str | None): Optional path or directory to save the figure.
             initial_guess (list[float] | None): Optional initial guess passed to `add_fit`.
+            default_z_label (str): Default colorbar label used when no dims_override is set for the z dimension.
+            apply_z_override (bool): Whether to apply dims_override for the z dimension. Set to False for non-amplitude plot types.
         """
         x_dim = self.dims_override[0](dims[0]) if len(self.dims_override) > 0 and self.dims_override[0] else dims[0]
         y_dim = self.dims_override[1](dims[1]) if len(self.dims_override) > 1 and self.dims_override[1] else dims[1]
-        z_override = self.dims_override[2] if len(self.dims_override) > 2 else None  # noqa: PLR2004
+        z_override = self.dims_override[2] if apply_z_override and len(self.dims_override) > 2 else None  # noqa: PLR2004
         x_labels, x_values = x_dim.labels, x_dim.values
         y_labels, y_values = y_dim.labels, y_dim.values
 
-        z_dim_input = Dimension(labels=[r"$|S_{21}|$"], values=[s21])
+        z_dim_input = Dimension(labels=[default_z_label], values=[s21])
         z_dim = z_override(z_dim_input) if z_override else z_dim_input
         z_values = z_dim.values[0]
 
@@ -216,9 +237,7 @@ class ExperimentResult(FunctionalResult):
         ax1.ticklabel_format(axis="both", style="sci", scilimits=(-3, 3))
 
         mesh = ax1.pcolormesh(x_edges, y_edges, z_values.T, cmap="viridis", shading="auto")
-        z_label = z_dim.labels[0]
-        default_z_label = r"$|S_{21}|$ ∝ Voltage"
-        colorbar_label = z_label if z_override else default_z_label
+        colorbar_label = z_dim.labels[0]
         fig.colorbar(mesh, ax=ax1, label=colorbar_label)
 
         if len(x_labels) > 1:
@@ -248,6 +267,7 @@ class ExperimentResult(FunctionalResult):
         initial_guess: list[float] | None = None,
         fit: bool | None = None,
         connect_points: bool = False,
+        plot_type: Literal["amplitude", "phase", "db"] = "amplitude",
     ) -> None:
         """Plot the S21 parameter from experiment results.
 
@@ -261,13 +281,28 @@ class ExperimentResult(FunctionalResult):
             initial_guess (list[float] | None): Optional initial guess for the fit parameters, passed to the `add_fit` method.
             fit (bool | None): Whether to perform and plot the fit using the `add_fit` method. If None, the class-level `fit_by_default` is used.
             connect_points (bool): Whether to connect data points with a grey dashed line (1D plots only).
+            plot_type (Literal["amplitude", "phase", "db"]): Whether to plot amplitude (default), phase, or magnitude in dB of the S21 parameter.
 
         Raises:
             NotImplementedError: If the experiment data has more than 2 dimensions.
         """
-        to_plot = self.s21_modulus
+        if plot_type == "phase":
+            to_plot = self.s21_phase
+            default_label = _LABEL_PHASE
+        elif plot_type == "db":
+            to_plot = self.s21_db
+            default_label = _LABEL_DB
+        else:
+            to_plot = self.s21_modulus
+            default_label = _LABEL_AMPLITUDE
+        is_amplitude = plot_type == "amplitude"
         n_dimensions = len(to_plot.shape)
         should_fit = fit if fit is not None else self.fit_by_default
+        if fit is not None and fit and not is_amplitude:
+            logger.warning(
+                "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+            )
+            should_fit = False
         if n_dimensions == 1:
             self._plot_1d(
                 to_plot,
@@ -276,9 +311,19 @@ class ExperimentResult(FunctionalResult):
                 save_to=save_to,
                 initial_guess=initial_guess,
                 connect_points=connect_points,
+                default_y_label=default_label,
+                apply_y_override=is_amplitude,
             )
         elif n_dimensions == 2:  # noqa: PLR2004
-            self._plot_2d(to_plot, self.dims, fit=should_fit, save_to=save_to, initial_guess=initial_guess)
+            self._plot_2d(
+                to_plot,
+                self.dims,
+                fit=should_fit,
+                save_to=save_to,
+                initial_guess=initial_guess,
+                default_z_label=default_label,
+                apply_z_override=is_amplitude,
+            )
         else:
             raise NotImplementedError("3D and higher dimension plots are not supported yet.")
 

--- a/tests/unit_python/experiments/test_experiments.py
+++ b/tests/unit_python/experiments/test_experiments.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from loguru import logger
 
 from qilisdk.experiments import (
     Dimension,
@@ -95,6 +98,16 @@ def test_t1_plotting(monkeypatch):
     t1_result.plot(save_to="./.tmp/test_t1_default.png")
     t1_result.plot(save_to="./.tmp/test_t1.png", fit=False)
     t1_result.plot(save_to="./.tmp/test_t1_fit.png", fit=True)
+    t1_result.plot(save_to="./.tmp/test_t1_phase.png", fit=False, plot_type="phase")
+    t1_result.plot(save_to="./.tmp/test_t1_db.png", fit=False, plot_type="db")
+
+    # need to monkeypatch the logger to catch the warning about fitting only being implemented for amplitude plots
+    fakeWarning = MagicMock()
+    monkeypatch.setattr(logger, "warning", fakeWarning)
+    t1_result.plot(save_to="./.tmp/test_t1_phase_fit.png", fit=True, plot_type="phase")
+    fakeWarning.assert_called_with(
+        "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+    )
 
 
 def test_rabi_plotting(monkeypatch):
@@ -116,6 +129,15 @@ def test_rabi_plotting(monkeypatch):
     result_rabi.plot(save_to="./.tmp/test_rabi.png", fit=False)
     result_rabi.plot(save_to="./.tmp/test_rabi_connected.png", fit=False, connect_points=True)
     result_rabi.plot(save_to="./.tmp/test_rabi_fit.png", fit=True)
+    result_rabi.plot(save_to="./.tmp/test_rabi_phase.png", fit=False, plot_type="phase")
+    result_rabi.plot(save_to="./.tmp/test_rabi_db.png", fit=False, plot_type="db")
+
+    fakeWarning = MagicMock()
+    monkeypatch.setattr(logger, "warning", fakeWarning)
+    result_rabi.plot(save_to="./.tmp/test_rabi_phase_fit.png", fit=True, plot_type="phase")
+    fakeWarning.assert_called_with(
+        "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+    )
 
 
 def test_two_tones_at_flux_bias_plotting(monkeypatch):
@@ -139,6 +161,15 @@ def test_two_tones_at_flux_bias_plotting(monkeypatch):
     result_at.plot(save_to="./.tmp/test_two_tones_at_default.png")
     result_at.plot(save_to="./.tmp/test_two_tones_at.png", fit=False)
     result_at.plot(save_to="./.tmp/test_two_tones_at_fit.png", fit=True)
+    result_at.plot(save_to="./.tmp/test_two_tones_at_phase.png", fit=False, plot_type="phase")
+    result_at.plot(save_to="./.tmp/test_two_tones_at_db.png", fit=False, plot_type="db")
+
+    fakeWarning = MagicMock()
+    monkeypatch.setattr(logger, "warning", fakeWarning)
+    result_at.plot(save_to="./.tmp/test_two_tones_at_phase_fit.png", fit=True, plot_type="phase")
+    fakeWarning.assert_called_with(
+        "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+    )
 
 
 def test_two_tones_vs_flux_bias_plotting(monkeypatch):
@@ -167,6 +198,15 @@ def test_two_tones_vs_flux_bias_plotting(monkeypatch):
     result_vs.plot(save_to="./.tmp/test_two_tones_vs_default.png")
     result_vs.plot(save_to="./.tmp/test_two_tones_vs.png", fit=False)
     result_vs.plot(save_to="./.tmp/test_two_tones_vs_fit.png", fit=True)
+    result_vs.plot(save_to="./.tmp/test_two_tones_vs_phase.png", fit=False, plot_type="phase")
+    result_vs.plot(save_to="./.tmp/test_two_tones_vs_db.png", fit=False, plot_type="db")
+
+    fakeWarning = MagicMock()
+    monkeypatch.setattr(logger, "warning", fakeWarning)
+    result_vs.plot(save_to="./.tmp/test_two_tones_vs_phase_fit.png", fit=True, plot_type="phase")
+    fakeWarning.assert_called_with(
+        "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+    )
 
 
 def test_t2_plotting(monkeypatch):
@@ -188,3 +228,12 @@ def test_t2_plotting(monkeypatch):
     result_t2.plot(save_to="./.tmp/test_t2_default.png")
     result_t2.plot(save_to="./.tmp/test_t2.png", fit=False)
     result_t2.plot(save_to="./.tmp/test_t2_fit.png", fit=True)
+    result_t2.plot(save_to="./.tmp/test_t2_phase.png", fit=False, plot_type="phase")
+    result_t2.plot(save_to="./.tmp/test_t2_db.png", fit=False, plot_type="db")
+
+    fakeWarning = MagicMock()
+    monkeypatch.setattr(logger, "warning", fakeWarning)
+    result_t2.plot(save_to="./.tmp/test_t2_phase_fit.png", fit=True, plot_type="phase")
+    fakeWarning.assert_called_with(
+        "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
+    )


### PR DESCRIPTION
Phase plots for each experiment have been added, enabled via a new argument: `.plot(plot_type = "phase")`.

dB plots are also back (since it was only a few lines extra), which can be enabled with `plot_type = "db"`.

The default axis names have been changed from "|S21|" to "Amplitude (V)" to be more consistent.