### PR TITLE
fix(security): QSDK-04 coerce from_numpy input to contiguous complex128

### DIFF
--- a/src/qilisdk_cpp/libs/numpy.cpp
+++ b/src/qilisdk_cpp/libs/numpy.cpp
@@ -29,7 +29,19 @@ SparseMatrix from_numpy(const py::buffer& matrix_buffer, double atol) {
     Returns:
         SparseMatrix: The converted sparse matrix.
     */
-    py::buffer_info buf = matrix_buffer.request();
+    // QSDK-04 (CWE-843 / CWE-125): coerce to a C-contiguous complex128 array
+    // instead of reinterpreting the raw buffer. Without this, a non-complex128
+    // input (e.g. float64, or every gate matrix under
+    // QILISDK_COMPLEX_PRECISION=COMPLEX_64) or a non-contiguous view strides
+    // 16 bytes per element over a smaller/mismatched allocation, reading out of
+    // bounds. forcecast converts the dtype and c_style guarantees contiguity,
+    // so ptr[r * cols + c] is always in-bounds.
+    auto array =
+        py::array_t<std::complex<double>, py::array::c_style | py::array::forcecast>::ensure(matrix_buffer);
+    if (!array) {
+        throw py::value_error("Input array must be convertible to a 2D complex128 array.");
+    }
+    py::buffer_info buf = array.request();
     if (buf.ndim != 2) {
         throw py::value_error("Input array must be 2D.");
     }

--- a/tests/unit_python/core/test_qtensor.py
+++ b/tests/unit_python/core/test_qtensor.py
@@ -63,6 +63,14 @@ def test_from_numpy_coerces_mismatched_dtype_and_strides():
     assert np.allclose(result, np.ascontiguousarray(view))
 
 
+def test_from_numpy_raises_when_array_is_not_convertible_to_complex128():
+    from qtensor_module import QTensorCpp  # noqa: PLC0415
+
+    bad = np.array([["not-a-number"]], dtype=object)
+    with pytest.raises(ValueError, match=r"Input array must be convertible to a 2D complex128 array\."):
+        QTensorCpp(bad)
+
+
 def test_constructor_valid_sparse():
     """QTensor should accept a valid SciPy sparse matrix."""
     sparse_mat = csc_array([[1, 0], [0, 1]])

--- a/tests/unit_python/core/test_qtensor.py
+++ b/tests/unit_python/core/test_qtensor.py
@@ -43,6 +43,26 @@ def test_constructor_valid_ndarray():
     assert issparse(qobj.data)
 
 
+def test_from_numpy_coerces_mismatched_dtype_and_strides():
+    """QSDK-04: ``from_numpy`` must coerce a non-complex128 or non-contiguous
+    input to a contiguous complex128 buffer instead of reinterpreting the raw
+    bytes (which strides 16 B/element over a smaller/mismatched allocation and
+    reads out of bounds). Exercised via the uncoerced ``QTensorCpp`` path."""
+    from qtensor_module import QTensorCpp
+
+    expected = np.eye(4)
+    for dtype in (np.complex64, np.float64, np.float32, np.complex128):
+        result = np.asarray(QTensorCpp(np.eye(4, dtype=dtype)).as_numpy())
+        assert np.allclose(result, expected), f"dtype {np.dtype(dtype).name} mismatched"
+
+    # Non-contiguous complex128 view: strides must be honoured, not ignored.
+    base = np.arange(64, dtype=np.complex128).reshape(8, 8)
+    view = base[::2, ::2]
+    assert not view.flags["C_CONTIGUOUS"]
+    result = np.asarray(QTensorCpp(view).as_numpy())
+    assert np.allclose(result, np.ascontiguousarray(view))
+
+
 def test_constructor_valid_sparse():
     """QTensor should accept a valid SciPy sparse matrix."""
     sparse_mat = csc_array([[1, 0], [0, 1]])

--- a/tests/unit_python/core/test_qtensor.py
+++ b/tests/unit_python/core/test_qtensor.py
@@ -48,7 +48,7 @@ def test_from_numpy_coerces_mismatched_dtype_and_strides():
     input to a contiguous complex128 buffer instead of reinterpreting the raw
     bytes (which strides 16 B/element over a smaller/mismatched allocation and
     reads out of bounds). Exercised via the uncoerced ``QTensorCpp`` path."""
-    from qtensor_module import QTensorCpp
+    from qtensor_module import QTensorCpp  # noqa: PLC0415
 
     expected = np.eye(4)
     for dtype in (np.complex64, np.float64, np.float32, np.complex128):


### PR DESCRIPTION
## Summary

Fixes **QSDK-04** (Medium, CWE-843 / CWE-125) from the QiliSDK security analysis.

Finding: https://app.notion.com/p/37d7eec14c5381abae83fa006b1c4cd5

`from_numpy()` reinterpreted the raw numpy buffer as `complex128` after only checking `ndim == 2`, never verifying itemsize / dtype / contiguity. A non-`complex128` array (`float64`, or every gate matrix under `QILISDK_COMPLEX_PRECISION=COMPLEX_64`) or a non-contiguous view strides 16 bytes per element over a smaller / mismatched allocation, reading out of bounds; under `COMPLEX_64` this was a deterministic OOB read on any circuit run.

## Fix

Coerce the buffer to a C-contiguous `complex128` array (`py::array::c_style | py::array::forcecast`) before reading. This covers every caller (`QTensorCpp`, `parse_gates`, observables) since they all route through `from_numpy`, and makes the `COMPLEX_64` path produce correct values instead of reading past the buffer. Adds a regression test.

Verified locally: built and 140 QTensor tests pass (incl. the new regression).
