### PR TITLE
[SDK-332] Add CUDA dynamics precision toggle

### DIFF
--- a/changes/258.bugfix.1.md
+++ b/changes/258.bugfix.1.md
@@ -1,0 +1,1 @@
+A bug regarding QuTiP matrices being cast to dense unnecessarily has been fixed, reducing the conversion overhead.

--- a/changes/258.bugfix.md
+++ b/changes/258.bugfix.md
@@ -1,3 +1,1 @@
 The precision for CUDA-Q is now set correctly based on the QiliSDK precision setting.
-
-A bug regarding QuTiP matrices being cast to dense unnecessarily has been fixed, reducing the conversion overhead.

--- a/changes/258.bugfix.md
+++ b/changes/258.bugfix.md
@@ -1,0 +1,3 @@
+The precision for CUDA-Q is now set correctly based on the QiliSDK precision setting.
+
+A bug regarding QuTiP matrices being cast to dense unnecessarily has been fixed, reducing the conversion overhead.

--- a/docs/locale/ca/LC_MESSAGES/modules/backends/backends_cuda.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/backends/backends_cuda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 17:26+0200\n"
+"POT-Creation-Date: 2026-07-01 10:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -153,8 +153,8 @@ msgstr ""
 "El backend CUDA exposa un únic paràmetre de configuració — "
 ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod` — que "
 "selecciona el target subjacent de CUDA-Q utilitzat per als circuits "
-"**digitals**. Si no s'especifica cap mètode, s'utilitza ``STATE_VECTOR``. "
-"L'evolució analògica sempre s'executa sobre el target ``dynamics`` i "
+"**digitals**. Si no s'especifica cap mètode, s'utilitza ``STATE_VECTOR``."
+" L'evolució analògica sempre s'executa sobre el target ``dynamics`` i "
 "ignora aquesta opció."
 
 #: ../../modules/backends/backends_cuda.rst:75
@@ -236,11 +236,32 @@ msgstr "``cpu``. Força l'execució a la CPU. Útil principalment per a benchmar
 msgid "Set the method at construction time:"
 msgstr "Definiu el mètode en el moment de la construcció:"
 
-#: ../../modules/backends/backends_cuda.rst:115
+#: ../../modules/backends/backends_cuda.rst:114
+msgid ""
+"Some CUDA simulation methods support parameters being set via environment"
+" variables, notably the `MATRIX_PRODUCT_STATE` and `TENSOR_NETWORK` "
+"methods. See the `CUDA-Q documentation <https://nvidia.github.io/cuda-"
+"quantum/latest/using/backends/sims/tnsims.html>`_ for details."
+msgstr ""
+"Alguns mètodes de simulació de CUDA admeten establir paràmetres mitjançant "
+"variables d'entorn, especialment els mètodes `MATRIX_PRODUCT_STATE` i "
+"`TENSOR_NETWORK`. Consulteu la `documentació de CUDA-Q "
+"<https://nvidia.github.io/cuda-"
+"quantum/latest/using/backends/sims/tnsims.html>`_ per a més detalls."
+
+#: ../../modules/backends/backends_cuda.rst:117
+msgid ""
+"To set the precision of the simulation, use the "
+":class:`~qilisdk.settings.Settings` object:"
+msgstr ""
+"Per definir la precisió de la simulació, utilitzeu l'objecte "
+":class:`~qilisdk.settings.Settings`:"
+
+#: ../../modules/backends/backends_cuda.rst:127
 msgid "Noise model support"
 msgstr "Suport de models de soroll"
 
-#: ../../modules/backends/backends_cuda.rst:117
+#: ../../modules/backends/backends_cuda.rst:129
 msgid ""
 "A :class:`~qilisdk.noise.NoiseModel` can be passed to "
 "``CudaBackend(noise_model=…)``:"
@@ -248,7 +269,7 @@ msgstr ""
 "Es pot passar un :class:`~qilisdk.noise.NoiseModel` a "
 "``CudaBackend(noise_model=…)``:"
 
-#: ../../modules/backends/backends_cuda.rst:119
+#: ../../modules/backends/backends_cuda.rst:131
 msgid ""
 "For :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`,"
 " qilisdk noise channels are translated into a ``cudaq.NoiseModel`` (Kraus"
@@ -263,7 +284,7 @@ msgstr ""
 "de paràmetres aplicades al circuit). Amb soroll activat, només s'admet "
 "una única :class:`~qilisdk.readout.SamplingReadout`."
 
-#: ../../modules/backends/backends_cuda.rst:123
+#: ../../modules/backends/backends_cuda.rst:135
 msgid ""
 "For :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, "
 "Lindblad-compatible noise channels become CUDA-Q jump operators and "
@@ -273,7 +294,7 @@ msgstr ""
 " canals de soroll compatibles amb Lindblad esdevenen operadors de salt de"
 " CUDA-Q i deltes del Hamiltonià que es passen a ``cudaq.evolve``."
 
-#: ../../modules/backends/backends_cuda.rst:125
+#: ../../modules/backends/backends_cuda.rst:137
 msgid ""
 "For :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
 "the fallback implementation drops the noise model (a warning is logged)."
@@ -282,7 +303,7 @@ msgstr ""
 "la implementació de fallback descarta el model de soroll (s'emet un avís "
 "al registre)."
 
-#: ../../modules/backends/backends_cuda.rst:128
+#: ../../modules/backends/backends_cuda.rst:140
 msgid ""
 "Example: a depolarising channel applied to every gate of a digital "
 "circuit:"

--- a/docs/locale/es/LC_MESSAGES/modules/backends/backends_cuda.po
+++ b/docs/locale/es/LC_MESSAGES/modules/backends/backends_cuda.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-03 17:26+0200\n"
+"POT-Creation-Date: 2026-07-01 10:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -186,8 +186,8 @@ msgid ""
 "``nvidia`` when a GPU is available, otherwise ``qpp-cpu``. Precision "
 "matches :class:`~qilisdk.settings.Precision`."
 msgstr ""
-"``nvidia`` cuando hay una GPU disponible, en caso contrario ``qpp-cpu``."
-" La precisión coincide con :class:`~qilisdk.settings.Precision`."
+"``nvidia`` cuando hay una GPU disponible, en caso contrario ``qpp-cpu``. "
+"La precisión coincide con :class:`~qilisdk.settings.Precision`."
 
 #: ../../modules/backends/backends_cuda.rst:85
 msgid ":class:`~qilisdk.backends.cuda_backend.CudaSamplingMethod.STATE_VECTOR_MGPU`"
@@ -240,11 +240,32 @@ msgstr ""
 msgid "Set the method at construction time:"
 msgstr "Defina el método en el momento de la construcción:"
 
-#: ../../modules/backends/backends_cuda.rst:115
+#: ../../modules/backends/backends_cuda.rst:114
+msgid ""
+"Some CUDA simulation methods support parameters being set via environment"
+" variables, notably the `MATRIX_PRODUCT_STATE` and `TENSOR_NETWORK` "
+"methods. See the `CUDA-Q documentation <https://nvidia.github.io/cuda-"
+"quantum/latest/using/backends/sims/tnsims.html>`_ for details."
+msgstr ""
+"Algunos métodos de simulación de CUDA admiten configurar parámetros "
+"mediante variables de entorno, en particular los métodos "
+"`MATRIX_PRODUCT_STATE` y `TENSOR_NETWORK`. Consulte la `documentación de "
+"CUDA-Q <https://nvidia.github.io/cuda-"
+"quantum/latest/using/backends/sims/tnsims.html>`_ para más detalles."
+
+#: ../../modules/backends/backends_cuda.rst:117
+msgid ""
+"To set the precision of the simulation, use the "
+":class:`~qilisdk.settings.Settings` object:"
+msgstr ""
+"Para establecer la precisión de la simulación, utilice el objeto "
+":class:`~qilisdk.settings.Settings`:"
+
+#: ../../modules/backends/backends_cuda.rst:127
 msgid "Noise model support"
 msgstr "Soporte de modelos de ruido"
 
-#: ../../modules/backends/backends_cuda.rst:117
+#: ../../modules/backends/backends_cuda.rst:129
 msgid ""
 "A :class:`~qilisdk.noise.NoiseModel` can be passed to "
 "``CudaBackend(noise_model=…)``:"
@@ -252,7 +273,7 @@ msgstr ""
 "Puede pasarse un :class:`~qilisdk.noise.NoiseModel` a "
 "``CudaBackend(noise_model=…)``:"
 
-#: ../../modules/backends/backends_cuda.rst:119
+#: ../../modules/backends/backends_cuda.rst:131
 msgid ""
 "For :class:`~qilisdk.functionals.digital_propagation.DigitalPropagation`,"
 " qilisdk noise channels are translated into a ``cudaq.NoiseModel`` (Kraus"
@@ -267,7 +288,7 @@ msgstr ""
 "perturbaciones de parámetros aplicadas al circuito). Con ruido activado, "
 "solo se admite una única :class:`~qilisdk.readout.SamplingReadout`."
 
-#: ../../modules/backends/backends_cuda.rst:123
+#: ../../modules/backends/backends_cuda.rst:135
 msgid ""
 "For :class:`~qilisdk.functionals.analog_evolution.AnalogEvolution`, "
 "Lindblad-compatible noise channels become CUDA-Q jump operators and "
@@ -278,7 +299,7 @@ msgstr ""
 "salto de CUDA-Q y en deltas del Hamiltoniano que se pasan a "
 "``cudaq.evolve``."
 
-#: ../../modules/backends/backends_cuda.rst:125
+#: ../../modules/backends/backends_cuda.rst:137
 msgid ""
 "For :class:`~qilisdk.functionals.quantum_reservoirs.QuantumReservoir`, "
 "the fallback implementation drops the noise model (a warning is logged)."
@@ -287,7 +308,7 @@ msgstr ""
 "la implementación de fallback descarta el modelo de ruido (se emite un "
 "aviso en el log)."
 
-#: ../../modules/backends/backends_cuda.rst:128
+#: ../../modules/backends/backends_cuda.rst:140
 msgid ""
 "Example: a depolarising channel applied to every gate of a digital "
 "circuit:"

--- a/docs/modules/backends/backends_cuda.rst
+++ b/docs/modules/backends/backends_cuda.rst
@@ -111,6 +111,18 @@ Set the method at construction time:
 
     backend = CudaBackend(sampling_method=CudaSamplingMethod.MATRIX_PRODUCT_STATE)
 
+Some CUDA simulation methods support parameters being set via environment variables, notably the `MATRIX_PRODUCT_STATE` and `TENSOR_NETWORK` methods. 
+See the `CUDA-Q documentation <https://nvidia.github.io/cuda-quantum/latest/using/backends/sims/tnsims.html>`_ for details.
+
+To set the precision of the simulation, use the :class:`~qilisdk.settings.Settings` object:
+
+.. code-block:: python
+
+    from qilisdk.settings import get_settings, Precision
+
+    settings = get_settings()
+    settings.complex_precision = Precision.COMPLEX_64  # or COMPLEX_32
+
 Noise model support
 ===================
 

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -372,7 +372,14 @@ class CudaBackend(Backend):
                 ``functional.store_intermediate_results`` is ``True``.
         """
         logger.info("Executing TimeEvolution (T={}, dt={})", functional.schedule.T, functional.schedule.dt)
-        cudaq.set_target("dynamics")
+        # The CUDA-Q "dynamics" target only ships an fp64 (complex128) simulator, so the
+        # complex_precision setting cannot be honoured here. Warn and force fp64.
+        if get_settings().complex_precision != Precision.COMPLEX_128:
+            logger.warning(
+                "CUDA-Q dynamics simulation only supports fp64; ignoring complex_precision={} and using fp64.",
+                get_settings().complex_precision.value,
+            )
+        cudaq.set_target("dynamics", option="fp64")
         og_params = None
         # Apply parameter perturbations
         if self._noise_model and self._noise_model.global_perturbations:
@@ -405,7 +412,8 @@ class CudaBackend(Backend):
             state_as_qtensor = functional.initial_state.as_qtensor(functional.schedule.nqubits)
         else:
             state_as_qtensor = functional.initial_state
-        state_as_cuda = self._qtensor_initial_state_to_cuda(state_as_qtensor)
+        # Dynamics is fp64-only, so the initial state must be complex128.
+        state_as_cuda = self._qtensor_initial_state_to_cuda(state_as_qtensor, dtype=np.complex128)
 
         evolution_result = evolve(
             hamiltonian=cuda_hamiltonian,
@@ -418,9 +426,10 @@ class CudaBackend(Backend):
         )
 
         logger.success("TimeEvolution finished")
+        # Dynamics computes in fp64; keep the results complex128 to match.
         final_state = np.array(
             evolution_result.final_state(),  # ty:ignore[unresolved-attribute]
-            dtype=_complex_dtype(),
+            dtype=np.complex128,
         )
         if len(final_state.shape) == 1:
             final_state = final_state.reshape(-1, 1)
@@ -435,7 +444,7 @@ class CudaBackend(Backend):
             and functional.store_intermediate_results
         ):
             for state in evolution_result.intermediate_states():  # ty:ignore[unresolved-attribute]
-                _state = np.array(state, dtype=_complex_dtype())
+                _state = np.array(state, dtype=np.complex128)
                 if len(_state.shape) == 1:
                     _state = _state.reshape(-1, 1)
                 intermediate_states.append(QTensor(_state))
@@ -497,7 +506,7 @@ class CudaBackend(Backend):
         """
         logger.info("Applying sampling simulation method {}", self.sampling_method.value)
         if self.sampling_method in {CudaSamplingMethod.STATE_VECTOR, CudaSamplingMethod.STATE_VECTOR_MGPU}:
-            float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp32"
+            float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_128 else "fp32"
             num_gpus = cudaq.num_available_gpus()
             if num_gpus == 0:
                 cudaq.set_target("qpp-cpu")
@@ -1052,7 +1061,7 @@ class CudaBackend(Backend):
             raise ValueError("QTensor observables in the CUDA backend must be Hermitian operators.") from exc
 
     @staticmethod
-    def _qtensor_initial_state_to_cuda(initial_state: QTensor) -> State:
+    def _qtensor_initial_state_to_cuda(initial_state: QTensor, dtype: np.dtype | None = None) -> State:
         """Convert a ``QTensor`` initial state to a CUDA-Q ``State``.
 
         The state is normalized and, if given as a bra, transposed to a
@@ -1060,6 +1069,10 @@ class CudaBackend(Backend):
 
         Args:
             initial_state (QTensor): The initial quantum state to convert.
+            dtype (np.dtype | None): Complex dtype to build the state data
+                with. Defaults to the dtype implied by the global
+                ``complex_precision`` setting. The dynamics target requires
+                ``np.complex128`` regardless of that setting.
 
         Returns:
             State: The equivalent CUDA-Q state object.
@@ -1068,7 +1081,7 @@ class CudaBackend(Backend):
         if normalized_state.is_bra():
             normalized_state = normalized_state.adjoint()
 
-        cuda_state_data = np.array(normalized_state.dense(), dtype=_complex_dtype())
+        cuda_state_data = np.array(normalized_state.dense(), dtype=dtype or _complex_dtype())
         if normalized_state.is_ket():
             cuda_state_data = cuda_state_data.reshape(-1)
 

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -372,8 +372,6 @@ class CudaBackend(Backend):
                 ``functional.store_intermediate_results`` is ``True``.
         """
         logger.info("Executing TimeEvolution (T={}, dt={})", functional.schedule.T, functional.schedule.dt)
-        # The CUDA-Q "dynamics" target only ships an fp64 (complex128) simulator, so the
-        # complex_precision setting cannot be honoured here. Warn and force fp64.
         if get_settings().complex_precision != Precision.COMPLEX_128:
             logger.warning(
                 "CUDA-Q dynamics simulation only supports fp64; ignoring complex_precision={} and using fp64.",
@@ -412,8 +410,7 @@ class CudaBackend(Backend):
             state_as_qtensor = functional.initial_state.as_qtensor(functional.schedule.nqubits)
         else:
             state_as_qtensor = functional.initial_state
-        # Dynamics is fp64-only, so the initial state must be complex128.
-        state_as_cuda = self._qtensor_initial_state_to_cuda(state_as_qtensor, dtype=np.complex128)
+        state_as_cuda = self._qtensor_initial_state_to_cuda(state_as_qtensor, dtype=np.dtype(np.complex128))
 
         evolution_result = evolve(
             hamiltonian=cuda_hamiltonian,

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -197,7 +197,7 @@ class QutipBackend(Backend):
         for hamiltonian in functional.schedule.hamiltonians.values():
             qutip_hamiltonians.append(
                 Qobj(
-                    hamiltonian.to_qtensor(total_nqubits=functional.schedule.nqubits).dense(),
+                    hamiltonian.to_qtensor(total_nqubits=functional.schedule.nqubits).data,
                     dims=[[2 for _ in range(functional.schedule.nqubits)] for _ in range(2)],
                 )
             )

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -64,6 +65,26 @@ COMPLEX_DTYPE = get_settings().complex_precision.dtype
 
 def _get_float_precision():
     return "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+
+
+@pytest.fixture
+def mock_cuda_dynamics(monkeypatch):
+    """Patch out ``cudaq.evolve`` / ``set_target`` / ``State.from_data`` for analog-evolution tests.
+
+    Returns a namespace exposing the ``evolve`` and ``state_from_data`` mocks and the ``result``
+    object returned by ``evolve``. ``result.final_state`` defaults to a normalized single-qubit
+    statevector; tests needing a different shape (e.g. a density matrix) or intermediate states can
+    override the relevant attributes on ``result``.
+    """
+    result = MagicMock()
+    result.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
+    evolve = MagicMock(return_value=result)
+    state_from_data = MagicMock(return_value=None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", evolve)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", state_from_data)
+    # this is just a convenient way to return all three mocks
+    return SimpleNamespace(evolve=evolve, result=result, state_from_data=state_from_data)
 
 
 class DummyKernel:
@@ -510,16 +531,7 @@ def test_multi_qubit_controls_no_decompose(monkeypatch):
         backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=1000))
 
 
-def test_time_dependent_hamiltonian_cuda(monkeypatch):
-    # monkeypatch the evolve that we import from cudaq in cuda_backend
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    dummy_state = MagicMock(return_value=None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
-
+def test_time_dependent_hamiltonian_cuda(mock_cuda_dynamics):
     o = 1.0
     dt = 1
     T = 1000
@@ -541,19 +553,12 @@ def test_time_dependent_hamiltonian_cuda(monkeypatch):
     )
 
     assert isinstance(res, FunctionalResult)
-    assert dummy_evolve.called
-    assert dummy_state.called
-    assert dummy_state.call_args.args[0].shape == (2,)
+    assert mock_cuda_dynamics.evolve.called
+    assert mock_cuda_dynamics.state_from_data.called
+    assert mock_cuda_dynamics.state_from_data.call_args.args[0].shape == (2,)
 
 
-def test_time_dependent_hamiltonian_cuda_qtensor_observable(monkeypatch):
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
-
+def test_time_dependent_hamiltonian_cuda_qtensor_observable(mock_cuda_dynamics):
     schedule = Schedule(
         dt=1,
         hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
@@ -569,18 +574,11 @@ def test_time_dependent_hamiltonian_cuda_qtensor_observable(monkeypatch):
     )
 
     assert isinstance(res, FunctionalResult)
-    assert dummy_evolve.called
+    assert mock_cuda_dynamics.evolve.called
 
 
-def test_analog_evolution_warns_when_precision_not_fp64(monkeypatch):
+def test_analog_evolution_warns_when_precision_not_fp64(monkeypatch, mock_cuda_dynamics):
     """The dynamics target is fp64-only, so a non-COMPLEX_128 precision must emit a warning."""
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
-
     warnings: list[str] = []
     monkeypatch.setattr("loguru.logger.warning", lambda msg, *a, **kw: warnings.append(msg.format(*a, **kw)))
 
@@ -613,16 +611,7 @@ def test_bad_observable_raises():
         ExpectationReadout(observables=["bad observable"])
 
 
-def test_time_dependent_hamiltonian_cuda_with_noise(monkeypatch):
-    # monkeypatch the evolve that we import from cudaq in cuda_backend
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    dummy_state = MagicMock(return_value=None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
-
+def test_time_dependent_hamiltonian_cuda_with_noise(mock_cuda_dynamics):
     noise_model = NoiseModel()
     noise_model.add(Dephasing(t_phi=1.0))
     noise_model.add(AmplitudeDamping(t1=1.0))
@@ -648,8 +637,8 @@ def test_time_dependent_hamiltonian_cuda_with_noise(monkeypatch):
     )
 
     assert isinstance(res, FunctionalResult)
-    assert dummy_evolve.called
-    assert dummy_state.called
+    assert mock_cuda_dynamics.evolve.called
+    assert mock_cuda_dynamics.state_from_data.called
 
 
 @patch("cudaq.make_kernel", side_effect=dummy_make_kernel)
@@ -664,16 +653,7 @@ def test_execute_cuda_noise(mock_set_target, mock_sample, mock_make_kernel):
     backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
 
 
-def test_time_dependent_hamiltonian_cuda_noise(monkeypatch):
-    # monkeypatch the evolve that we import from cudaq in cuda_backend
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    dummy_state = MagicMock(return_value=None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
-
+def test_time_dependent_hamiltonian_cuda_noise(mock_cuda_dynamics):
     o = 1.0
     dt = 1
     T = 1000
@@ -702,25 +682,19 @@ def test_time_dependent_hamiltonian_cuda_noise(monkeypatch):
     )
 
     assert isinstance(res, FunctionalResult)
-    assert dummy_evolve.called
-    assert dummy_state.called
+    assert mock_cuda_dynamics.evolve.called
+    assert mock_cuda_dynamics.state_from_data.called
 
 
-def test_time_evolution_keeps_statevector_outputs_as_columns(monkeypatch):
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    dummy_return.intermediate_states = MagicMock(
+def test_time_evolution_keeps_statevector_outputs_as_columns(mock_cuda_dynamics):
+    mock_cuda_dynamics.result.intermediate_states = MagicMock(
         return_value=[
             np.array([1.0, 0.0]),
             np.array([0.0, 1.0]),
         ]
     )
-    dummy_return.final_expectation_values = MagicMock(return_value=[])
-    dummy_return.expectation_values = MagicMock(return_value=[])
-
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
+    mock_cuda_dynamics.result.final_expectation_values = MagicMock(return_value=[])
+    mock_cuda_dynamics.result.expectation_values = MagicMock(return_value=[])
 
     schedule = Schedule(
         dt=1,
@@ -742,20 +716,14 @@ def test_time_evolution_keeps_statevector_outputs_as_columns(monkeypatch):
     assert all(s.shape == (2, 1) for s in res.get_intermediate_states())
 
 
-def test_time_evolution_preserves_density_matrix_shape(monkeypatch):
+def test_time_evolution_preserves_density_matrix_shape(mock_cuda_dynamics):
     final_density = np.array([[1.0, 0.0], [0.0, 0.0]])
     intermediate_density = np.array([[0.5, 0.0], [0.0, 0.5]])
 
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=final_density)
-    dummy_return.intermediate_states = MagicMock(return_value=[intermediate_density])
-    dummy_return.final_expectation_values = MagicMock(return_value=[])
-    dummy_return.expectation_values = MagicMock(return_value=[])
-
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    state_from_data = MagicMock(return_value=None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", state_from_data)
+    mock_cuda_dynamics.result.final_state = MagicMock(return_value=final_density)
+    mock_cuda_dynamics.result.intermediate_states = MagicMock(return_value=[intermediate_density])
+    mock_cuda_dynamics.result.final_expectation_values = MagicMock(return_value=[])
+    mock_cuda_dynamics.result.expectation_values = MagicMock(return_value=[])
 
     schedule = Schedule(
         dt=1,
@@ -867,14 +835,8 @@ def test_qtensor_observable_to_hamiltonian_wrong_nqubits_raises():
         backend._qtensor_observable_to_hamiltonian(obs, nqubits=1)
 
 
-def test_time_dependent_hamiltonian_cuda_initial_state_enum(monkeypatch):
-
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), 1 / np.sqrt(2)]))
-    dummy_evolve = MagicMock(return_value=dummy_return)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
+def test_time_dependent_hamiltonian_cuda_initial_state_enum(mock_cuda_dynamics):
+    mock_cuda_dynamics.result.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), 1 / np.sqrt(2)]))
 
     schedule = Schedule(
         dt=1,
@@ -887,7 +849,7 @@ def test_time_dependent_hamiltonian_cuda_initial_state_enum(monkeypatch):
         Readout().with_state_tomography(),
     )
     assert isinstance(res, FunctionalResult)
-    assert dummy_evolve.called
+    assert mock_cuda_dynamics.evolve.called
 
 
 def test_qtensor_initial_state_bra_converted_to_ket():

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -396,8 +396,10 @@ def test_controlled_with_unsupported_basic_gate_raises(monkeypatch):
     circuit = Circuit(2)  # small helper from Backend superclass
     circuit._gates.append(Controlled(1, basic_gate=BadGate(0)))
 
+    func = DigitalPropagation(circuit)
+    read = Readout().with_sampling(nshots=10)
     with pytest.raises(UnsupportedGateError):
-        be.execute(DigitalPropagation(circuit=circuit), Readout().with_sampling(nshots=10))
+        be.execute(func, read)
 
 
 @patch("cudaq.make_kernel", side_effect=dummy_make_kernel)

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -596,33 +596,6 @@ def test_analog_evolution_warns_when_precision_not_fp64(monkeypatch):
     assert any("only supports fp64" in w and "COMPLEX_64" in w for w in warnings)
 
 
-def test_analog_evolution_no_precision_warning_for_fp64(monkeypatch):
-    """No warning should fire when the precision is already COMPLEX_128 (fp64)."""
-    dummy_return = MagicMock()
-    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
-
-    warnings: list[str] = []
-    monkeypatch.setattr("loguru.logger.warning", lambda msg, *a, **kw: warnings.append(msg.format(*a, **kw)))
-
-    monkeypatch.setattr(get_settings(), "complex_precision", Precision.COMPLEX_128)
-
-    schedule = Schedule(
-        dt=1,
-        hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
-        coefficients={"h1": {(0, 100): lambda t: 1 - t / 100}, "h2": {(0, 100): lambda t: t / 100}},
-    )
-    backend = CudaBackend()
-    backend.execute(
-        AnalogEvolution(schedule=schedule, initial_state=ket(0)),
-        Readout().with_expectation(observables=[pauli_z(0)]),
-    )
-
-    assert not any("only supports fp64" in w for w in warnings)
-
-
 def test_qtensor_observable_non_hermitian_raises():
     backend = CudaBackend()
     non_hermitian = QTensor(np.array([[0, 1], [0, 0]], dtype=np.complex128))

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -211,7 +211,7 @@ def test_state_vector_with_gpu(mock_sample, mock_make_kernel, mock_set_target, m
     backend = CudaBackend(sampling_method=CudaSamplingMethod.STATE_VECTOR)
     circuit = Circuit(nqubits=1)
     result = backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
-    float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp32"
+    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
     mock_set_target.assert_called_with("nvidia", option=float_precision)
     assert isinstance(result, FunctionalResult)
     assert result.get_samples() == {"0": 1000}
@@ -512,7 +512,7 @@ def test_time_dependent_hamiltonian_cuda(monkeypatch):
     dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
     dummy_evolve = MagicMock(return_value=dummy_return)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     dummy_state = MagicMock(return_value=None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
 
@@ -547,7 +547,7 @@ def test_time_dependent_hamiltonian_cuda_qtensor_observable(monkeypatch):
     dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
     dummy_evolve = MagicMock(return_value=dummy_return)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
 
     schedule = Schedule(
@@ -566,6 +566,61 @@ def test_time_dependent_hamiltonian_cuda_qtensor_observable(monkeypatch):
 
     assert isinstance(res, FunctionalResult)
     assert dummy_evolve.called
+
+
+def test_analog_evolution_warns_when_precision_not_fp64(monkeypatch):
+    """The dynamics target is fp64-only, so a non-COMPLEX_128 precision must emit a warning."""
+    dummy_return = MagicMock()
+    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
+    dummy_evolve = MagicMock(return_value=dummy_return)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
+
+    warnings: list[str] = []
+    monkeypatch.setattr("loguru.logger.warning", lambda msg, *a, **kw: warnings.append(msg.format(*a, **kw)))
+
+    monkeypatch.setattr(get_settings(), "complex_precision", Precision.COMPLEX_64)
+
+    schedule = Schedule(
+        dt=1,
+        hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
+        coefficients={"h1": {(0, 100): lambda t: 1 - t / 100}, "h2": {(0, 100): lambda t: t / 100}},
+    )
+    backend = CudaBackend()
+    backend.execute(
+        AnalogEvolution(schedule=schedule, initial_state=ket(0)),
+        Readout().with_expectation(observables=[pauli_z(0)]),
+    )
+
+    assert any("only supports fp64" in w and "COMPLEX_64" in w for w in warnings)
+
+
+def test_analog_evolution_no_precision_warning_for_fp64(monkeypatch):
+    """No warning should fire when the precision is already COMPLEX_128 (fp64)."""
+    dummy_return = MagicMock()
+    dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
+
+    warnings: list[str] = []
+    monkeypatch.setattr("loguru.logger.warning", lambda msg, *a, **kw: warnings.append(msg.format(*a, **kw)))
+
+    monkeypatch.setattr(get_settings(), "complex_precision", Precision.COMPLEX_128)
+
+    schedule = Schedule(
+        dt=1,
+        hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
+        coefficients={"h1": {(0, 100): lambda t: 1 - t / 100}, "h2": {(0, 100): lambda t: t / 100}},
+    )
+    backend = CudaBackend()
+    backend.execute(
+        AnalogEvolution(schedule=schedule, initial_state=ket(0)),
+        Readout().with_expectation(observables=[pauli_z(0)]),
+    )
+
+    assert not any("only supports fp64" in w for w in warnings)
 
 
 def test_qtensor_observable_non_hermitian_raises():
@@ -587,7 +642,7 @@ def test_time_dependent_hamiltonian_cuda_with_noise(monkeypatch):
     dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
     dummy_evolve = MagicMock(return_value=dummy_return)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     dummy_state = MagicMock(return_value=None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
 
@@ -638,7 +693,7 @@ def test_time_dependent_hamiltonian_cuda_noise(monkeypatch):
     dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]))
     dummy_evolve = MagicMock(return_value=dummy_return)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     dummy_state = MagicMock(return_value=None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", dummy_state)
 
@@ -687,7 +742,7 @@ def test_time_evolution_keeps_statevector_outputs_as_columns(monkeypatch):
     dummy_return.expectation_values = MagicMock(return_value=[])
 
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
 
     schedule = Schedule(
@@ -721,7 +776,7 @@ def test_time_evolution_preserves_density_matrix_shape(monkeypatch):
     dummy_return.expectation_values = MagicMock(return_value=[])
 
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", MagicMock(return_value=dummy_return))
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     state_from_data = MagicMock(return_value=None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", state_from_data)
 
@@ -841,7 +896,7 @@ def test_time_dependent_hamiltonian_cuda_initial_state_enum(monkeypatch):
     dummy_return.final_state = MagicMock(return_value=np.array([1 / np.sqrt(2), 1 / np.sqrt(2)]))
     dummy_evolve = MagicMock(return_value=dummy_return)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.evolve", dummy_evolve)
-    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target: None)
+    monkeypatch.setattr("qilisdk.backends.cuda_backend.cudaq.set_target", lambda target, option=None: None)
     monkeypatch.setattr("qilisdk.backends.cuda_backend.State.from_data", MagicMock(return_value=None))
 
     schedule = Schedule(
@@ -885,7 +940,7 @@ def test_apply_digital_simulation_method_state_vector_with_gpu(monkeypatch):
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp32"
+    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
     mock_set_target.assert_called_once_with("nvidia", option=float_precision)
 
 
@@ -912,7 +967,7 @@ def test_apply_digital_simulation_method_state_vector_mgpu_multiple_gpus(monkeyp
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp32"
+    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
     mock_set_target.assert_called_once_with("nvidia", option="mgpu," + float_precision)
 
 
@@ -923,7 +978,7 @@ def test_apply_digital_simulation_method_state_vector_mgpu_single_gpu(monkeypatc
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp64" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp32"
+    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
     mock_set_target.assert_called_once_with("nvidia", option=float_precision)
 
 

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -62,6 +62,10 @@ COMPLEX_DTYPE = get_settings().complex_precision.dtype
 # --- Dummy classes and helper functions ---
 
 
+def _get_float_precision():
+    return "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+
+
 class DummyKernel:
     """A dummy kernel that records method calls."""
 
@@ -211,7 +215,7 @@ def test_state_vector_with_gpu(mock_sample, mock_make_kernel, mock_set_target, m
     backend = CudaBackend(sampling_method=CudaSamplingMethod.STATE_VECTOR)
     circuit = Circuit(nqubits=1)
     result = backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
-    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+    float_precision = _get_float_precision()
     mock_set_target.assert_called_with("nvidia", option=float_precision)
     assert isinstance(result, FunctionalResult)
     assert result.get_samples() == {"0": 1000}
@@ -913,7 +917,7 @@ def test_apply_digital_simulation_method_state_vector_with_gpu(monkeypatch):
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+    float_precision = _get_float_precision()
     mock_set_target.assert_called_once_with("nvidia", option=float_precision)
 
 
@@ -940,7 +944,7 @@ def test_apply_digital_simulation_method_state_vector_mgpu_multiple_gpus(monkeyp
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+    float_precision = _get_float_precision()
     mock_set_target.assert_called_once_with("nvidia", option="mgpu," + float_precision)
 
 
@@ -951,7 +955,7 @@ def test_apply_digital_simulation_method_state_vector_mgpu_single_gpu(monkeypatc
     monkeypatch.setattr("cudaq.set_target", mock_set_target)
     monkeypatch.setattr("cudaq.num_available_gpus", mock_num_gpus)
     backend._apply_digital_simulation_method()
-    float_precision = "fp32" if get_settings().complex_precision == Precision.COMPLEX_64 else "fp64"
+    float_precision = _get_float_precision()
     mock_set_target.assert_called_once_with("nvidia", option=float_precision)
 
 

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -360,8 +360,10 @@ def test_execute_measurement_partial_with_bad_samples_raises(mock_set_target, mo
     circuit = Circuit(nqubits=3)
     measurement_gate = M(1, 2)
     circuit._gates.append(measurement_gate)
+    func = DigitalPropagation(circuit)
+    read = Readout().with_sampling(nshots=10)
     with pytest.raises(ValueError, match="filter samples for more qubits"):
-        backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
+        backend.execute(func, read)
 
 
 # --- Tests for unsupported gate errors ---
@@ -374,8 +376,10 @@ def test_execute_unsupported_gate(mock_set_target, mock_sample, mock_make_kernel
     backend = CudaBackend()
     circuit = Circuit(nqubits=1)
     circuit._gates.append(DummyGate(0))
+    func = DigitalPropagation(circuit)
+    read = Readout().with_sampling(nshots=10)
     with pytest.raises(UnsupportedGateError):
-        backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
+        backend.execute(func, read)
 
 
 def test_controlled_with_unsupported_basic_gate_raises(monkeypatch):
@@ -427,8 +431,10 @@ def test_adjoint_unsupported_gate_error(mock_set_target, mock_sample, mock_make_
     circuit = Circuit(nqubits=1)
     adjoint_gate = Adjoint(DummyGate(0))
     circuit._gates.append(adjoint_gate)
+    func = DigitalPropagation(circuit)
+    read = Readout().with_sampling(nshots=10)
     with pytest.raises(UnsupportedGateError):
-        backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=10))
+        backend.execute(func, read)
 
 
 def test_hamiltonian_to_cuda_computes_expected_sum(monkeypatch):
@@ -527,8 +533,10 @@ def test_multi_qubit_controls_no_decompose(monkeypatch):
     gate = Controlled(0, 1, basic_gate=X(2))
     assert gate.control_qubits == (0, 1)
     circuit.add(gate)
+    func = DigitalPropagation(circuit)
+    read = Readout().with_sampling(nshots=1000)
     with pytest.raises(UnsupportedGateError):
-        backend.execute(DigitalPropagation(circuit), Readout().with_sampling(nshots=1000))
+        backend.execute(func, read)
 
 
 def test_time_dependent_hamiltonian_cuda(mock_cuda_dynamics):
@@ -766,8 +774,9 @@ def test_execute_quantum_reservoir_raises_if_time_evolution_returns_no_state(mon
         _mock_execute_analog_evolution,
     )
 
+    read = SamplingReadout(nshots=10)
     with pytest.raises(ValueError, match="Reservoir Runtime Error"):
-        backend._execute_quantum_reservoir(functional, [SamplingReadout(nshots=10)])
+        backend._execute_quantum_reservoir(functional, [read])
 
 
 def test_cudaq_to_standard_reorders_statevector():
@@ -781,14 +790,16 @@ def test_cudaq_to_standard_reorders_statevector():
 
 def test_cudaq_to_standard_invalid_ndim_raises():
 
+    arr = np.array([[1, 0], [0, 0]], dtype=complex)
     with pytest.raises(ValueError, match="1D array"):
-        cudaq_to_standard(np.array([[1, 0], [0, 0]], dtype=complex))
+        cudaq_to_standard(arr)
 
 
 def test_cudaq_to_standard_non_power_of_two_raises():
 
+    arr = np.array([1, 0, 0], dtype=complex)
     with pytest.raises(ValueError, match="power of 2"):
-        cudaq_to_standard(np.array([1, 0, 0], dtype=complex))
+        cudaq_to_standard(arr)
 
 
 def test_reverse_bits():
@@ -801,14 +812,17 @@ def test_reverse_bits():
 
 def test_validate_digital_readout_with_noise_non_sampling_raises():
     backend = CudaBackend(noise_model=NoiseModel())
+    read = StateTomographyReadout()
     with pytest.raises(ValueError, match="only the sample readout"):
-        backend._validate_digital_readout_with_noise([StateTomographyReadout()])
+        backend._validate_digital_readout_with_noise([read])
 
 
 def test_validate_digital_readout_with_noise_multiple_readouts_raises():
     backend = CudaBackend(noise_model=NoiseModel())
+    read_10 = SamplingReadout(nshots=10)
+    read_20 = SamplingReadout(nshots=20)
     with pytest.raises(ValueError, match="single sampling operation"):
-        backend._validate_digital_readout_with_noise([SamplingReadout(nshots=10), SamplingReadout(nshots=20)])
+        backend._validate_digital_readout_with_noise([read_10, read_20])
 
 
 def test_validate_digital_readout_with_noise_ok():
@@ -824,8 +838,9 @@ def test_sampling_method_property():
 def test_qtensor_observable_to_hamiltonian_not_operator_raises():
     backend = CudaBackend()
     # A ket is not an operator
+    k = ket(0)
     with pytest.raises(ValueError, match="must be an operator"):
-        backend._qtensor_observable_to_hamiltonian(ket(0), nqubits=1)
+        backend._qtensor_observable_to_hamiltonian(k, nqubits=1)
 
 
 def test_qtensor_observable_to_hamiltonian_wrong_nqubits_raises():


### PR DESCRIPTION
The precision for CUDA-Q is now set correctly based on the QiliSDK precision setting.

A bug regarding QuTiP matrices being cast to dense unnecessarily has been fixed, reducing the conversion overhead.