### PR TITLE
[SDK-308] Add `averages` to all experiments and their results

### DIFF
--- a/changes/236.misc.md
+++ b/changes/236.misc.md
@@ -1,0 +1,2 @@
+- Added `averages` as a common field for experiment functionals and experiment results.
+- Renamed `TwoTonesAtFluxBiasExperiment` to `TwoTonesAtFixedFluxBiasExperiment`.

--- a/docs/modules/speqtrum/speqtrum.rst
+++ b/docs/modules/speqtrum/speqtrum.rst
@@ -209,13 +209,13 @@ functional objects mirror the interfaces described in the :doc:`/modules/functio
     )[0].code
 
     # Rabi experiment: sweep drive durations
-    rabi = RabiExperiment(qubit=0, drive_duration_values=np.linspace(0, 200, 21))
+    rabi = RabiExperiment(qubit=0, averages=10_000, drive_duration_values=np.linspace(0, 200, 21))
     rabi_handle = client.submit(rabi, device=device)
     rabi_response = client.wait_for_job(rabi_handle, timeout=600)
     rabi_result = rabi_response.get_results()
 
     # T1 relaxation experiment: sweep wait durations
-    t1 = T1Experiment(qubit=0, wait_duration_values=np.linspace(0, 400, 41))
+    t1 = T1Experiment(qubit=0, averages=10_000, wait_duration_values=np.linspace(0, 400, 41))
     t1_handle = client.submit(t1, device=device)
     t1_response = client.wait_for_job(t1_handle, timeout=600)
     t1_result = t1_response.get_results()

--- a/src/qilisdk/experiments/__init__.py
+++ b/src/qilisdk/experiments/__init__.py
@@ -16,7 +16,7 @@ from .experiment_functional import (
     RabiExperiment,
     T1Experiment,
     T2Experiment,
-    TwoTonesAtFluxBiasExperiment,
+    TwoTonesAtFixedFluxBiasExperiment,
     TwoTonesVsFluxBiasExperiment,
 )
 from .experiment_result import (
@@ -39,8 +39,8 @@ __all__ = [
     "T1ExperimentResult",
     "T2Experiment",
     "T2ExperimentResult",
-    "TwoTonesAtFluxBiasExperiment",
-    "TwoTonesAtFluxBiasExperimentResult",
+    "TwoTonesAtFixedFluxBiasExperiment",
+    "TwoTonesAtFixedFluxBiasExperimentResult",
     "TwoTonesVsFluxBiasExperiment",
     "TwoTonesVsFluxBiasExperimentResult",
 ]

--- a/src/qilisdk/experiments/__init__.py
+++ b/src/qilisdk/experiments/__init__.py
@@ -25,7 +25,7 @@ from .experiment_result import (
     RabiExperimentResult,
     T1ExperimentResult,
     T2ExperimentResult,
-    TwoTonesAtFluxBiasExperimentResult,
+    TwoTonesAtFixedFluxBiasExperimentResult,
     TwoTonesVsFluxBiasExperimentResult,
 )
 

--- a/src/qilisdk/experiments/experiment_functional.py
+++ b/src/qilisdk/experiments/experiment_functional.py
@@ -175,7 +175,7 @@ class T2Experiment(ExperimentFunctional[T2ExperimentResult]):
 
 
 @yaml.register_class
-class TwoTonesAtFluxBiasExperiment(ExperimentFunctional[TwoTonesAtFixedFluxBiasExperimentResult]):
+class TwoTonesAtFixedFluxBiasExperiment(ExperimentFunctional[TwoTonesAtFixedFluxBiasExperimentResult]):
     """Two-tone spectroscopy functional for a single qubit.
 
     Sweeps a drive tone frequency while monitoring the readout tone to

--- a/src/qilisdk/experiments/experiment_functional.py
+++ b/src/qilisdk/experiments/experiment_functional.py
@@ -21,7 +21,7 @@ from qilisdk.experiments.experiment_result import (
     RabiExperimentResult,
     T1ExperimentResult,
     T2ExperimentResult,
-    TwoTonesAtFluxBiasExperimentResult,
+    TwoTonesAtFixedFluxBiasExperimentResult,
     TwoTonesVsFluxBiasExperimentResult,
 )
 from qilisdk.functionals.functional import Functional
@@ -43,13 +43,15 @@ class ExperimentFunctional(Functional, ABC, Generic[TResult_co]):
     sweep parameters.
     """
 
-    def __init__(self, qubit: int) -> None:
+    def __init__(self, qubit: int, averages: int) -> None:
         """Initialize the experiment functional.
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
         """
         self._qubit = qubit
+        self._averages = averages
 
     @property
     def qubit(self) -> int:
@@ -59,6 +61,15 @@ class ExperimentFunctional(Functional, ABC, Generic[TResult_co]):
             int: Index of the qubit.
         """
         return self._qubit
+
+    @property
+    def averages(self) -> int:
+        """The physical qubit index on which the experiment is performed.
+
+        Returns:
+            int: Index of the qubit.
+        """
+        return self._averages
 
 
 @yaml.register_class
@@ -73,15 +84,16 @@ class RabiExperiment(ExperimentFunctional[RabiExperimentResult]):
     result_type: ClassVar[type[RabiExperimentResult]] = RabiExperimentResult
     """Result type returned by this functional."""
 
-    def __init__(self, qubit: int, drive_duration_values: np.ndarray) -> None:
+    def __init__(self, qubit: int, averages: int, drive_duration_values: np.ndarray) -> None:
         """Initialize a Rabi experiment functional.
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
             drive_duration_values (np.ndarray): Array of drive pulse durations (in nanoseconds)
                 used to sweep the experiment.
         """
-        super().__init__(qubit=qubit)
+        super().__init__(qubit=qubit, averages=averages)
         self._drive_duration_values = drive_duration_values
 
     @property
@@ -106,15 +118,16 @@ class T1Experiment(ExperimentFunctional[T1ExperimentResult]):
     result_type: ClassVar[type[T1ExperimentResult]] = T1ExperimentResult
     """Result type returned by this functional."""
 
-    def __init__(self, qubit: int, wait_duration_values: np.ndarray) -> None:
+    def __init__(self, qubit: int, averages: int, wait_duration_values: np.ndarray) -> None:
         """Initialize a T1 experiment functional.
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
             wait_duration_values (np.ndarray): Array of waiting times (in nanoseconds)
                 between excitation and measurement.
         """
-        super().__init__(qubit=qubit)
+        super().__init__(qubit=qubit, averages=averages)
         self._wait_duration_values: np.ndarray = wait_duration_values
 
     @property
@@ -139,15 +152,16 @@ class T2Experiment(ExperimentFunctional[T2ExperimentResult]):
     result_type: ClassVar[type[T2ExperimentResult]] = T2ExperimentResult
     """Result type returned by this functional."""
 
-    def __init__(self, qubit: int, wait_duration_values: np.ndarray) -> None:
+    def __init__(self, qubit: int, averages: int, wait_duration_values: np.ndarray) -> None:
         """Initialize a T2 dephasing experiment functional.
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
             wait_duration_values (np.ndarray): Array of free-evolution delays
                 (in nanoseconds) between the phase-sensitive pulses.
         """
-        super().__init__(qubit=qubit)
+        super().__init__(qubit=qubit, averages=averages)
         self._wait_duration_values: np.ndarray = wait_duration_values
 
     @property
@@ -161,26 +175,34 @@ class T2Experiment(ExperimentFunctional[T2ExperimentResult]):
 
 
 @yaml.register_class
-class TwoTonesAtFluxBiasExperiment(ExperimentFunctional[TwoTonesAtFluxBiasExperimentResult]):
+class TwoTonesAtFluxBiasExperiment(ExperimentFunctional[TwoTonesAtFixedFluxBiasExperimentResult]):
     """Two-tone spectroscopy functional for a single qubit.
 
     Sweeps a drive tone frequency while monitoring the readout tone to
     identify the qubit transition frequency.
     """
 
-    result_type: ClassVar[type[TwoTonesAtFluxBiasExperimentResult]] = TwoTonesAtFluxBiasExperimentResult
+    result_type: ClassVar[type[TwoTonesAtFixedFluxBiasExperimentResult]] = TwoTonesAtFixedFluxBiasExperimentResult
     """Result type returned by this functional."""
 
-    def __init__(self, qubit: int, frequency_start: float, frequency_stop: float, frequency_step: float) -> None:
+    def __init__(
+        self,
+        qubit: int,
+        averages: int,
+        frequency_start: float,
+        frequency_stop: float,
+        frequency_step: float,
+    ) -> None:
         """Initialize a two-tone spectroscopy functional.
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
             frequency_start (float): Starting frequency of the swept drive tone (in Hz).
             frequency_stop (float): Ending frequency of the swept drive tone (in Hz).
             frequency_step (float): Frequency increment between sweep points (in Hz).
         """
-        super().__init__(qubit=qubit)
+        super().__init__(qubit=qubit, averages=averages)
         self._frequency_start: float = frequency_start
         self._frequency_stop: float = frequency_stop
         self._frequency_step: float = frequency_step
@@ -227,6 +249,7 @@ class TwoTonesVsFluxBiasExperiment(ExperimentFunctional[TwoTonesVsFluxBiasExperi
     def __init__(
         self,
         qubit: int,
+        averages: int,
         frequency_start: float,
         frequency_stop: float,
         frequency_step: float,
@@ -238,6 +261,7 @@ class TwoTonesVsFluxBiasExperiment(ExperimentFunctional[TwoTonesVsFluxBiasExperi
 
         Args:
             qubit (int): The physical qubit index on which the experiment is performed.
+            averages (int): Number of averages to acquire for the experiment.
             frequency_start (float): Starting frequency of the swept drive tone (in Hz).
             frequency_stop (float): Ending frequency of the swept drive tone (in Hz).
             frequency_step (float): Frequency increment between sweep points (in Hz).
@@ -245,7 +269,7 @@ class TwoTonesVsFluxBiasExperiment(ExperimentFunctional[TwoTonesVsFluxBiasExperi
             flux_stop (float): Ending value of the flux bias sweep (in units of flux quantum).
             flux_step (float): Increment between flux bias sweep points (in units of flux quantum).
         """
-        super().__init__(qubit=qubit)
+        super().__init__(qubit=qubit, averages=averages)
         self._frequency_start: float = frequency_start
         self._frequency_stop: float = frequency_stop
         self._frequency_step: float = frequency_step

--- a/src/qilisdk/experiments/experiment_result.py
+++ b/src/qilisdk/experiments/experiment_result.py
@@ -65,15 +65,17 @@ class ExperimentResult(FunctionalResult):
     fit_by_default: ClassVar[bool] = False
     """Whether to perform fitting by default when plotting; can be overridden by subclasses if needed."""
 
-    def __init__(self, qubit: int, data: np.ndarray, dims: list[Dimension]) -> None:
+    def __init__(self, qubit: int, averages: int, data: np.ndarray, dims: list[Dimension]) -> None:
         """Initialize an experiment result.
 
         Args:
             qubit (int): The qubit index on which the experiment was performed.
+            averages (int): Number of averages acquired for the experiment.
             data (np.ndarray): Raw experimental data array.
             dims (list[Dimension]): Sweep dimensions of the experiment.
         """
         self.qubit = qubit
+        self.averages = averages
         self.data = data
         self.dims = dims
 
@@ -425,10 +427,10 @@ class T2ExperimentResult(ExperimentResult):
 
 
 @yaml.register_class
-class TwoTonesAtFluxBiasExperimentResult(ExperimentResult):
-    """Result container for TwoTones experiments."""
+class TwoTonesAtFixedFluxBiasExperimentResult(ExperimentResult):
+    """Result container for Two Tones at Fixed Flux Bias experiments."""
 
-    plot_title: ClassVar[str] = "Two Tones At Flux Bias"
+    plot_title: ClassVar[str] = "Two Tones at Fixed Flux Bias"
     """Default title for TwoTones at flux bias experiment plots."""
 
     dims_override: ClassVar[list[DimensionOverride | None]] = [
@@ -439,7 +441,7 @@ class TwoTonesAtFluxBiasExperimentResult(ExperimentResult):
     @staticmethod
     def add_fit(x_values: np.ndarray, y_values: np.ndarray, initial_guess: list[float] | None = None) -> None:
         """
-        Fit a Lorentzian curve to the TwoTones at flux bias experiment data.
+        Fit a Lorentzian curve to the Two Tones at Fixed Flux Bias experiment data.
 
         Args:
             x_values (list[np.ndarray]): The independent variable data (e.g., frequencies).
@@ -479,7 +481,7 @@ class TwoTonesAtFluxBiasExperimentResult(ExperimentResult):
 
 @yaml.register_class
 class TwoTonesVsFluxBiasExperimentResult(ExperimentResult):
-    """Result container for TwoTones experiments swept vs flux bias."""
+    """Result container for TwoTones vs Flux Bias experiments swept vs flux bias."""
 
     plot_title: ClassVar[str] = "Two Tones Vs Flux Bias"
     """Default title for TwoTones vs flux bias experiment plots."""

--- a/src/qilisdk/speqtrum/speqtrum.py
+++ b/src/qilisdk/speqtrum/speqtrum.py
@@ -33,7 +33,7 @@ from qilisdk.experiments import (
     T2Experiment,
     T2ExperimentResult,
 )
-from qilisdk.experiments.experiment_functional import TwoTonesAtFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
+from qilisdk.experiments.experiment_functional import TwoTonesAtFixedFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
 from qilisdk.functionals import (
     AnalogEvolution,
     DigitalPropagation,
@@ -62,7 +62,7 @@ from .speqtrum_models import (
     T1ExperimentPayload,
     T2ExperimentPayload,
     Token,
-    TwoTonesAtFluxBiasExperimentPayload,
+    TwoTonesAtFixedFluxBiasExperimentPayload,
     TwoTonesVsFluxBiasExperimentPayload,
     TypedJobDetail,
     VariationalProgramPayload,
@@ -708,7 +708,7 @@ class SpeQtrum:
         * :class:`~qilisdk.experiments.experiment_functional.RabiExperiment`
         * :class:`~qilisdk.experiments.experiment_functional.T1Experiment`
         * :class:`~qilisdk.experiments.experiment_functional.T2Experiment`
-        * :class:`~qilisdk.experiments.experiment_functional.TwoTonesAtFluxBiasExperiment`
+        * :class:`~qilisdk.experiments.experiment_functional.TwoTonesAtFixedFluxBiasExperiment`
         * :class:`~qilisdk.experiments.experiment_functional.TwoTonesVsFluxBiasExperiment`
 
         Args:
@@ -737,7 +737,7 @@ class SpeQtrum:
         if isinstance(functional, T2Experiment):
             return self._submit_t2(functional, device, job_name)
 
-        if isinstance(functional, TwoTonesAtFluxBiasExperiment):
+        if isinstance(functional, TwoTonesAtFixedFluxBiasExperiment):
             return self._submit_two_tones(functional, device, job_name)
 
         if isinstance(functional, TwoTonesVsFluxBiasExperiment):
@@ -813,7 +813,7 @@ class SpeQtrum:
         """
         payload = ExecutePayload(
             type=ExecuteType.RABI_EXPERIMENT,
-            rabi_experiment_payload=RabiExperimentPayload(rabi_experiment=rabi_experiment),
+            rabi_experiment_payload=RabiExperimentPayload(experiment=rabi_experiment),
         )
         json = {
             "device_code": device,
@@ -849,7 +849,7 @@ class SpeQtrum:
         """
         payload = ExecutePayload(
             type=ExecuteType.T1_EXPERIMENT,
-            t1_experiment_payload=T1ExperimentPayload(t1_experiment=t1_experiment),
+            t1_experiment_payload=T1ExperimentPayload(experiment=t1_experiment),
         )
         json = {
             "device_code": device,
@@ -885,7 +885,7 @@ class SpeQtrum:
         """
         payload = ExecutePayload(
             type=ExecuteType.T2_EXPERIMENT,
-            t2_experiment_payload=T2ExperimentPayload(t2_experiment=t2_experiment),
+            t2_experiment_payload=T2ExperimentPayload(experiment=t2_experiment),
         )
         json = {
             "device_code": device,
@@ -907,23 +907,23 @@ class SpeQtrum:
         return JobHandle.t2_experiment(job.id)
 
     def _submit_two_tones(
-        self, two_tones_experiment: TwoTonesAtFluxBiasExperiment, device: str, job_name: str | None = None
+        self, two_tones_experiment: TwoTonesAtFixedFluxBiasExperiment, device: str, job_name: str | None = None
     ) -> JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]:
         """Submit a Two-Tones at flux bias experiment to the SpeQtrum API.
 
         Args:
-            two_tones_experiment (TwoTonesAtFluxBiasExperiment): The experiment to execute.
+            two_tones_experiment (TwoTonesAtFixedFluxBiasExperiment): The experiment to execute.
             device (str): Target device code.
             job_name (str | None): Optional human-readable job name.
 
         Returns:
-            JobHandle[TwoTonesAtFluxBiasExperimentResult]: A handle for tracking the
+            JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]: A handle for tracking the
             submitted job.
         """
         payload = ExecutePayload(
             type=ExecuteType.TWO_TONES_AT_FIXED_FLUX_EXPERIMENT,
-            two_tones_at_flux_bias_experiment_payload=TwoTonesAtFluxBiasExperimentPayload(
-                two_tones_experiment=two_tones_experiment
+            two_tones_at_flux_bias_experiment_payload=TwoTonesAtFixedFluxBiasExperimentPayload(
+                experiment=two_tones_experiment
             ),
         )
         json = {
@@ -962,7 +962,7 @@ class SpeQtrum:
         payload = ExecutePayload(
             type=ExecuteType.TWO_TONES_VS_FLUX_BIAS_EXPERIMENT,
             two_tones_vs_flux_bias_experiment_payload=TwoTonesVsFluxBiasExperimentPayload(
-                two_tones_vs_flux_experiment=two_tones_vs_flux_bias_experiment
+                experiment=two_tones_vs_flux_bias_experiment
             ),
         )
         json = {

--- a/src/qilisdk/speqtrum/speqtrum.py
+++ b/src/qilisdk/speqtrum/speqtrum.py
@@ -70,7 +70,7 @@ from .speqtrum_models import (
 
 if TYPE_CHECKING:
     from qilisdk.experiments.experiment_result import (
-        TwoTonesAtFluxBiasExperimentResult,
+        TwoTonesAtFixedFluxBiasExperimentResult,
         TwoTonesVsFluxBiasExperimentResult,
     )
     from qilisdk.functionals.functional import Functional, PrimitiveFunctional
@@ -908,7 +908,7 @@ class SpeQtrum:
 
     def _submit_two_tones(
         self, two_tones_experiment: TwoTonesAtFluxBiasExperiment, device: str, job_name: str | None = None
-    ) -> JobHandle[TwoTonesAtFluxBiasExperimentResult]:
+    ) -> JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]:
         """Submit a Two-Tones at flux bias experiment to the SpeQtrum API.
 
         Args:
@@ -921,7 +921,7 @@ class SpeQtrum:
             submitted job.
         """
         payload = ExecutePayload(
-            type=ExecuteType.TWO_TONES_EXPERIMENT,
+            type=ExecuteType.TWO_TONES_AT_FIXED_FLUX_EXPERIMENT,
             two_tones_at_flux_bias_experiment_payload=TwoTonesAtFluxBiasExperimentPayload(
                 two_tones_experiment=two_tones_experiment
             ),

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -30,7 +30,10 @@ from qilisdk.experiments import (
     T2ExperimentResult,
 )
 from qilisdk.experiments.experiment_functional import TwoTonesAtFixedFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
-from qilisdk.experiments.experiment_result import TwoTonesAtFixedFluxBiasExperimentResult, TwoTonesVsFluxBiasExperimentResult
+from qilisdk.experiments.experiment_result import (
+    TwoTonesAtFixedFluxBiasExperimentResult,
+    TwoTonesVsFluxBiasExperimentResult,
+)
 from qilisdk.functionals import (
     AnalogEvolution,
     DigitalPropagation,
@@ -295,9 +298,7 @@ class TwoTonesVsFluxBiasExperimentPayload(SpeQtrumModel):
     experiment: TwoTonesVsFluxBiasExperiment = Field(...)
 
     @field_serializer("experiment")
-    def _serialize_experiment(
-        self, experiment: TwoTonesVsFluxBiasExperiment, _info
-    ):
+    def _serialize_experiment(self, experiment: TwoTonesVsFluxBiasExperiment, _info):
         return serialize(experiment)
 
     @field_validator("experiment", mode="before")

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -30,7 +30,7 @@ from qilisdk.experiments import (
     T2ExperimentResult,
 )
 from qilisdk.experiments.experiment_functional import TwoTonesAtFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
-from qilisdk.experiments.experiment_result import TwoTonesAtFluxBiasExperimentResult, TwoTonesVsFluxBiasExperimentResult
+from qilisdk.experiments.experiment_result import TwoTonesAtFixedFluxBiasExperimentResult, TwoTonesVsFluxBiasExperimentResult
 from qilisdk.functionals import (
     AnalogEvolution,
     DigitalPropagation,
@@ -113,7 +113,7 @@ class ExecuteType(str, Enum):
     RABI_EXPERIMENT = "rabi_experiment"
     T1_EXPERIMENT = "t1_experiment"
     T2_EXPERIMENT = "t2_experiment"
-    TWO_TONES_EXPERIMENT = "two_tones_experiment"
+    TWO_TONES_AT_FIXED_FLUX_EXPERIMENT = "two_tones_at_fixed_flux_experiment"
     TWO_TONES_VS_FLUX_BIAS_EXPERIMENT = "two_tones_vs_flux_bias_experiment"
 
 
@@ -340,7 +340,7 @@ class ExecuteResult(SpeQtrumModel):
     rabi_experiment_result: RabiExperimentResult | None = None
     t1_experiment_result: T1ExperimentResult | None = None
     t2_experiment_result: T2ExperimentResult | None = None
-    two_tones_at_flux_bias_experiment_result: TwoTonesAtFluxBiasExperimentResult | None = None
+    two_tones_at_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult | None = None
     two_tones_vs_flux_bias_experiment_result: TwoTonesVsFluxBiasExperimentResult | None = None
 
     @field_serializer("functional_result")
@@ -395,7 +395,7 @@ class ExecuteResult(SpeQtrumModel):
 
     @field_serializer("two_tones_at_flux_bias_experiment_result")
     def _serialize_two_tones_at_flux_bias_experiment_result(
-        self, two_tones_at_flux_bias_experiment_result: TwoTonesAtFluxBiasExperimentResult, _info
+        self, two_tones_at_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult, _info
     ):
         return (
             serialize(two_tones_at_flux_bias_experiment_result)
@@ -406,7 +406,7 @@ class ExecuteResult(SpeQtrumModel):
     @field_validator("two_tones_at_flux_bias_experiment_result", mode="before")
     def _load_two_tones_at_flux_bias_experiment_result(cls, v):
         if isinstance(v, str) and v.startswith("!"):
-            return deserialize(v, TwoTonesAtFluxBiasExperimentResult)
+            return deserialize(v, TwoTonesAtFixedFluxBiasExperimentResult)
         return v
 
     @field_serializer("two_tones_vs_flux_bias_experiment_result")
@@ -520,7 +520,7 @@ def _require_t2_experiment_result(result: ExecuteResult) -> T2ExperimentResult:
     return result.t2_experiment_result
 
 
-def _require_two_tones_experiment_result(result: ExecuteResult) -> TwoTonesAtFluxBiasExperimentResult:
+def _require_two_tones_experiment_result(result: ExecuteResult) -> TwoTonesAtFixedFluxBiasExperimentResult:
     """Extract and return the ``TwoTonesAtFluxBiasExperimentResult`` from *result*.
 
     Args:
@@ -688,8 +688,8 @@ class JobHandle(SpeQtrumModel, Generic[TFunctionalResult_co]):
 
     @classmethod
     def two_tones_experiment(
-        cls: type[JobHandle[TwoTonesAtFluxBiasExperimentResult]], job_id: int
-    ) -> JobHandle[TwoTonesAtFluxBiasExperimentResult]:
+        cls: type[JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]], job_id: int
+    ) -> JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]:
         """Create a handle for a Two-Tones at flux bias experiment job.
 
         Args:
@@ -701,7 +701,7 @@ class JobHandle(SpeQtrumModel, Generic[TFunctionalResult_co]):
         """
         return cls(
             id=job_id,
-            execute_type=ExecuteType.TWO_TONES_EXPERIMENT,
+            execute_type=ExecuteType.TWO_TONES_AT_FIXED_FLUX_EXPERIMENT,
             extractor=_require_two_tones_experiment_result,
         )
 

--- a/src/qilisdk/speqtrum/speqtrum_models.py
+++ b/src/qilisdk/speqtrum/speqtrum_models.py
@@ -29,7 +29,7 @@ from qilisdk.experiments import (
     T2Experiment,
     T2ExperimentResult,
 )
-from qilisdk.experiments.experiment_functional import TwoTonesAtFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
+from qilisdk.experiments.experiment_functional import TwoTonesAtFixedFluxBiasExperiment, TwoTonesVsFluxBiasExperiment
 from qilisdk.experiments.experiment_result import TwoTonesAtFixedFluxBiasExperimentResult, TwoTonesVsFluxBiasExperimentResult
 from qilisdk.functionals import (
     AnalogEvolution,
@@ -228,14 +228,14 @@ class VariationalProgramPayload(SpeQtrumModel):
 class RabiExperimentPayload(SpeQtrumModel):
     """Payload model wrapping a ``RabiExperiment`` for API submission."""
 
-    rabi_experiment: RabiExperiment = Field(...)
+    experiment: RabiExperiment = Field(...)
 
-    @field_serializer("rabi_experiment")
-    def _serialize_rabi_experiment(self, rabi_experiment: RabiExperiment, _info):
-        return serialize(rabi_experiment)
+    @field_serializer("experiment")
+    def _serialize_experiment(self, experiment: RabiExperiment, _info):
+        return serialize(experiment)
 
-    @field_validator("rabi_experiment", mode="before")
-    def _load_rabi_experiment(cls, v):
+    @field_validator("experiment", mode="before")
+    def _load_experiment(cls, v):
         if isinstance(v, str):
             return deserialize(v, RabiExperiment)
         return v
@@ -244,14 +244,14 @@ class RabiExperimentPayload(SpeQtrumModel):
 class T1ExperimentPayload(SpeQtrumModel):
     """Payload model wrapping a ``T1Experiment`` for API submission."""
 
-    t1_experiment: T1Experiment = Field(...)
+    experiment: T1Experiment = Field(...)
 
-    @field_serializer("t1_experiment")
-    def _serialize_t1_experiment(self, t1_experiment: T1Experiment, _info):
-        return serialize(t1_experiment)
+    @field_serializer("experiment")
+    def _serialize_experiment(self, experiment: T1Experiment, _info):
+        return serialize(experiment)
 
-    @field_validator("t1_experiment", mode="before")
-    def _load_t1_experiment(cls, v):
+    @field_validator("experiment", mode="before")
+    def _load_experiment(cls, v):
         if isinstance(v, str):
             return deserialize(v, T1Experiment)
         return v
@@ -260,48 +260,48 @@ class T1ExperimentPayload(SpeQtrumModel):
 class T2ExperimentPayload(SpeQtrumModel):
     """Payload model wrapping a ``T2Experiment`` for API submission."""
 
-    t2_experiment: T2Experiment = Field(...)
+    experiment: T2Experiment = Field(...)
 
-    @field_serializer("t2_experiment")
-    def _serialize_t2_experiment(self, t2_experiment: T2Experiment, _info):
-        return serialize(t2_experiment)
+    @field_serializer("experiment")
+    def _serialize_experiment(self, experiment: T2Experiment, _info):
+        return serialize(experiment)
 
-    @field_validator("t2_experiment", mode="before")
-    def _load_t2_experiment(cls, v):
+    @field_validator("experiment", mode="before")
+    def _load_experiment(cls, v):
         if isinstance(v, str):
             return deserialize(v, T2Experiment)
         return v
 
 
-class TwoTonesAtFluxBiasExperimentPayload(SpeQtrumModel):
-    """Payload model wrapping a ``TwoTonesAtFluxBiasExperiment`` for API submission."""
+class TwoTonesAtFixedFluxBiasExperimentPayload(SpeQtrumModel):
+    """Payload model wrapping a ``TwoTonesAtFixedFluxBiasExperiment`` for API submission."""
 
-    two_tones_experiment: TwoTonesAtFluxBiasExperiment = Field(...)
+    experiment: TwoTonesAtFixedFluxBiasExperiment = Field(...)
 
-    @field_serializer("two_tones_experiment")
-    def _serialize_two_tones_experiment(self, two_tones_experiment: TwoTonesAtFluxBiasExperiment, _info):
-        return serialize(two_tones_experiment)
+    @field_serializer("experiment")
+    def _serialize_experiment(self, experiment: TwoTonesAtFixedFluxBiasExperiment, _info):
+        return serialize(experiment)
 
-    @field_validator("two_tones_experiment", mode="before")
-    def _load_two_tones_experiment(cls, v):
+    @field_validator("experiment", mode="before")
+    def _load_experiment(cls, v):
         if isinstance(v, str):
-            return deserialize(v, TwoTonesAtFluxBiasExperiment)
+            return deserialize(v, TwoTonesAtFixedFluxBiasExperiment)
         return v
 
 
 class TwoTonesVsFluxBiasExperimentPayload(SpeQtrumModel):
     """Payload model wrapping a ``TwoTonesVsFluxBiasExperiment`` for API submission."""
 
-    two_tones_vs_flux_experiment: TwoTonesVsFluxBiasExperiment = Field(...)
+    experiment: TwoTonesVsFluxBiasExperiment = Field(...)
 
-    @field_serializer("two_tones_vs_flux_experiment")
-    def _serialize_two_tones_vs_flux_experiment(
-        self, two_tones_vs_flux_experiment: TwoTonesVsFluxBiasExperiment, _info
+    @field_serializer("experiment")
+    def _serialize_experiment(
+        self, experiment: TwoTonesVsFluxBiasExperiment, _info
     ):
-        return serialize(two_tones_vs_flux_experiment)
+        return serialize(experiment)
 
-    @field_validator("two_tones_vs_flux_experiment", mode="before")
-    def _load_two_tones_vs_flux_experiment(cls, v):
+    @field_validator("experiment", mode="before")
+    def _load_experiment(cls, v):
         if isinstance(v, str):
             return deserialize(v, TwoTonesVsFluxBiasExperiment)
         return v
@@ -322,7 +322,7 @@ class ExecutePayload(SpeQtrumModel):
     rabi_experiment_payload: RabiExperimentPayload | None = None
     t1_experiment_payload: T1ExperimentPayload | None = None
     t2_experiment_payload: T2ExperimentPayload | None = None
-    two_tones_at_flux_bias_experiment_payload: TwoTonesAtFluxBiasExperimentPayload | None = None
+    two_tones_at_flux_bias_experiment_payload: TwoTonesAtFixedFluxBiasExperimentPayload | None = None
     two_tones_vs_flux_bias_experiment_payload: TwoTonesVsFluxBiasExperimentPayload | None = None
 
 
@@ -340,7 +340,7 @@ class ExecuteResult(SpeQtrumModel):
     rabi_experiment_result: RabiExperimentResult | None = None
     t1_experiment_result: T1ExperimentResult | None = None
     t2_experiment_result: T2ExperimentResult | None = None
-    two_tones_at_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult | None = None
+    two_tones_at_fixed_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult | None = None
     two_tones_vs_flux_bias_experiment_result: TwoTonesVsFluxBiasExperimentResult | None = None
 
     @field_serializer("functional_result")
@@ -393,18 +393,18 @@ class ExecuteResult(SpeQtrumModel):
             return deserialize(v, T2ExperimentResult)
         return v
 
-    @field_serializer("two_tones_at_flux_bias_experiment_result")
-    def _serialize_two_tones_at_flux_bias_experiment_result(
-        self, two_tones_at_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult, _info
+    @field_serializer("two_tones_at_fixed_flux_bias_experiment_result")
+    def _serialize_two_tones_at_fixed_flux_bias_experiment_result(
+        self, two_tones_at_fixed_flux_bias_experiment_result: TwoTonesAtFixedFluxBiasExperimentResult, _info
     ):
         return (
-            serialize(two_tones_at_flux_bias_experiment_result)
-            if two_tones_at_flux_bias_experiment_result is not None
+            serialize(two_tones_at_fixed_flux_bias_experiment_result)
+            if two_tones_at_fixed_flux_bias_experiment_result is not None
             else None
         )
 
-    @field_validator("two_tones_at_flux_bias_experiment_result", mode="before")
-    def _load_two_tones_at_flux_bias_experiment_result(cls, v):
+    @field_validator("two_tones_at_fixed_flux_bias_experiment_result", mode="before")
+    def _load_ttwo_tones_at_fixed_flux_bias_experiment_result(cls, v):
         if isinstance(v, str) and v.startswith("!"):
             return deserialize(v, TwoTonesAtFixedFluxBiasExperimentResult)
         return v
@@ -521,22 +521,22 @@ def _require_t2_experiment_result(result: ExecuteResult) -> T2ExperimentResult:
 
 
 def _require_two_tones_experiment_result(result: ExecuteResult) -> TwoTonesAtFixedFluxBiasExperimentResult:
-    """Extract and return the ``TwoTonesAtFluxBiasExperimentResult`` from *result*.
+    """Extract and return the ``TwoTonesAtFixedFluxBiasExperimentResult`` from *result*.
 
     Args:
         result (ExecuteResult): The execution result to inspect.
 
     Returns:
-        TwoTonesAtFluxBiasExperimentResult: The contained Two-Tones at flux bias experiment result.
+        TwoTonesAtFixedFluxBiasExperimentResult: The contained Two-Tones at flux bias experiment result.
 
     Raises:
         RuntimeError: If the ``two_tones_experiment_result`` field is ``None``.
     """
-    if result.two_tones_at_flux_bias_experiment_result is None:
+    if result.two_tones_at_fixed_flux_bias_experiment_result is None:
         raise RuntimeError(
-            "SpeQtrum did not return a two_tones_at_flux_bias_experiment_result for a Two-Tones at flux bias experiment execution."
+            "SpeQtrum did not return a two_tones_at_fixed_flux_bias_experiment_result for a Two-Tones at flux bias experiment execution."
         )
-    return result.two_tones_at_flux_bias_experiment_result
+    return result.two_tones_at_fixed_flux_bias_experiment_result
 
 
 def _require_two_tones_vs_flux_bias_experiment_result(result: ExecuteResult) -> TwoTonesVsFluxBiasExperimentResult:
@@ -696,8 +696,8 @@ class JobHandle(SpeQtrumModel, Generic[TFunctionalResult_co]):
             job_id (int): Numeric identifier returned by the SpeQtrum service.
 
         Returns:
-            JobHandle[TwoTonesAtFluxBiasExperimentResult]: A handle whose result type is
-            ``TwoTonesAtFluxBiasExperimentResult``.
+            JobHandle[TwoTonesAtFixedFluxBiasExperimentResult]: A handle whose result type is
+            ``TwoTonesAtFixedFluxBiasExperimentResult``.
         """
         return cls(
             id=job_id,

--- a/tests/unit_python/experiments/test_experiment_functional.py
+++ b/tests/unit_python/experiments/test_experiment_functional.py
@@ -26,43 +26,67 @@ from qilisdk.experiments import (
 
 def test_experiment_functional_initialization():
     qubit = 0
-    functional = ExperimentFunctional(qubit=qubit)
+    averages = 1000
+
+    functional = ExperimentFunctional(qubit=qubit, averages=averages)
+
     assert functional.qubit == qubit
+    assert functional.averages == averages
 
 
 def test_rabi_experiment_initialization():
     qubit = 0
+    averages = 1000
     values = np.array([0.1, 0.2, 0.3])
-    rabi_exp = RabiExperiment(qubit=qubit, drive_duration_values=values)
+
+    rabi_exp = RabiExperiment(qubit=qubit, averages=averages, drive_duration_values=values)
+
     assert rabi_exp.qubit == qubit
+    assert rabi_exp.averages == averages
     assert np.array_equal(rabi_exp.drive_duration_values, values)
 
 
 def test_t1_experiment_initialization():
     qubit = 0
+    averages = 1000
     values = np.array([10, 20, 30])
-    t1_exp = T1Experiment(qubit=qubit, wait_duration_values=values)
+
+    t1_exp = T1Experiment(qubit=qubit, averages=averages, wait_duration_values=values)
+
     assert t1_exp.qubit == qubit
+    assert t1_exp.averages == averages
     assert np.array_equal(t1_exp.wait_duration_values, values)
 
 
 def test_t2_experiment_initialization():
     qubit = 0
+    averages = 1000
     values = np.array([5, 15, 25])
-    t2_exp = T2Experiment(qubit=qubit, wait_duration_values=values)
+
+    t2_exp = T2Experiment(qubit=qubit, averages=averages, wait_duration_values=values)
+
     assert t2_exp.qubit == qubit
+    assert t2_exp.averages == averages
     assert np.array_equal(t2_exp.wait_duration_values, values)
 
 
 def test_two_tones_experiment_initialization():
     qubit = 0
+    averages = 1000
     freq_start = 4.0
     freq_stop = 5.0
     freq_step = 5.0
+
     two_tones_exp = TwoTonesAtFluxBiasExperiment(
-        qubit=qubit, frequency_start=freq_start, frequency_stop=freq_stop, frequency_step=freq_step
+        qubit=qubit,
+        averages=averages,
+        frequency_start=freq_start,
+        frequency_stop=freq_stop,
+        frequency_step=freq_step,
     )
+
     assert two_tones_exp.qubit == qubit
+    assert two_tones_exp.averages == averages
     assert np.isclose(two_tones_exp.frequency_start, freq_start)
     assert np.isclose(two_tones_exp.frequency_stop, freq_stop)
     assert np.isclose(two_tones_exp.frequency_step, freq_step)
@@ -70,14 +94,17 @@ def test_two_tones_experiment_initialization():
 
 def test_two_tones_versus_flux_experiment_initialization():
     qubit = 0
+    averages = 1000
     freq_start = 4.0
     freq_stop = 5.0
     freq_step = 5.0
     flux_start = -1.0
     flux_stop = 1.0
     flux_step = 0.5
+
     two_tones_flux_exp = TwoTonesVsFluxBiasExperiment(
         qubit=qubit,
+        averages=averages,
         frequency_start=freq_start,
         frequency_stop=freq_stop,
         frequency_step=freq_step,
@@ -85,7 +112,9 @@ def test_two_tones_versus_flux_experiment_initialization():
         flux_stop=flux_stop,
         flux_step=flux_step,
     )
+
     assert two_tones_flux_exp.qubit == qubit
+    assert two_tones_flux_exp.averages == averages
     assert np.isclose(two_tones_flux_exp.frequency_start, freq_start)
     assert np.isclose(two_tones_flux_exp.frequency_stop, freq_stop)
     assert np.isclose(two_tones_flux_exp.frequency_step, freq_step)

--- a/tests/unit_python/experiments/test_experiment_functional.py
+++ b/tests/unit_python/experiments/test_experiment_functional.py
@@ -19,7 +19,7 @@ from qilisdk.experiments import (
     RabiExperiment,
     T1Experiment,
     T2Experiment,
-    TwoTonesAtFluxBiasExperiment,
+    TwoTonesAtFixedFluxBiasExperiment,
     TwoTonesVsFluxBiasExperiment,
 )
 
@@ -77,7 +77,7 @@ def test_two_tones_experiment_initialization():
     freq_stop = 5.0
     freq_step = 5.0
 
-    two_tones_exp = TwoTonesAtFluxBiasExperiment(
+    two_tones_exp = TwoTonesAtFixedFluxBiasExperiment(
         qubit=qubit,
         averages=averages,
         frequency_start=freq_start,

--- a/tests/unit_python/experiments/test_experiments.py
+++ b/tests/unit_python/experiments/test_experiments.py
@@ -22,7 +22,7 @@ from qilisdk.experiments import (
     RabiExperimentResult,
     T1ExperimentResult,
     T2ExperimentResult,
-    TwoTonesAtFluxBiasExperimentResult,
+    TwoTonesAtFixedFluxBiasExperimentResult,
     TwoTonesVsFluxBiasExperimentResult,
 )
 
@@ -39,16 +39,21 @@ def test_dimension_initialization():
 def test_experiment_result_init():
     data = np.array([[1, 2], [3, 4]])
     qubit = 0
+    averages = 1000
     dims = [Dimension(labels=["Freq"], values=[np.array([1, 2])])]
-    exp_result = ExperimentResult(qubit=qubit, data=data, dims=dims)
+
+    exp_result = ExperimentResult(qubit=qubit, averages=averages, data=data, dims=dims)
+
     assert exp_result.qubit == qubit
+    assert exp_result.averages == averages
     assert np.array_equal(exp_result.data, data)
     assert exp_result.dims == dims
 
 
 def test_experiment_s21_computation():
     data = np.array([[1, 2], [3, 4]])
-    exp_result = ExperimentResult(qubit=0, data=data, dims=[])
+
+    exp_result = ExperimentResult(qubit=0, averages=1000, data=data, dims=[])
 
     s21 = exp_result.s21
     expected_s21 = np.array([1 + 2j, 3 + 4j])
@@ -74,7 +79,8 @@ def test_experiment_plotting(monkeypatch):
         Dimension(labels=["Dim2", "Freq2"], values=[np.array([3, 4]), np.array([30, 40])]),
         Dimension(labels=["Dim3", "Freq3"], values=[np.array([5, 6]), np.array([50, 60])]),
     ]
-    exp_result_3d = RabiExperimentResult(qubit=0, data=data3d, dims=dims3d)
+    exp_result_3d = RabiExperimentResult(qubit=0, averages=1000, data=data3d, dims=dims3d)
+
     with pytest.raises(NotImplementedError, match="3D and higher"):
         exp_result_3d.plot(save_to="./.tmp/")
 
@@ -90,7 +96,8 @@ def test_t1_plotting(monkeypatch):
     noise = rng.normal(0, 0.02, size=(len(tau), 2))
     amplitudes = np.clip(decay[:, np.newaxis] + noise, 0, 1)
     dims = [Dimension(labels=["Time"], values=[tau])]
-    t1_result = T1ExperimentResult(qubit=0, data=amplitudes, dims=dims)
+
+    t1_result = T1ExperimentResult(qubit=0, averages=1000, data=amplitudes, dims=dims)
 
     t1_result.plot(save_to="./.tmp/test_t1_default.png")
     t1_result.plot(save_to="./.tmp/test_t1.png", fit=False)
@@ -110,7 +117,8 @@ def test_rabi_plotting(monkeypatch):
     I += rng.normal(0, 0.01, size=I.shape)
     data_rabi = np.stack([I, Q], axis=-1)
     dims_rabi = [Dimension(labels=["Drive duration (ns)"], values=[drive_durations])]
-    result_rabi = RabiExperimentResult(qubit=0, data=data_rabi, dims=dims_rabi)
+
+    result_rabi = RabiExperimentResult(qubit=0, averages=1000, data=data_rabi, dims=dims_rabi)
 
     result_rabi.plot(save_to="./.tmp/test_rabi_default.png")
     result_rabi.plot(save_to="./.tmp/test_rabi.png", fit=False)
@@ -134,7 +142,8 @@ def test_two_tones_at_flux_bias_plotting(monkeypatch):
     s21_complex = s21_mag * np.exp(1j * phase)
     data_at = np.stack([s21_complex.real, s21_complex.imag], axis=-1)
     dims_at = [Dimension(labels=["IF Frequency (Hz)"], values=[freqs])]
-    result_at = TwoTonesAtFluxBiasExperimentResult(qubit=0, data=data_at, dims=dims_at)
+
+    result_at = TwoTonesAtFixedFluxBiasExperimentResult(qubit=0, averages=1000, data=data_at, dims=dims_at)
 
     result_at.plot(save_to="./.tmp/test_two_tones_at_default.png")
     result_at.plot(save_to="./.tmp/test_two_tones_at.png", fit=False)
@@ -162,7 +171,8 @@ def test_two_tones_vs_flux_bias_plotting(monkeypatch):
         Dimension(labels=["Flux bias (Φ₀)"], values=[fluxes]),
         Dimension(labels=["Drive frequency (Hz)"], values=[freqs2d]),
     ]
-    result_vs = TwoTonesVsFluxBiasExperimentResult(qubit=0, data=data_vs, dims=dims_vs)
+
+    result_vs = TwoTonesVsFluxBiasExperimentResult(qubit=0, averages=1000, data=data_vs, dims=dims_vs)
 
     result_vs.plot(save_to="./.tmp/test_two_tones_vs_default.png")
     result_vs.plot(save_to="./.tmp/test_two_tones_vs.png", fit=False)
@@ -183,7 +193,8 @@ def test_t2_plotting(monkeypatch):
     I += rng.normal(0, 0.002, size=I.shape)
     data_t2 = np.stack([I, Q], axis=-1)
     dims_t2 = [Dimension(labels=["Wait duration (μs)"], values=[tau])]
-    result_t2 = T2ExperimentResult(qubit=0, data=data_t2, dims=dims_t2)
+
+    result_t2 = T2ExperimentResult(qubit=0, averages=1000, data=data_t2, dims=dims_t2)
 
     result_t2.plot(save_to="./.tmp/test_t2_default.png")
     result_t2.plot(save_to="./.tmp/test_t2.png", fit=False)

--- a/tests/unit_python/speqtrum/test_speqtrum.py
+++ b/tests/unit_python/speqtrum/test_speqtrum.py
@@ -36,7 +36,7 @@ from qilisdk.experiments.experiment_functional import (
     RabiExperiment,
     T1Experiment,
     T2Experiment,
-    TwoTonesAtFluxBiasExperiment,
+    TwoTonesAtFixedFluxBiasExperiment,
     TwoTonesVsFluxBiasExperiment,
 )
 from qilisdk.functionals.analog_evolution import AnalogEvolution
@@ -148,7 +148,7 @@ class FakeT2Experiment(T2Experiment):
     def __init__(self): ...
 
 
-class FakeTwoTonesAtFluxBiasExperiment(TwoTonesAtFluxBiasExperiment):
+class FakeTwoTonesAtFluxBiasExperiment(TwoTonesAtFixedFluxBiasExperiment):
     def __init__(self): ...
 
 
@@ -263,7 +263,7 @@ def test_submit_dispatches_to_t2_experiment_handler(monkeypatch):
 
 
 def test_submit_dispatches_to_two_tones_at_flux_bias_handler(monkeypatch):
-    monkeypatch.setattr(speqtrum, "TwoTonesAtFluxBiasExperiment", FakeTwoTonesAtFluxBiasExperiment)
+    monkeypatch.setattr(speqtrum, "TwoTonesAtFixedFluxBiasExperiment", FakeTwoTonesAtFluxBiasExperiment)
     monkeypatch.setattr(speqtrum, "load_credentials", lambda: ("u", SimpleNamespace(access_token="t")))
     monkeypatch.setattr(
         speqtrum.SpeQtrum,

--- a/tests/unit_python/speqtrum/test_speqtrum_models.py
+++ b/tests/unit_python/speqtrum/test_speqtrum_models.py
@@ -395,7 +395,9 @@ def test_requires():
     with pytest.raises(RuntimeError, match="did not return a t2_experiment_result"):
         _require_t2_experiment_result(bad_result)
 
-    assert _require_two_tones_experiment_result(good_result) is good_result.two_tones_at_fixed_flux_bias_experiment_result
+    assert (
+        _require_two_tones_experiment_result(good_result) is good_result.two_tones_at_fixed_flux_bias_experiment_result
+    )
     with pytest.raises(RuntimeError, match="did not return a two_tones_at_fixed_flux_bias_experiment_result"):
         _require_two_tones_experiment_result(bad_result)
 

--- a/tests/unit_python/speqtrum/test_speqtrum_models.py
+++ b/tests/unit_python/speqtrum/test_speqtrum_models.py
@@ -33,7 +33,7 @@ from qilisdk.experiments.experiment_functional import (
     RabiExperiment,
     T1Experiment,
     T2Experiment,
-    TwoTonesAtFluxBiasExperiment,
+    TwoTonesAtFixedFluxBiasExperiment,
     TwoTonesVsFluxBiasExperiment,
 )
 from qilisdk.experiments.experiment_result import (
@@ -82,7 +82,7 @@ from qilisdk.speqtrum.speqtrum_models import (
     RabiExperimentPayload,
     T1ExperimentPayload,
     T2ExperimentPayload,
-    TwoTonesAtFluxBiasExperimentPayload,
+    TwoTonesAtFixedFluxBiasExperimentPayload,
     TwoTonesVsFluxBiasExperimentPayload,
     VariationalProgramPayload,
 )
@@ -131,9 +131,9 @@ def test_variational_program_payload():
 
 def test_rabi_experiment_payload():
     experiment = RabiExperiment(qubit=0, averages=1000, drive_duration_values=[10, 20, 30])
-    payload = RabiExperimentPayload(rabi_experiment=experiment)
-    serialized_experiment = payload._serialize_rabi_experiment(rabi_experiment=experiment, _info={})
-    deserialized_experiment = payload._load_rabi_experiment(serialized_experiment)
+    payload = RabiExperimentPayload(experiment=experiment)
+    serialized_experiment = payload._serialize_experiment(experiment=experiment, _info={})
+    deserialized_experiment = payload._load_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
     assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.drive_duration_values == experiment.drive_duration_values
@@ -141,9 +141,9 @@ def test_rabi_experiment_payload():
 
 def test_t1_experiment_payload():
     experiment = T1Experiment(qubit=0, averages=1000, wait_duration_values=[10, 20, 30])
-    payload = T1ExperimentPayload(t1_experiment=experiment)
-    serialized_experiment = payload._serialize_t1_experiment(t1_experiment=experiment, _info={})
-    deserialized_experiment = payload._load_t1_experiment(serialized_experiment)
+    payload = T1ExperimentPayload(experiment=experiment)
+    serialized_experiment = payload._serialize_experiment(experiment=experiment, _info={})
+    deserialized_experiment = payload._load_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
     assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.wait_duration_values == experiment.wait_duration_values
@@ -151,25 +151,25 @@ def test_t1_experiment_payload():
 
 def test_t2_experiment_payload():
     experiment = T2Experiment(qubit=0, averages=1000, wait_duration_values=[10, 20, 30])
-    payload = T2ExperimentPayload(t2_experiment=experiment)
-    serialized_experiment = payload._serialize_t2_experiment(t2_experiment=experiment, _info={})
-    deserialized_experiment = payload._load_t2_experiment(serialized_experiment)
+    payload = T2ExperimentPayload(experiment=experiment)
+    serialized_experiment = payload._serialize_experiment(experiment=experiment, _info={})
+    deserialized_experiment = payload._load_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
     assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.wait_duration_values == experiment.wait_duration_values
 
 
 def test_two_tones_at_flux_bias_experiment_payload():
-    experiment = TwoTonesAtFluxBiasExperiment(
+    experiment = TwoTonesAtFixedFluxBiasExperiment(
         qubit=0,
         averages=1000,
         frequency_start=4.9e9,
         frequency_stop=5.1e9,
         frequency_step=1e6,
     )
-    payload = TwoTonesAtFluxBiasExperimentPayload(two_tones_experiment=experiment)
-    serialized_experiment = payload._serialize_two_tones_experiment(two_tones_experiment=experiment, _info={})
-    deserialized_experiment = payload._load_two_tones_experiment(serialized_experiment)
+    payload = TwoTonesAtFixedFluxBiasExperimentPayload(experiment=experiment)
+    serialized_experiment = payload._serialize_experiment(experiment=experiment, _info={})
+    deserialized_experiment = payload._load_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
     assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.frequency_start == experiment.frequency_start
@@ -188,11 +188,9 @@ def test_two_tones_vs_flux_bias_experiment_payload():
         flux_stop=1.0,
         flux_step=0.1,
     )
-    payload = TwoTonesVsFluxBiasExperimentPayload(two_tones_vs_flux_experiment=experiment)
-    serialized_experiment = payload._serialize_two_tones_vs_flux_experiment(
-        two_tones_vs_flux_experiment=experiment, _info={}
-    )
-    deserialized_experiment = payload._load_two_tones_vs_flux_experiment(serialized_experiment)
+    payload = TwoTonesVsFluxBiasExperimentPayload(experiment=experiment)
+    serialized_experiment = payload._serialize_experiment(experiment=experiment, _info={})
+    deserialized_experiment = payload._load_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
     assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.frequency_start == experiment.frequency_start
@@ -314,7 +312,7 @@ def test_execute_result_t2_experiment():
     assert deserialized_result.dims == t2_experiment_result.dims
 
 
-def test_execute_result_two_tones_experiment():
+def test_execute_result_two_tones_at_fixed_flux_bias_experiment():
     execute_type = ExecuteType.TWO_TONES_AT_FIXED_FLUX_EXPERIMENT
     two_tones_experiment_result = TwoTonesAtFixedFluxBiasExperimentResult(
         qubit=0,
@@ -324,12 +322,12 @@ def test_execute_result_two_tones_experiment():
     )
     result = ExecuteResult(
         type=execute_type,
-        two_tones_at_flux_bias_experiment_result=two_tones_experiment_result,
+        two_tones_at_fixed_flux_bias_experiment_result=two_tones_experiment_result,
     )
-    serialized_result = result._serialize_two_tones_at_flux_bias_experiment_result(
-        two_tones_at_flux_bias_experiment_result=result.two_tones_at_flux_bias_experiment_result, _info={}
+    serialized_result = result._serialize_two_tones_at_fixed_flux_bias_experiment_result(
+        two_tones_at_fixed_flux_bias_experiment_result=result.two_tones_at_fixed_flux_bias_experiment_result, _info={}
     )
-    deserialized_result = result._load_two_tones_at_flux_bias_experiment_result(serialized_result)
+    deserialized_result = result._load_ttwo_tones_at_fixed_flux_bias_experiment_result(serialized_result)
     assert deserialized_result.qubit == two_tones_experiment_result.qubit
     assert deserialized_result.averages == two_tones_experiment_result.averages
     assert deserialized_result.data == two_tones_experiment_result.data
@@ -365,7 +363,7 @@ def test_requires():
     good_result.rabi_experiment_result = MagicMock()
     good_result.t1_experiment_result = MagicMock()
     good_result.t2_experiment_result = MagicMock()
-    good_result.two_tones_at_flux_bias_experiment_result = MagicMock()
+    good_result.two_tones_at_fixed_flux_bias_experiment_result = MagicMock()
     good_result.two_tones_vs_flux_bias_experiment_result = MagicMock()
 
     bad_result = MagicMock()
@@ -374,7 +372,7 @@ def test_requires():
     bad_result.rabi_experiment_result = None
     bad_result.t1_experiment_result = None
     bad_result.t2_experiment_result = None
-    bad_result.two_tones_at_flux_bias_experiment_result = None
+    bad_result.two_tones_at_fixed_flux_bias_experiment_result = None
     bad_result.two_tones_vs_flux_bias_experiment_result = None
 
     assert _require_variational_program_result(good_result) is good_result.variational_program_result
@@ -397,8 +395,8 @@ def test_requires():
     with pytest.raises(RuntimeError, match="did not return a t2_experiment_result"):
         _require_t2_experiment_result(bad_result)
 
-    assert _require_two_tones_experiment_result(good_result) is good_result.two_tones_at_flux_bias_experiment_result
-    with pytest.raises(RuntimeError, match="did not return a two_tones_at_flux_bias_experiment_result"):
+    assert _require_two_tones_experiment_result(good_result) is good_result.two_tones_at_fixed_flux_bias_experiment_result
+    with pytest.raises(RuntimeError, match="did not return a two_tones_at_fixed_flux_bias_experiment_result"):
         _require_two_tones_experiment_result(bad_result)
 
     assert (

--- a/tests/unit_python/speqtrum/test_speqtrum_models.py
+++ b/tests/unit_python/speqtrum/test_speqtrum_models.py
@@ -40,7 +40,7 @@ from qilisdk.experiments.experiment_result import (
     RabiExperimentResult,
     T1ExperimentResult,
     T2ExperimentResult,
-    TwoTonesAtFluxBiasExperimentResult,
+    TwoTonesAtFixedFluxBiasExperimentResult,
     TwoTonesVsFluxBiasExperimentResult,
 )
 from qilisdk.functionals.analog_evolution import AnalogEvolution
@@ -130,38 +130,48 @@ def test_variational_program_payload():
 
 
 def test_rabi_experiment_payload():
-    experiment = RabiExperiment(qubit=0, drive_duration_values=[10, 20, 30])
+    experiment = RabiExperiment(qubit=0, averages=1000, drive_duration_values=[10, 20, 30])
     payload = RabiExperimentPayload(rabi_experiment=experiment)
     serialized_experiment = payload._serialize_rabi_experiment(rabi_experiment=experiment, _info={})
     deserialized_experiment = payload._load_rabi_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
+    assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.drive_duration_values == experiment.drive_duration_values
 
 
 def test_t1_experiment_payload():
-    experiment = T1Experiment(qubit=0, wait_duration_values=[10, 20, 30])
+    experiment = T1Experiment(qubit=0, averages=1000, wait_duration_values=[10, 20, 30])
     payload = T1ExperimentPayload(t1_experiment=experiment)
     serialized_experiment = payload._serialize_t1_experiment(t1_experiment=experiment, _info={})
     deserialized_experiment = payload._load_t1_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
+    assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.wait_duration_values == experiment.wait_duration_values
 
 
 def test_t2_experiment_payload():
-    experiment = T2Experiment(qubit=0, wait_duration_values=[10, 20, 30])
+    experiment = T2Experiment(qubit=0, averages=1000, wait_duration_values=[10, 20, 30])
     payload = T2ExperimentPayload(t2_experiment=experiment)
     serialized_experiment = payload._serialize_t2_experiment(t2_experiment=experiment, _info={})
     deserialized_experiment = payload._load_t2_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
+    assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.wait_duration_values == experiment.wait_duration_values
 
 
 def test_two_tones_at_flux_bias_experiment_payload():
-    experiment = TwoTonesAtFluxBiasExperiment(qubit=0, frequency_start=4.9e9, frequency_stop=5.1e9, frequency_step=1e6)
+    experiment = TwoTonesAtFluxBiasExperiment(
+        qubit=0,
+        averages=1000,
+        frequency_start=4.9e9,
+        frequency_stop=5.1e9,
+        frequency_step=1e6,
+    )
     payload = TwoTonesAtFluxBiasExperimentPayload(two_tones_experiment=experiment)
     serialized_experiment = payload._serialize_two_tones_experiment(two_tones_experiment=experiment, _info={})
     deserialized_experiment = payload._load_two_tones_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
+    assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.frequency_start == experiment.frequency_start
     assert deserialized_experiment.frequency_stop == experiment.frequency_stop
     assert deserialized_experiment.frequency_step == experiment.frequency_step
@@ -170,6 +180,7 @@ def test_two_tones_at_flux_bias_experiment_payload():
 def test_two_tones_vs_flux_bias_experiment_payload():
     experiment = TwoTonesVsFluxBiasExperiment(
         qubit=0,
+        averages=1000,
         frequency_start=4.9e9,
         frequency_stop=5.1e9,
         frequency_step=1e6,
@@ -183,6 +194,7 @@ def test_two_tones_vs_flux_bias_experiment_payload():
     )
     deserialized_experiment = payload._load_two_tones_vs_flux_experiment(serialized_experiment)
     assert deserialized_experiment.qubit == experiment.qubit
+    assert deserialized_experiment.averages == experiment.averages
     assert deserialized_experiment.frequency_start == experiment.frequency_start
     assert deserialized_experiment.frequency_stop == experiment.frequency_stop
     assert deserialized_experiment.frequency_step == experiment.frequency_step
@@ -240,6 +252,7 @@ def test_execute_result_rabi_experiment():
     execute_type = ExecuteType.RABI_EXPERIMENT
     rabi_experiment_result = RabiExperimentResult(
         qubit=0,
+        averages=1000,
         data=[[0.1, 0.2], [0.3, 0.4]],
         dims=[],
     )
@@ -252,6 +265,7 @@ def test_execute_result_rabi_experiment():
     )
     deserialized_result = result._load_rabi_experiment_result(serialized_result)
     assert deserialized_result.qubit == rabi_experiment_result.qubit
+    assert deserialized_result.averages == rabi_experiment_result.averages
     assert deserialized_result.data == rabi_experiment_result.data
     assert deserialized_result.dims == rabi_experiment_result.dims
 
@@ -260,6 +274,7 @@ def test_execute_result_t1_experiment():
     execute_type = ExecuteType.T1_EXPERIMENT
     t1_experiment_result = T1ExperimentResult(
         qubit=0,
+        averages=1000,
         data=[[0.1, 0.2], [0.3, 0.4]],
         dims=[],
     )
@@ -272,6 +287,7 @@ def test_execute_result_t1_experiment():
     )
     deserialized_result = result._load_t1_experiment_result(serialized_result)
     assert deserialized_result.qubit == t1_experiment_result.qubit
+    assert deserialized_result.averages == t1_experiment_result.averages
     assert deserialized_result.data == t1_experiment_result.data
     assert deserialized_result.dims == t1_experiment_result.dims
 
@@ -280,6 +296,7 @@ def test_execute_result_t2_experiment():
     execute_type = ExecuteType.T2_EXPERIMENT
     t2_experiment_result = T2ExperimentResult(
         qubit=0,
+        averages=1000,
         data=[[0.1, 0.2], [0.3, 0.4]],
         dims=[],
     )
@@ -292,14 +309,16 @@ def test_execute_result_t2_experiment():
     )
     deserialized_result = result._load_t2_experiment_result(serialized_result)
     assert deserialized_result.qubit == t2_experiment_result.qubit
+    assert deserialized_result.averages == t2_experiment_result.averages
     assert deserialized_result.data == t2_experiment_result.data
     assert deserialized_result.dims == t2_experiment_result.dims
 
 
 def test_execute_result_two_tones_experiment():
-    execute_type = ExecuteType.TWO_TONES_EXPERIMENT
-    two_tones_experiment_result = TwoTonesAtFluxBiasExperimentResult(
+    execute_type = ExecuteType.TWO_TONES_AT_FIXED_FLUX_EXPERIMENT
+    two_tones_experiment_result = TwoTonesAtFixedFluxBiasExperimentResult(
         qubit=0,
+        averages=1000,
         data=[[0.1, 0.2], [0.3, 0.4]],
         dims=[],
     )
@@ -312,6 +331,7 @@ def test_execute_result_two_tones_experiment():
     )
     deserialized_result = result._load_two_tones_at_flux_bias_experiment_result(serialized_result)
     assert deserialized_result.qubit == two_tones_experiment_result.qubit
+    assert deserialized_result.averages == two_tones_experiment_result.averages
     assert deserialized_result.data == two_tones_experiment_result.data
     assert deserialized_result.dims == two_tones_experiment_result.dims
 
@@ -320,6 +340,7 @@ def test_execute_result_two_tones_vs_flux_bias_experiment():
     execute_type = ExecuteType.TWO_TONES_VS_FLUX_BIAS_EXPERIMENT
     two_tones_vs_flux_bias_result = TwoTonesVsFluxBiasExperimentResult(
         qubit=0,
+        averages=1000,
         data=[[0.1, 0.2], [0.3, 0.4]],
         dims=[],
     )
@@ -332,6 +353,7 @@ def test_execute_result_two_tones_vs_flux_bias_experiment():
     )
     deserialized_result = result._load_two_tones_vs_flux_bias_experiment_result(serialized_result)
     assert deserialized_result.qubit == two_tones_vs_flux_bias_result.qubit
+    assert deserialized_result.averages == two_tones_vs_flux_bias_result.averages
     assert deserialized_result.data == two_tones_vs_flux_bias_result.data
     assert deserialized_result.dims == two_tones_vs_flux_bias_result.dims
 


### PR DESCRIPTION
- Added `averages` as a common field for experiment functionals and experiment results.
- Renamed `TwoTonesAtFluxBiasExperiment` to `TwoTonesAtFixedFluxBiasExperiment`.