### PR TITLE
[SDK-345] Reservoir Input Label Warning

### DIFF
--- a/changes/263.misc.md
+++ b/changes/263.misc.md
@@ -1,0 +1,1 @@
+A warning has been added if a label is given to reservoir that it doesn't recognize.

--- a/src/qilisdk/functionals/quantum_reservoirs.py
+++ b/src/qilisdk/functionals/quantum_reservoirs.py
@@ -227,6 +227,13 @@ class ReservoirLayer(Parameterizable):
             yield self._output_encoding
 
     def set_parameters(self, parameters: dict[str, RealNumber]) -> None:
+        known_labels = set(self.get_parameter_names())
+        unknown_labels = [p for p in parameters if p not in known_labels]
+        if unknown_labels:
+            raise ValueError(
+                f"Cannot set unknown parameter(s) {sorted(unknown_labels)} on this reservoir layer. "
+                f"Valid parameter names are {sorted(known_labels)}."
+            )
         if self._input_encoding:
             param_labels = self._input_encoding.get_parameter_names()
             self._input_encoding.set_parameters({p: v for p, v in parameters.items() if p in param_labels})

--- a/src/qilisdk_cpp/backends/qilisim/analog/iterations_integrate.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/analog/iterations_integrate.cpp
@@ -18,7 +18,9 @@
 
 #ifndef _WIN32
 #if defined(_OPENMP)
-#pragma omp declare reduction(complex_double_reduction : std::complex <double> : omp_out += omp_in) initializer(omp_priv = std::complex <double>(0.0, 0.0))
+// clang-format off
+#pragma omp declare reduction(complex_double_reduction : std::complex<double> : omp_out += omp_in) initializer(omp_priv = std::complex<double>(0.0, 0.0))
+// clang-format on
 #endif
 #endif
 

--- a/src/qilisdk_cpp/core/qtensor.cpp
+++ b/src/qilisdk_cpp/core/qtensor.cpp
@@ -24,7 +24,9 @@
 
 #ifndef _WIN32
 #if defined(_OPENMP)
-#pragma omp declare reduction(complex_double_reduction : std::complex <double> : omp_out += omp_in) initializer(omp_priv = std::complex <double>(0.0, 0.0))
+// clang-format off
+#pragma omp declare reduction(complex_double_reduction : std::complex<double> : omp_out += omp_in) initializer(omp_priv = std::complex<double>(0.0, 0.0))
+// clang-format on
 #endif
 #endif
 

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -462,7 +462,10 @@ def test_matrix_free_complex_gate_on_mixed_state_stays_hermitian():
         return QuantumReservoir(
             initial_state=QTensor.uniform(2).to_density_matrix(),
             reservoir_layer=layer,
-            input_per_layer=[{"phi": 0.2, "gamma": 0.1}, {"phi": 0.3, "gamma": 0.2}],
+            input_per_layer=[
+                {"U2(1)_phi_0": 0.2, "U2(1)_gamma_1": 0.1},
+                {"U2(1)_phi_0": 0.3, "U2(1)_gamma_1": 0.2},
+            ],
         )
 
     readout = (

--- a/tests/unit_python/functionals/test_quantum_reservoirs.py
+++ b/tests/unit_python/functionals/test_quantum_reservoirs.py
@@ -132,6 +132,30 @@ def test_reservoir_layer_properties_and_parameter_interface():
     assert isinstance(steps[2], Circuit)
 
 
+def test_reservoir_layer_set_parameters_rejects_unknown_labels():
+    schedule, _ = _schedule_with_parameter(nqubits=2)
+    u = ReservoirInput("u", 0.2)
+
+    pre = Circuit(1)
+    pre.add(RX(0, theta=u))
+
+    reservoir_layer = ReservoirLayer(
+        evolution_dynamics=schedule,
+        input_encoding=pre,
+        qubits_to_reset=[0],
+    )
+
+    with pytest.raises(ValueError, match="unknown parameter"):
+        reservoir_layer.set_parameters({"does_not_exist": 9.9})
+
+    with pytest.raises(ValueError, match="unknown parameter"):
+        reservoir_layer.set_parameters({"u": 0.5, "phi": 9.9})
+    assert _isclose(reservoir_layer.get_parameters()["u"], 0.2)
+
+    reservoir_layer.set_parameters({"u": 0.5, "g": 0.7})
+    _assert_parameter_dict_close(reservoir_layer.get_parameters(), {"u": 0.5, "g": 0.7})
+
+
 def test_reservoir_layer_validation_errors():
     schedule, _ = _schedule_with_parameter(nqubits=2)
 


### PR DESCRIPTION
A warning has been added if a label is given to reservoir that it doesn't recognize.