### PR TITLE
fix(security): QSDK-05/06 reject out-of-range qubit indices at the trust boundary

### DIFF
--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -120,6 +120,10 @@ class PauliOperator(ABC):
         cls._MATRIX_CACHE = {}
 
     def __init__(self, qubit: int) -> None:
+        # QSDK-05: reject negative qubit indices at construction (the upper bound
+        # depends on the Hamiltonian / circuit and is enforced at execution).
+        if qubit < 0:
+            raise ValueError(f"Qubit index must be non-negative, got {qubit}.")
         self._qubit = qubit
 
     @property

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -185,7 +185,7 @@ class Circuit(Parameterizable):
         Raises:
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
-        if any(qubit >= self.nqubits for qubit in gate.qubits):
+        if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
         self._parse_params(gate)
@@ -214,7 +214,7 @@ class Circuit(Parameterizable):
         Raises:
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
-        if any(qubit >= self.nqubits for qubit in gate.qubits):
+        if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
         self._parse_params(gate)

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -14,6 +14,7 @@
 
 #include "matrix_free_operator.h"
 #include <sstream>
+#include <stdexcept>
 #include "../../../libs/pybind.h"
 
 // GCOV_EXCL_BR_START
@@ -36,7 +37,18 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
 
     // Precompute things that are used in all branches
     int num_qubits = static_cast<int>(std::log2(output_state.rows()));
-    long long mask = 1LL << (num_qubits - 1 - target_qubits[0]);
+    // QSDK-05 defense-in-depth: indices are validated at parse time, but this
+    // kernel is also reachable via deserialized objects, so guard the shift so
+    // a bad target can never produce an undefined shift / wild mask.
+    if (target_qubits.empty()) {
+        throw std::out_of_range("MatrixFreeOperator has no target qubit.");
+    }
+    int shift = num_qubits - 1 - target_qubits[0];
+    if (shift < 0 || shift >= 64) {
+        throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
+                                " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
+    }
+    long long mask = 1LL << shift;
     long N = output_state.rows();
     long stride = mask;
     long half = N >> 1;

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -52,7 +52,7 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
     }
     unsigned long long mask = 1ULL << shift;
     long N = output_state.rows();
-    long stride = mask;
+    long stride = static_cast<long>(mask);
     long half = N >> 1;
     long dim = 1LL << num_qubits;
 

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -53,6 +53,9 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }
     unsigned long long mask = 1ULL << shift;
+    if (mask > static_cast<unsigned long long>(std::numeric_limits<long>::max())) {
+        throw std::out_of_range("MatrixFreeOperator target mask exceeds index range.");
+    }
     long N = output_state.rows();
     long stride = static_cast<long>(mask);
     long half = N >> 1;

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "matrix_free_operator.h"
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include "../../../libs/pybind.h"
@@ -44,7 +45,8 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
         throw std::out_of_range("MatrixFreeOperator has no target qubit.");
     }
     int shift = num_qubits - 1 - target_qubits[0];
-    if (shift < 0 || shift >= 64) {
+    constexpr int kMaskBitWidth = std::numeric_limits<unsigned long long>::digits;
+    if (shift < 0 || shift >= kMaskBitWidth) {
         throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -50,7 +50,7 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
         throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }
-    long long mask = 1LL << shift;
+    unsigned long long mask = 1ULL << shift;
     long N = output_state.rows();
     long stride = mask;
     long half = N >> 1;

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "matrix_free_operator.h"
+#include <algorithm>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
@@ -47,17 +48,14 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
     int shift = num_qubits - 1 - target_qubits[0];
     constexpr int kMaskBitWidth = std::numeric_limits<unsigned long long>::digits;
     constexpr int kStrideBitWidth = std::numeric_limits<long>::digits;
-    constexpr int kSafeShiftBitWidth = kMaskBitWidth < kStrideBitWidth ? kMaskBitWidth : kStrideBitWidth;
+    constexpr int kSafeShiftBitWidth = std::min(kMaskBitWidth, kStrideBitWidth);
     if (shift < 0 || shift >= kSafeShiftBitWidth) {
         throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }
-    unsigned long long mask = 1ULL << shift;
-    if (mask > static_cast<unsigned long long>(std::numeric_limits<long>::max())) {
-        throw std::out_of_range("MatrixFreeOperator target mask exceeds index range.");
-    }
+    long mask = static_cast<long>(1ULL << shift);
     long N = output_state.rows();
-    long stride = static_cast<long>(mask);
+    long stride = mask;
     long half = N >> 1;
     long dim = 1LL << num_qubits;
 

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -47,7 +47,8 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
     int shift = num_qubits - 1 - target_qubits[0];
     constexpr int kMaskBitWidth = std::numeric_limits<unsigned long long>::digits;
     constexpr int kStrideBitWidth = std::numeric_limits<long>::digits;
-    if (shift < 0 || shift >= kMaskBitWidth || shift >= kStrideBitWidth) {
+    constexpr int kSafeShiftBitWidth = kMaskBitWidth < kStrideBitWidth ? kMaskBitWidth : kStrideBitWidth;
+    if (shift < 0 || shift >= kSafeShiftBitWidth) {
         throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_operator.cpp
@@ -46,7 +46,8 @@ void MatrixFreeOperator::apply(DenseMatrix& output_state, MatrixFreeApplicationT
     }
     int shift = num_qubits - 1 - target_qubits[0];
     constexpr int kMaskBitWidth = std::numeric_limits<unsigned long long>::digits;
-    if (shift < 0 || shift >= kMaskBitWidth) {
+    constexpr int kStrideBitWidth = std::numeric_limits<long>::digits;
+    if (shift < 0 || shift >= kMaskBitWidth || shift >= kStrideBitWidth) {
         throw std::out_of_range("MatrixFreeOperator target qubit " + std::to_string(target_qubits[0]) +
                                 " is out of range for a " + std::to_string(num_qubits) + "-qubit state.");
     }

--- a/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
@@ -23,6 +23,21 @@
 
 #pragma GCC visibility push(default)
 
+namespace {
+// QSDK-05 / QSDK-06 (CWE-125 / CWE-787): reject out-of-range qubit indices at
+// the C++ trust boundary. The Python layer only guards the upper bound and is
+// bypassed by deserialization (ruamel reconstructs Circuit / Gate / Pauli
+// objects without re-running __init__), so an unvalidated index (e.g. -1)
+// otherwise reaches the matrix-free kernels (undefined shift -> wild mask ->
+// out-of-bounds state access) and the measurement vector (out-of-bounds write).
+inline void validate_qubit_index(int qubit, int nqubits, const char* context) {
+    if (qubit < 0 || qubit >= nqubits) {
+        throw py::value_error("Qubit index " + std::to_string(qubit) + " is out of range [0, " +
+                              std::to_string(nqubits) + ") for " + context + ".");
+    }
+}
+}  // namespace
+
 py::object construct_result_object(const ExponentialAnsatz& state, const py::object& readout, int n_qubits) {
     py::list results;
     for (py::handle ro_handle : readout) {
@@ -155,6 +170,8 @@ std::vector<MatrixFreeHamiltonian> parse_hamiltonians_matrix_free(int nqubits, c
             for (auto& pauli_op : pauli_ops) {
                 std::string name = pauli_op.attr("name").cast<std::string>();
                 int target = pauli_op.attr("qubit").cast<int>();
+                // QSDK-05: validate before the index reaches the matrix-free kernels
+                validate_qubit_index(target, nqubits, "a Pauli operator qubit");
                 ops.push_back(MatrixFreeOperator(name, target));
             }
             H.add(coeff, ops);
@@ -580,6 +597,7 @@ std::vector<Gate> parse_gates(const py::object& circuit, double atol, const py::
         std::vector<Gate>: The list of Gate objects.
     */
     std::vector<Gate> gates;
+    int nqubits = circuit.attr("nqubits").cast<int>();
     py::list py_gates = circuit.attr("gates");
     for (auto py_gate : py_gates) {
         // Get the name
@@ -663,6 +681,14 @@ std::vector<Gate> parse_gates(const py::object& circuit, double atol, const py::
             targets.push_back(py_target.cast<int>());
         }
 
+        // QSDK-05: validate every control / target index against the circuit size
+        for (int control : controls) {
+            validate_qubit_index(control, nqubits, "a gate control qubit");
+        }
+        for (int target : targets) {
+            validate_qubit_index(target, nqubits, "a gate target qubit");
+        }
+
         // If we have controls, only get the bottom right part of the matrix
         if (!controls.empty() && !targets.empty() && base_matrix.rows() > 2) {
             int dim = 1 << targets.size();
@@ -724,6 +750,8 @@ std::vector<bool> parse_measurements(const py::object& circuit) {
             py::list py_targets = py_gate.attr("target_qubits");
             for (auto py_target : py_targets) {
                 int target = py_target.cast<int>();
+                // QSDK-06: bounds-check before the std::vector<bool> write
+                validate_qubit_index(target, n_qubits, "a measurement target qubit");
                 final_qubits_to_measure[target] = true;
             }
         } else {

--- a/tests/unit_python/backends/test_qsdk05_qubit_index_bounds.py
+++ b/tests/unit_python/backends/test_qsdk05_qubit_index_bounds.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Qilimanjaro Quantum Tech
+# Copyright 2026 Qilimanjaro Quantum Tech
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_python/backends/test_qsdk05_qubit_index_bounds.py
+++ b/tests/unit_python/backends/test_qsdk05_qubit_index_bounds.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for QSDK-05 / QSDK-06: out-of-range qubit indices must be
+rejected at the trust boundary instead of producing an out-of-bounds
+read/write in the matrix-free kernels or the measurement vector."""
+
+import pytest
+
+from qilisdk.analog import PauliX
+from qilisdk.backends.qilisim import QiliSim
+from qilisdk.digital import Circuit, H, X
+from qilisdk.digital.exceptions import QubitOutOfRangeError
+from qilisdk.functionals import DigitalPropagation
+from qilisdk.readout import Readout
+
+
+@pytest.mark.parametrize("bad_qubit", [-1, 2, 5])
+def test_circuit_rejects_out_of_range_qubit(bad_qubit):
+    """QSDK-05: the Python layer must reject both negative and too-large qubit
+    indices (the negative case was previously unguarded)."""
+    circuit = Circuit(2)
+    with pytest.raises(QubitOutOfRangeError):
+        circuit.add(X(bad_qubit))
+
+
+def test_pauli_operator_rejects_negative_qubit():
+    """QSDK-05: a Pauli operator must reject a negative qubit at construction."""
+    with pytest.raises(ValueError, match="non-negative"):
+        PauliX(-1)
+
+
+def test_simulator_rejects_out_of_range_qubit_from_unvalidated_gate():
+    """QSDK-05 (keystone): even when the Python guard is bypassed, as happens on
+    deserialization (ruamel reconstructs gates without re-running ``__init__``),
+    the C++ parser must reject an out-of-range target before it reaches the
+    matrix-free kernels, raising instead of reading out of bounds."""
+    circuit = Circuit(2)
+    circuit.add(H(0))
+    circuit.add(X(1))
+    backend = QiliSim()
+    readout = Readout().with_sampling(nshots=100)
+
+    # Sanity: the valid circuit runs.
+    backend.execute(DigitalPropagation(circuit), readout)
+
+    # Bypass validation the way deserialization does: an out-of-range target on
+    # an already-added gate, with no __init__ re-check.
+    gate = circuit.gates[1]
+    inner = getattr(gate, "_basic_gate", gate)
+    inner._target_qubits = (5,)
+
+    with pytest.raises(ValueError, match="out of range"):
+        backend.execute(DigitalPropagation(circuit), readout)


### PR DESCRIPTION
## Summary

Fixes **QSDK-05** (Medium, CWE-125 / CWE-787) and the closely related **QSDK-06** (Low, CWE-787) from the QiliSDK security analysis.

Findings: [QSDK-05](https://app.notion.com/p/37d7eec14c5381c0b1ebc1866a31833e) and [QSDK-06](https://app.notion.com/p/37d7eec14c5381da8770db5cf7e8ec3b)

The matrix-free kernels computed a shift mask from an unvalidated qubit index, and `parse_measurements` wrote `final_qubits_to_measure[target]` with no bounds check. The Python layer only rejected `qubit >= nqubits` (never `qubit < 0`), and deserialization reconstructs `Circuit` / `Gate` / `Pauli` objects without re-running `__init__`, so a crafted or negative index reached the C++ kernels (undefined shift, wild mask, out-of-bounds state access, QSDK-05) and the measurement vector (out-of-bounds write, QSDK-06).

## Fix

- **C++ (keystone):** validate every control / target / Pauli / measurement index against the circuit size in `parse_gates`, `parse_hamiltonians_matrix_free` and `parse_measurements`, before it reaches the kernels (covers the deserialization-bypass path). Defensively guard the shift in `MatrixFreeOperator::apply`.
- **Python (defense-in-depth):** reject `qubit < 0` in `Circuit._add` / `_insert` and `PauliOperator.__init__`.
- Regression tests for the Python guards and the C++ parser guard via a deserialization-style bypassed gate.

Verified locally: built and 605 digital/analog + 16 backend + 5 new regression tests pass; a bypassed out-of-range gate now raises `ValueError` instead of reading out of bounds.
