### PR TITLE
[SDK-329] Add check for changelog

### DIFF
--- a/changes/257.misc.md
+++ b/changes/257.misc.md
@@ -1,0 +1,1 @@
+The `checks.sh` pre-commit check script now checks to make sure a changelog file is added in the branch diff, assuming the branch has a non-hotfix name like `sdk-XXX-description`.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -38,4 +38,8 @@ bash scripts/missing_translations.sh 2>&1 | tee -a $LOG_FILE
 echo "Running copyright header checks..." | tee -a $LOG_FILE
 bash scripts/copyrights.sh 2>&1 | tee -a $LOG_FILE
 
+# Check for changelog entry
+echo "Running changelog check..." | tee -a $LOG_FILE
+bash scripts/has_changelog.sh 2>&1 | tee -a $LOG_FILE
+
 echo "All checks passed successfully!" | tee -a $LOG_FILE

--- a/scripts/has_changelog.sh
+++ b/scripts/has_changelog.sh
@@ -6,10 +6,8 @@
 # Time estimate: basically instant
 # --------------------------------------------------------------------------
 
-# Get the name of the branch
-branch_name=$(git rev-parse --abbrev-ref HEAD)
-
 # Only enforce on feature branches named like "sdk-XXX-description"
+branch_name=$(git rev-parse --abbrev-ref HEAD)
 if [[ $branch_name =~ ^sdk-[0-9]+- ]]; then
     git fetch --quiet origin main
     base=$(git merge-base origin/main HEAD)

--- a/scripts/has_changelog.sh
+++ b/scripts/has_changelog.sh
@@ -11,19 +11,14 @@ branch_name=$(git rev-parse --abbrev-ref HEAD)
 
 # Only enforce on feature branches named like "sdk-XXX-description"
 if [[ $branch_name =~ ^sdk-[0-9]+- ]]; then
-    # Make sure we have an up-to-date reference to the remote main, so the
-    # diff does not depend on a possibly-stale local "main" ref.
     git fetch --quiet origin main
-
-    # Compare against the merge-base with origin/main so we only look at what
-    # this branch introduced (committed + working-tree changes), regardless of
-    # how far the local refs have drifted.
     base=$(git merge-base origin/main HEAD)
-
-    if ! git diff "$base" --name-only | grep -qE '^changes/.*\.md$'; then
+    files_changed=$(git diff "$base" --name-only)
+    if ! echo "$files_changed" | grep -qE '^changes/.*\.md$'; then
         echo "Error: No changelog entry found for branch $branch_name. Please add a changelog entry via towncrier." >&2
+        echo "Files changed in this branch:" >&2
+        echo "$files_changed" >&2
         exit 1
     fi
-
     echo "Changelog found."
 fi

--- a/scripts/has_changelog.sh
+++ b/scripts/has_changelog.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# --------------------------------------------------------------------------
+# This script checks that this branch has a changelog entry.
+# --------------------------------------------------------------------------
+# Time estimate: basically instant
+# --------------------------------------------------------------------------
+
+# Get the name of the branch
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+
+# Only enforce on feature branches named like "sdk-XXX-description"
+if [[ $branch_name =~ ^sdk-[0-9]+- ]]; then
+    # Make sure we have an up-to-date reference to the remote main, so the
+    # diff does not depend on a possibly-stale local "main" ref.
+    git fetch --quiet origin main
+
+    # Compare against the merge-base with origin/main so we only look at what
+    # this branch introduced (committed + working-tree changes), regardless of
+    # how far the local refs have drifted.
+    base=$(git merge-base origin/main HEAD)
+
+    if ! git diff "$base" --name-only | grep -qE '^changes/.*\.md$'; then
+        echo "Error: No changelog entry found for branch $branch_name. Please add a changelog entry via towncrier." >&2
+        exit 1
+    fi
+
+    echo "Changelog found."
+fi


### PR DESCRIPTION
The `checks.sh` pre-commit check script now checks to make sure a changelog file is added in the branch diff, assuming the branch has a non-hotfix name like `sdk-XXX-description`.