### PR TITLE
[SDK-330] Allow Initial State for Circuits

### DIFF
--- a/changes/264.feature.md
+++ b/changes/264.feature.md
@@ -1,0 +1,17 @@
+The initial state for a `DigitalPropagaton` functional can now be set, just as in the case of the `AnalogEvolution` functional. It can be set to either a `Circuit`, `InitialState` (i.e. `InitialState.ZERO`, `InitialState.ONE` or `InitialState.UNIFORM`), or a `QTensor`. Note that the `QTensor` input will not be supported on real hardware. Usage:
+
+```python
+from qilisdk.digital import Circuit
+from qilisdk.backends import QiliSim
+from qilisdk.readout import Readout
+from qilisdk.core import InitialState
+from qilisdk.functionals import DigitalPropagation
+
+c = Circuit(5)
+digital = DigitalPropagation(circuit=c, initial_state=InitialState.ONE)
+backend = QiliSim()
+readout = Readout().with_sampling(1000)
+
+results = backend.execute(digital, readout)
+print(results.get_samples())
+```

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -263,13 +263,25 @@ class CudaBackend(Backend):
                 f"Only Sampling Readouts are supported for {self.sampling_method.value.upper()} simulation."
             )
 
+        # If an initial state is given, convert it to a circuit, since CUDA doesn't support any other initial state format
+        circuit = functional.circuit
+        if isinstance(functional.initial_state, InitialState):
+            if functional.initial_state == InitialState.UNIFORM:
+                for i in range(circuit.nqubits):
+                    circuit.add(H(i))
+            elif functional.initial_state == InitialState.ONE:
+                for i in range(circuit.nqubits):
+                    circuit.add(X(i))
+        elif isinstance(functional.initial_state, QTensor):
+            logger.warning("QTensor initial states are not natively supported by the CUDA backend, ignoring.")
+
         # Apply parameter perturbations
         if self._noise_model:
             og_param = copy(functional.get_parameters())
-            self._handle_gate_parameter_perturbations(functional.circuit, self._noise_model)
+            self._handle_gate_parameter_perturbations(circuit, self._noise_model)
 
         # Transpile the circuit into CUDAQ format
-        transpiled_circuit = DecomposeMultiControlledGatesPass().run(functional.circuit)
+        transpiled_circuit = DecomposeMultiControlledGatesPass().run(circuit)
         measured_qubits = set()
         for i, gate in enumerate(transpiled_circuit.gates):
             if isinstance(gate, Controlled):
@@ -290,13 +302,13 @@ class CudaBackend(Backend):
         qubits_to_measure = list(measured_qubits) if len(measured_qubits) > 0 else None
 
         if self._noise_model:
-            cuda_noise_model = self._noise_model_to_cudaq(self._noise_model, functional.circuit.nqubits)
+            cuda_noise_model = self._noise_model_to_cudaq(self._noise_model, circuit.nqubits)
             cudaq_result = cudaq.sample(
                 kernel,
                 shots_count=readout[0].nshots,  # ty:ignore[unresolved-attribute]
                 noise_model=cuda_noise_model,
             )
-            cudaq_result = self._handle_readout_errors(cudaq_result, self._noise_model, functional.circuit.nqubits)
+            cudaq_result = self._handle_readout_errors(cudaq_result, self._noise_model, circuit.nqubits)
             if og_param:
                 functional.set_parameters(og_param)
             logger.success("Sampling finished; {} distinct bitstrings", len(cudaq_result))
@@ -307,7 +319,7 @@ class CudaBackend(Backend):
                     sampling=SamplingReadoutResult.from_samples(
                         samples=dict(cudaq_result.items()),
                         qubits_to_measure=qubits_to_measure,
-                        nqubits=functional.circuit.nqubits,
+                        nqubits=circuit.nqubits,
                         expand_samples=expand_samples,
                     ),
                     expectation_values=None,
@@ -326,7 +338,7 @@ class CudaBackend(Backend):
                     sampling=SamplingReadoutResult.from_samples(
                         samples=dict(cudaq_result.items()),
                         qubits_to_measure=qubits_to_measure,
-                        nqubits=functional.circuit.nqubits,
+                        nqubits=circuit.nqubits,
                         expand_samples=sampling_readout.expand_samples,
                     ),
                     expectation_values=None,

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -221,6 +221,31 @@ class CudaBackend(Backend):
         self._sampling_method = sampling_method
         logger.success("CudaBackend initialised (sampling_method={})", sampling_method.value)
 
+    def _circuit_from_initial_state(self, initial_state: InitialState, nqubits: int) -> Circuit:
+        """Convert an initial state to a circuit representation.
+
+        Args:
+            initial_state (InitialState | QTensor): The initial state to convert.
+            nqubits (int): The number of qubits in the circuit.
+
+        Returns:
+            Circuit: A circuit that prepares the specified initial state.
+
+        Raises:
+            ValueError: If the initial state is not supported for conversion.
+        """
+        circuit = Circuit(nqubits)
+        if isinstance(initial_state, InitialState):
+        if initial_state == InitialState.UNIFORM:
+                for i in range(nqubits):
+                    circuit.add(H(i))
+            elif initial_state == InitialState.ONE:
+                for i in range(nqubits):
+                    circuit.add(X(i))
+        elif isinstance(initial_state, QTensor):
+            logger.warning("QTensor initial states are not natively supported by the CUDA backend, ignoring.")
+        return circuit
+
     def _execute_digital_propagation(
         self, functional: DigitalPropagation, readout: list[ReadoutMethod]
     ) -> FunctionalResult:
@@ -264,16 +289,7 @@ class CudaBackend(Backend):
             )
 
         # If an initial state is given, convert it to a circuit, since CUDA doesn't support any other initial state format
-        circuit = functional.circuit
-        if isinstance(functional.initial_state, InitialState):
-            if functional.initial_state == InitialState.UNIFORM:
-                for i in range(circuit.nqubits):
-                    circuit.add(H(i))
-            elif functional.initial_state == InitialState.ONE:
-                for i in range(circuit.nqubits):
-                    circuit.add(X(i))
-        elif isinstance(functional.initial_state, QTensor):
-            logger.warning("QTensor initial states are not natively supported by the CUDA backend, ignoring.")
+        circuit = self._circuit_from_initial_state(functional.initial_state, functional.circuit.nqubits)
 
         # Apply parameter perturbations
         if self._noise_model:

--- a/src/qilisdk/backends/cuda_backend.py
+++ b/src/qilisdk/backends/cuda_backend.py
@@ -26,6 +26,7 @@ from loguru import logger
 from qilisdk.analog.hamiltonian import Hamiltonian, PauliI, PauliOperator, PauliX, PauliY, PauliZ
 from qilisdk.backends.backend import Backend
 from qilisdk.core.qtensor import InitialState, QTensor
+from qilisdk.digital.circuit import Circuit
 from qilisdk.digital.circuit_transpiler_passes import DecomposeMultiControlledGatesPass
 from qilisdk.digital.exceptions import UnsupportedGateError
 from qilisdk.digital.gates import (
@@ -69,7 +70,6 @@ from qilisdk.settings import Precision, get_settings
 
 if TYPE_CHECKING:
     from qilisdk.analog.schedule import Schedule
-    from qilisdk.digital.circuit import Circuit
     from qilisdk.functionals.analog_evolution import AnalogEvolution
     from qilisdk.functionals.digital_propagation import DigitalPropagation
     from qilisdk.noise import NoiseModel
@@ -221,7 +221,8 @@ class CudaBackend(Backend):
         self._sampling_method = sampling_method
         logger.success("CudaBackend initialised (sampling_method={})", sampling_method.value)
 
-    def _circuit_from_initial_state(self, initial_state: InitialState, nqubits: int) -> Circuit:
+    @staticmethod
+    def _circuit_from_initial_state(initial_state: InitialState | QTensor, nqubits: int) -> Circuit:
         """Convert an initial state to a circuit representation.
 
         Args:
@@ -236,7 +237,7 @@ class CudaBackend(Backend):
         """
         circuit = Circuit(nqubits)
         if isinstance(initial_state, InitialState):
-        if initial_state == InitialState.UNIFORM:
+            if initial_state == InitialState.UNIFORM:
                 for i in range(nqubits):
                     circuit.add(H(i))
             elif initial_state == InitialState.ONE:
@@ -290,6 +291,7 @@ class CudaBackend(Backend):
 
         # If an initial state is given, convert it to a circuit, since CUDA doesn't support any other initial state format
         circuit = self._circuit_from_initial_state(functional.initial_state, functional.circuit.nqubits)
+        circuit.append(functional.circuit)
 
         # Apply parameter perturbations
         if self._noise_model:

--- a/src/qilisdk/backends/qilisim.py
+++ b/src/qilisdk/backends/qilisim.py
@@ -131,7 +131,7 @@ class QiliSim(Backend):
         return dict(self._solver_config)
 
     def _execute_digital_propagation(
-        self, functional: DigitalPropagation, readout: list[ReadoutMethod], initial_state: QTensor | None = None
+        self, functional: DigitalPropagation, readout: list[ReadoutMethod]
     ) -> FunctionalResult:
         """Execute a digital-circuit propagation functional and return measurement results.
 
@@ -140,9 +140,6 @@ class QiliSim(Backend):
                 functional to execute.
             readout (list[ReadoutMethod]): Readout specifications for
                 result extraction.
-            initial_state (QTensor | None): Optional initial state to start
-                the simulation from. Defaults to ``None`` (computational
-                basis zero state).
 
         Returns:
             FunctionalResult: The execution result containing the requested
@@ -150,7 +147,7 @@ class QiliSim(Backend):
         """
         logger.info("Executing Sampling")
         result = self.qili_sim.execute_digital_propagation(
-            functional, readout, self._noise_model, initial_state, self._solver_config
+            functional, readout, self._noise_model, functional.initial_state, self._solver_config
         )
         logger.success("Sampling finished")
         return result

--- a/src/qilisdk/backends/qilisim.py
+++ b/src/qilisdk/backends/qilisim.py
@@ -24,7 +24,6 @@ from .backend import Backend
 from .backend_config import AnalogMethod, DigitalMethod, ExecutionConfig, SolverConfigDict
 
 if TYPE_CHECKING:
-    from qilisdk.core import QTensor
     from qilisdk.functionals import AnalogEvolution, DigitalPropagation, QuantumReservoir
     from qilisdk.functionals.functional_result import FunctionalResult
     from qilisdk.noise.noise_model import NoiseModel

--- a/src/qilisdk/backends/qutip_backend.py
+++ b/src/qilisdk/backends/qutip_backend.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Callable, Type, TypeVar
 import numpy as np
 import qutip_qip.operations as QutipGates
 from loguru import logger
-from qutip import Qobj, basis, mesolve, qeye, tensor
+from qutip import Qobj, mesolve, qeye
 from qutip_qip.circuit import CircuitSimulator, QubitCircuit
 from qutip_qip.operations.gateclass import SingleQubitGate, is_qutip5
 
@@ -131,7 +131,14 @@ class QutipBackend(Backend):
         """
         logger.info("Executing Sampling")
 
-        init_state = tensor(*[basis(2, 0) for _ in range(functional.circuit.nqubits)])
+        # Get the initial state as a QTensor, by converting if needed
+        if isinstance(functional.initial_state, InitialState):
+            init_state_qtensor = functional.initial_state.as_qtensor(functional.circuit.nqubits)
+        else:
+            init_state_qtensor = functional.initial_state
+
+        # Convert to the qutip format
+        init_state = Qobj(init_state_qtensor.dense(), dims=[[2 for _ in range(init_state_qtensor.nqubits)], [1]])
 
         measurements_set = {q for g in functional.circuit.gates if isinstance(g, M) for q in g.qubits}
         measurements = sorted(measurements_set)

--- a/src/qilisdk/functionals/digital_propagation.py
+++ b/src/qilisdk/functionals/digital_propagation.py
@@ -15,6 +15,7 @@ from typing import Callable, ClassVar, Iterator
 
 from qilisdk.core import Parameter
 from qilisdk.core.parameterizable import Parameterizable
+from qilisdk.core.qtensor import InitialState, QTensor
 from qilisdk.digital.circuit import Circuit
 from qilisdk.functionals.functional import PrimitiveFunctional
 from qilisdk.functionals.functional_result import FunctionalResult
@@ -45,13 +46,24 @@ class DigitalPropagation(PrimitiveFunctional):
 
     result_type: ClassVar[type[FunctionalResult]] = FunctionalResult
 
-    def __init__(self, circuit: Circuit) -> None:
+    def __init__(self, 
+                 circuit: Circuit, 
+                 initial_state: QTensor | InitialState | Circuit = InitialState.ZERO,
+                ) -> None:
         """
         Args:
             circuit (Circuit): Circuit to propagate.
+            initial_state (QTensor | InitialState | Circuit): Quantum state used as the simulation starting point.
         """
         super().__init__()
-        self.circuit = circuit
+        # Circuit init just prepends it, that way if it's parameterized it will be handled correctly
+        if isinstance(initial_state, Circuit):
+            self.initial_state = InitialState.ZERO
+            self.circuit = initial_state + circuit
+        # Otherwise we leave it as is and let the backend handle it
+        else:
+            self.initial_state = initial_state
+            self.circuit = circuit
 
     def _iter_parameter_children(self) -> Iterator[Parameterizable]:
         """Yield the circuit as the sole parameterizable child.
@@ -62,7 +74,7 @@ class DigitalPropagation(PrimitiveFunctional):
         yield self.circuit
 
     def __repr__(self) -> str:
-        return f"DigitalPropagation(circuit={self.circuit})"
+        return f"DigitalPropagation(circuit={self.circuit}, initial_state={self.initial_state})"
 
     def set_parameter_values(
         self,

--- a/src/qilisdk/functionals/digital_propagation.py
+++ b/src/qilisdk/functionals/digital_propagation.py
@@ -46,10 +46,11 @@ class DigitalPropagation(PrimitiveFunctional):
 
     result_type: ClassVar[type[FunctionalResult]] = FunctionalResult
 
-    def __init__(self, 
-                 circuit: Circuit, 
-                 initial_state: QTensor | InitialState | Circuit = InitialState.ZERO,
-                ) -> None:
+    def __init__(
+        self,
+        circuit: Circuit,
+        initial_state: QTensor | InitialState | Circuit = InitialState.ZERO,
+    ) -> None:
         """
         Args:
             circuit (Circuit): Circuit to propagate.
@@ -59,7 +60,8 @@ class DigitalPropagation(PrimitiveFunctional):
         # Circuit init just prepends it, that way if it's parameterized it will be handled correctly
         if isinstance(initial_state, Circuit):
             self.initial_state = InitialState.ZERO
-            self.circuit = initial_state + circuit
+            self.circuit = initial_state
+            self.circuit.append(circuit)
         # Otherwise we leave it as is and let the backend handle it
         else:
             self.initial_state = initial_state

--- a/tests/integration/backends/test_all_backend_integration.py
+++ b/tests/integration/backends/test_all_backend_integration.py
@@ -37,7 +37,7 @@ from qilisdk.backends import QutipBackend
 from qilisdk.backends.backend_config import ExecutionConfig
 from qilisdk.backends.qilisim import QiliSim
 from qilisdk.core.model import Constraint, Model, Objective
-from qilisdk.core.qtensor import QTensor, ket, tensor_prod
+from qilisdk.core.qtensor import InitialState, QTensor, ket, tensor_prod
 from qilisdk.core.variables import BinaryVariable
 from qilisdk.cost_functions.model_cost_function import ModelCostFunction
 from qilisdk.digital import RX, RY, RZ, SWAP, U1, U2, U3, Circuit, H, I, M, S, T, X, Y, Z
@@ -549,3 +549,15 @@ def test_partial_measurements_no_expansion(backend):
     samples = result.get_samples()
     assert "1" in samples
     assert samples["1"] == 50
+
+
+@pytest.mark.parametrize("backend", backends)
+def test_circuit_initial_state(backend):
+    circuit = Circuit(nqubits=1)
+    circuit.add(X(0))
+    functional = DigitalPropagation(circuit=circuit, initial_state=InitialState.ONE)
+    result = backend.execute(functional, Readout().with_sampling(nshots=100))
+    assert isinstance(result, FunctionalResult)
+    samples = result.get_samples()
+    assert "0" in samples
+    assert samples["0"] == 100

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -73,7 +73,7 @@ def test_monte_carlo_circuit(method):
     circuit.add(H(0))
     readout = [SamplingReadout(nshots=100)]
     result = backend._execute_digital_propagation(
-        DigitalPropagation(circuit=circuit), readout=readout, initial_state=initial_state
+        DigitalPropagation(circuit=circuit, initial_state=initial_state), readout=readout
     )
     assert isinstance(result, FunctionalResult)
     samples = result.get_samples()

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from loguru import logger
 
 from qilisdk.analog.hamiltonian import Hamiltonian
 from qilisdk.backends.cuda_backend import cudaq_to_standard, reverse_bits
@@ -977,3 +978,47 @@ def test_tomography_for_methods_raises(monkeypatch, method):
     backend = CudaBackend(sampling_method=method)
     with pytest.raises(ValueError, match="Only Sampling"):
         backend.execute(f, r)
+
+
+def test_cuda_digital_propagation_initial_state_one():
+    c = Circuit(1)
+    digital = DigitalPropagation(circuit=c, initial_state=InitialState.ONE)
+    backend = CudaBackend()
+    readout = Readout().with_sampling(10)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert "1" in results.get_samples()
+
+
+def test_cuda_digital_propagation_initial_state_zero():
+    c = Circuit(1)
+    digital = DigitalPropagation(circuit=c, initial_state=InitialState.ZERO)
+    backend = CudaBackend()
+    readout = Readout().with_sampling(10)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert "0" in results.get_samples()
+
+
+def test_cuda_digital_propagation_initial_state_uniform():
+    c = Circuit(1)
+    digital = DigitalPropagation(circuit=c, initial_state=InitialState.UNIFORM)
+    backend = CudaBackend()
+    readout = Readout().with_sampling(100)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert "0" in results.get_samples()
+    assert "1" in results.get_samples()
+
+
+def test_cuda_digital_propagation_initial_state_qtensor(monkeypatch):
+    DummyLogger = MagicMock()
+    monkeypatch.setattr(logger, "warning", DummyLogger)
+    c = Circuit(1)
+    initial_state_qtensor = QTensor.one(1)
+    digital = DigitalPropagation(circuit=c, initial_state=initial_state_qtensor)
+    backend = CudaBackend()
+    readout = Readout().with_sampling(10)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert DummyLogger.called

--- a/tests/unit_python/backends/test_cuda_backend.py
+++ b/tests/unit_python/backends/test_cuda_backend.py
@@ -1012,8 +1012,8 @@ def test_cuda_digital_propagation_initial_state_uniform():
 
 
 def test_cuda_digital_propagation_initial_state_qtensor(monkeypatch):
-    DummyLogger = MagicMock()
-    monkeypatch.setattr(logger, "warning", DummyLogger)
+    dummy_loogger = MagicMock()
+    monkeypatch.setattr(logger, "warning", dummy_loogger)
     c = Circuit(1)
     initial_state_qtensor = QTensor.one(1)
     digital = DigitalPropagation(circuit=c, initial_state=initial_state_qtensor)
@@ -1021,4 +1021,4 @@ def test_cuda_digital_propagation_initial_state_qtensor(monkeypatch):
     readout = Readout().with_sampling(10)
     results = backend.execute(digital, readout)
     assert isinstance(results, FunctionalResult)
-    assert DummyLogger.called
+    assert dummy_loogger.called

--- a/tests/unit_python/backends/test_qutip_backend.py
+++ b/tests/unit_python/backends/test_qutip_backend.py
@@ -442,3 +442,24 @@ def test_get_qutip_observable_unsupported_type_raises():
     backend = QutipBackend()
     with pytest.raises(ValueError, match="unsupported observable type"):
         backend._to_qubip_observables(42, nqubits=1)
+
+
+def test_qutip_digital_propagation_initial_state():
+    c = Circuit(1)
+    digital = DigitalPropagation(circuit=c, initial_state=InitialState.ONE)
+    backend = QutipBackend()
+    readout = Readout().with_sampling(10)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert "1" in results.get_samples()
+
+
+def test_qutip_digital_propagation_initial_state_qtensor():
+    c = Circuit(1)
+    initial_state_qtensor = QTensor.one(1)
+    digital = DigitalPropagation(circuit=c, initial_state=initial_state_qtensor)
+    backend = QutipBackend()
+    readout = Readout().with_sampling(10)
+    results = backend.execute(digital, readout)
+    assert isinstance(results, FunctionalResult)
+    assert "1" in results.get_samples()

--- a/tests/unit_python/functionals/test_digital_propagation.py
+++ b/tests/unit_python/functionals/test_digital_propagation.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 
-from qilisdk.core import Parameter
+from qilisdk.core import Parameter, QTensor, InitialState
 from qilisdk.digital import RX, RZ, Circuit
 from qilisdk.functionals.digital_propagation import DigitalPropagation
 from qilisdk.settings import get_settings
@@ -121,3 +121,25 @@ def test_digital_propagation_set_parameter_values_clears_gate_matrix_cache():
     functional.set_parameter_values([np.pi / 2])
 
     assert not np.allclose(matrix_before, gate.matrix)
+
+
+def test_digital_propagation_qtensor_initial_state():
+    circuit = Circuit(1)
+    initial_state = QTensor.ket(0)
+    functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
+    assert functional.initial_state == initial_state
+
+def test_digital_propagation_initial_state_initial_state():
+    circuit = Circuit(1)
+    initial_state = InitialState.ONE
+    functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
+    assert functional.initial_state == initial_state
+
+def test_digital_propagation_circuit_initial_state():
+    circuit = Circuit(1)
+    circuit.add(RX(0, theta=np.pi/2))
+    initial_state = Circuit(1)
+    initial_state.add(RZ(0, phi=np.pi/4))
+    functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
+    assert functional.initial_state == InitialState.ZERO
+    assert functional.circuit == initial_state + circuit

--- a/tests/unit_python/functionals/test_digital_propagation.py
+++ b/tests/unit_python/functionals/test_digital_propagation.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 
-from qilisdk.core import Parameter, QTensor, InitialState
+from qilisdk.core import InitialState, Parameter, QTensor
 from qilisdk.digital import RX, RZ, Circuit
 from qilisdk.functionals.digital_propagation import DigitalPropagation
 from qilisdk.settings import get_settings
@@ -129,17 +129,19 @@ def test_digital_propagation_qtensor_initial_state():
     functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
     assert functional.initial_state == initial_state
 
+
 def test_digital_propagation_initial_state_initial_state():
     circuit = Circuit(1)
     initial_state = InitialState.ONE
     functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
     assert functional.initial_state == initial_state
 
+
 def test_digital_propagation_circuit_initial_state():
     circuit = Circuit(1)
-    circuit.add(RX(0, theta=np.pi/2))
+    circuit.add(RX(0, theta=np.pi / 2))
     initial_state = Circuit(1)
-    initial_state.add(RZ(0, phi=np.pi/4))
+    initial_state.add(RZ(0, phi=np.pi / 4))
     functional = DigitalPropagation(circuit=circuit, initial_state=initial_state)
     assert functional.initial_state == InitialState.ZERO
     assert functional.circuit == initial_state + circuit


### PR DESCRIPTION
The initial state for a `DigitalPropagaton` functional can now be set, just as in the case of the `AnalogEvolution` functional. It can be set to either a `Circuit`, `InitialState` (i.e. `InitialState.ZERO`, `InitialState.ONE` or `InitialState.UNIFORM`), or a `QTensor`. Note that the `QTensor` input will not be supported on real hardware. Usage:

```python
from qilisdk.digital import Circuit
from qilisdk.backends import QiliSim
from qilisdk.readout import Readout
from qilisdk.core import InitialState
from qilisdk.functionals import DigitalPropagation

c = Circuit(5)
digital = DigitalPropagation(circuit=c, initial_state=InitialState.ONE)
backend = QiliSim()
readout = Readout().with_sampling(1000)

results = backend.execute(digital, readout)
print(results.get_samples())
```