### PR TITLE
[SDK-313] Add Printing for Experiments

### DIFF
--- a/changes/237.bugfix.md
+++ b/changes/237.bugfix.md
@@ -1,1 +1,1 @@
-ExperimentResults can now be printed without error, previously it was using the FunctionalResult __repr__ (since it inherits from FunctionalResult), but now it has its own dedicated print.
+`ExperimentResult` can now be printed without error, previously it was using the `FunctionalResult` `__repr__` (since it inherits from `FunctionalResult`), but now it has its own dedicated print.

--- a/changes/237.bugfix.md
+++ b/changes/237.bugfix.md
@@ -1,0 +1,1 @@
+ExperimentResults can now be printed without error, previously it was using the FunctionalResult __repr__ (since it inherits from FunctionalResult), but now it has its own dedicated print.

--- a/src/qilisdk/experiments/experiment_result.py
+++ b/src/qilisdk/experiments/experiment_result.py
@@ -43,6 +43,9 @@ class Dimension:
         self.labels = labels
         self.values = values
 
+    def __repr__(self) -> str:
+        return f"Dimension(labels={self.labels}, values={self.values})"
+
 
 _LABEL_AMPLITUDE = "Amplitude (V)"
 _LABEL_PHASE = "Phase (rad)"
@@ -329,6 +332,9 @@ class ExperimentResult(FunctionalResult):
             )
         else:
             raise NotImplementedError("3D and higher dimension plots are not supported yet.")
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(qubit={self.qubit}, averages={self.averages}, data={self.data}, dims={self.dims})"
 
 
 @yaml.register_class

--- a/tests/unit_python/experiments/test_experiments.py
+++ b/tests/unit_python/experiments/test_experiments.py
@@ -248,3 +248,18 @@ def test_t2_plotting(monkeypatch):
     fakeWarning.assert_called_with(
         "Fitting is only implemented for amplitude plots. Ignoring fit request for non-amplitude plot."
     )
+
+
+def test_experiment_printing():
+    data = np.array([[1, 2], [3, 4]])
+    qubit = 0
+    averages = 1000
+    dims = [Dimension(labels=["Freq"], values=[np.array([1, 2])])]
+
+    exp_result = ExperimentResult(qubit=qubit, averages=averages, data=data, dims=dims)
+
+    expected_str = (
+        "ExperimentResult(qubit=0, averages=1000, data=[[1 2]\n [3 4]], "
+        "dims=[Dimension(labels=['Freq'], values=[array([1, 2])])])"
+    )
+    assert str(exp_result) == expected_str


### PR DESCRIPTION
`ExperimentResult` can now be printed without error, previously it was using the `FunctionalResult` `__repr__` (since it inherits from `FunctionalResult`), but now it has its own dedicated print.