### PR TITLE
[SDK-307] Add support for global optimizers

### DIFF
--- a/changes/250.feature.md
+++ b/changes/250.feature.md
@@ -1,0 +1,6 @@
+Support has been added for the SciPy global optimizers: `direct`, `dual_annealing`, `differential_evolution`, `shgo` and `basinhopping`, as per https://docs.scipy.org/doc/scipy/tutorial/optimize.html#global-optimization. They are quite slow, but they are guarenteed to find the global minimum, useful for testing small variational programs and ensuring that the ansatz covers the true solution. Usage is the same as choosing any other SciPy optimizer:
+
+```python
+from qilisdk.optimizers.scipy_optimizer import SciPyOptimizer
+optimizer = SciPyOptimizer(method="shgo")
+```

--- a/src/qilisdk/optimizers/scipy_optimizer.py
+++ b/src/qilisdk/optimizers/scipy_optimizer.py
@@ -50,7 +50,7 @@ class SciPyOptimizer(Optimizer):
                     - 'trust-constr
                     - 'dogleg'
                     - 'trust-ncg'
-                    - 'trust-exact
+                    - 'trust-exact'
                     - 'trust-krylov'
                     - 'basinhopping' (global)
                     - 'direct' (global)

--- a/src/qilisdk/optimizers/scipy_optimizer.py
+++ b/src/qilisdk/optimizers/scipy_optimizer.py
@@ -51,7 +51,12 @@ class SciPyOptimizer(Optimizer):
                     - 'dogleg'
                     - 'trust-ncg'
                     - 'trust-exact
-                    - 'trust-krylov
+                    - 'trust-krylov'
+                    - 'basinhopping' (global)
+                    - 'direct' (global)
+                    - 'dual_annealing' (global)
+                    - 'differential_evolution' (global)
+                    - 'shgo' (global)
                     - custom - a callable object, see `scipy.optimize.minimize <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`__ for description.
 
                     If not given, chosen to be one of ``BFGS``, ``L-BFGS-B``, ``SLSQP``,
@@ -97,19 +102,39 @@ class SciPyOptimizer(Optimizer):
         # Only pass the callback if we want to store intermediate results.
         callback = callback_fun if store_intermediate_results else None
 
-        res = scipy_optimize.minimize(
-            cost_function,
-            x0=init_parameters,
-            method=self.method,
-            bounds=bounds,
-            jac=self.extra_arguments.get("jac", None),
-            hess=self.extra_arguments.get("hess", None),
-            hessp=self.extra_arguments.get("hessp", None),
-            constraints=self.extra_arguments.get("constraints", ()),
-            tol=self.extra_arguments.get("tol", None),
-            options=self.extra_arguments.get("options", None),
-            callback=callback,
-        )
+        # Global optimizer have a different interface, like `scipy.optimize.shgo` rather than `scipy.optimize.minimize`
+        if self.method in {"direct", "dual_annealing", "differential_evolution", "shgo"} and isinstance(
+            self.method, str
+        ):
+            res = getattr(scipy_optimize, self.method)(
+                cost_function,
+                bounds=bounds,
+                callback=callback,
+                **self.extra_arguments,
+            )
+        # basinhopping doesn't allow bounds
+        elif self.method == "basinhopping":
+            res = scipy_optimize.basinhopping(
+                cost_function,
+                x0=init_parameters,
+                callback=callback,
+                **self.extra_arguments,
+            )
+        # the more general local minimizer interface
+        else:
+            res = scipy_optimize.minimize(
+                cost_function,
+                x0=init_parameters,
+                method=self.method,
+                bounds=bounds,
+                jac=self.extra_arguments.get("jac", None),
+                hess=self.extra_arguments.get("hess", None),
+                hessp=self.extra_arguments.get("hessp", None),
+                constraints=self.extra_arguments.get("constraints", ()),
+                tol=self.extra_arguments.get("tol", None),
+                options=self.extra_arguments.get("options", None),
+                callback=callback,
+            )
 
         return OptimizerResult(
             optimal_cost=res.fun,

--- a/tests/unit_python/optimizers/test_scipy_optimizer.py
+++ b/tests/unit_python/optimizers/test_scipy_optimizer.py
@@ -14,6 +14,7 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 
 from qilisdk.optimizers.scipy_optimizer import SciPyOptimizer
 
@@ -111,3 +112,17 @@ def test_repr():
     assert "SciPyOptimizer" in repr_str
     assert "method='BFGS'" in repr_str
     assert "jac='dummy_jac'" in repr_str
+
+
+@pytest.mark.parametrize("method", ["basinhopping", "direct", "dual_annealing", "differential_evolution", "shgo"])
+def test_global_optimizers_run(method):
+    dummy_cost = MagicMock(side_effect=lambda x: x[0] ** 2 + x[1] ** 2)
+    optimizer = SciPyOptimizer(method=method)
+    initial_parameters = [0.0, 0.0]
+    bounds = [(0, 5), (0, 5)]
+    optimizer_result = optimizer.optimize(dummy_cost, initial_parameters, bounds)
+
+    assert np.isclose(optimizer_result.optimal_cost, 0.0, atol=1e-2)
+    assert np.isclose(optimizer_result.optimal_parameters[0], 0.0, atol=1e-2)
+    assert np.isclose(optimizer_result.optimal_parameters[1], 0.0, atol=1e-2)
+    assert dummy_cost.call_count > 0


### PR DESCRIPTION
Support has been added for the SciPy global optimizers: `direct`, `dual_annealing`, `differential_evolution`, `shgo` and `basinhopping`, as per https://docs.scipy.org/doc/scipy/tutorial/optimize.html#global-optimization. They are quite slow, but they are guarenteed to find the global minimum, useful for testing small variational programs and ensuring that the ansatz covers the true solution. Usage is the same as choosing any other SciPy optimizer:

```python
from qilisdk.optimizers.scipy_optimizer import SciPyOptimizer
optimizer = SciPyOptimizer(method="shgo")
```