### PR TITLE
[SDK-361] make backends import lazy

### DIFF
--- a/changes/288.feature.md
+++ b/changes/288.feature.md
@@ -1,0 +1,15 @@
+The optional simulation backends are now imported lazily: their heavy third-party dependencies (`cudaq` for `CudaBackend`/`CudaSamplingMethod`, `qutip` for `QutipBackend`) are only loaded the first time the backend is actually accessed, not when `qilisdk.backends` (or the default `QiliSim`) is imported. This keeps import times and memory usage low when you only use one backend.
+
+```python
+import sys
+
+from qilisdk.backends import QiliSim  # neither cudaq nor qutip is imported
+
+assert "cudaq" not in sys.modules
+assert "qutip" not in sys.modules
+
+# The optional dependency is imported only on first access of its backend:
+from qilisdk.backends import QutipBackend  # now qutip is imported
+
+assert "qutip" in sys.modules
+```

--- a/src/qilisdk/backends/__init__.py
+++ b/src/qilisdk/backends/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
+from typing import Any
 
 from qilisdk._optionals import (
     DependencyGroup,
@@ -56,11 +56,46 @@ OPTIONAL_FEATURES: list[OptionalFeature] = [
 ]
 
 
-current_module = sys.modules[__name__]
+# Map every optional symbol name to the feature that provides it. Symbols are
+# advertised in ``__all__`` (so ``from qilisdk.backends import *`` and tooling see
+# them) but are NOT imported eagerly: the heavy dependency (``cudaq``, ``qutip``,
+# ...) is only imported the first time the symbol is actually accessed, via the
+# module-level ``__getattr__`` below (PEP 562). Static type info lives in the
+# accompanying ``__init__.pyi`` stub.
+_OPTIONAL_FEATURE_BY_SYMBOL: dict[str, OptionalFeature] = {
+    symbol.name: feature for feature in OPTIONAL_FEATURES for symbol in feature.symbols
+}
 
-# Dynamically import (or stub) each feature's symbols and attach them
-for feature in OPTIONAL_FEATURES:
+__all__ += list(_OPTIONAL_FEATURE_BY_SYMBOL)
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401
+    """Lazily import optional backend symbols on first access (PEP 562).
+
+    This runs only when normal attribute lookup on the module fails, i.e. the
+    first time ``name`` is requested. It resolves the whole owning feature, caches
+    every resolved symbol as a real module attribute so subsequent accesses skip
+    this hook, and returns the requested symbol (or a stub raising
+    ``OptionalDependencyError`` if the optional dependency is not installed).
+
+    Args:
+        name: The attribute being accessed on the ``qilisdk.backends`` module.
+
+    Returns:
+        The imported symbol, or a stub that raises on use when the optional
+        dependency is missing.
+
+    Raises:
+        AttributeError: If ``name`` is not an optional backend symbol.
+    """
+    feature = _OPTIONAL_FEATURE_BY_SYMBOL.get(name)
+    if feature is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     imported_feature: ImportedFeature = import_optional_dependencies(feature)
-    for symbol_name, symbol_obj in imported_feature.symbols.items():
-        setattr(current_module, symbol_name, symbol_obj)
-        __all__ += [symbol_name]  # noqa: PLE0604
+    globals().update(imported_feature.symbols)
+    return imported_feature.symbols[name]
+
+
+def __dir__() -> list[str]:
+    """Return the module's public attributes, including lazily-imported symbols."""
+    return sorted(__all__)

--- a/src/qilisdk_cpp/backends/qilisim/qilisim_bindings.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/qilisim_bindings.cpp
@@ -20,6 +20,11 @@
 
 PYBIND11_MODULE(qilisim_module, m) {
     initialize_all_pybind_types();
+    // Release the module-global py::object handles (see pybind.cpp) before the
+    // interpreter finalizes. The capsule destructor runs at module teardown with
+    // the GIL held and the interpreter still alive; without it the globals'
+    // static destructors run Py_DECREF after Py_Finalize and abort the process.
+    m.add_object("_qilisdk_cleanup", py::capsule(&finalize_all_pybind_types));
     py::class_<QiliSimCpp>(m, "QiliSimCpp").def(py::init<>()).def("execute_analog_evolution", &QiliSimCpp::execute_analog_evolution).def("execute_digital_propagation", &QiliSimCpp::execute_digital_propagation).def("execute_quantum_reservoir", &QiliSimCpp::execute_quantum_reservoir);
 }
 

--- a/src/qilisdk_cpp/core/qtensor_bindings.cpp
+++ b/src/qilisdk_cpp/core/qtensor_bindings.cpp
@@ -18,6 +18,11 @@
 // GCOVR_EXCL_START
 PYBIND11_MODULE(qtensor_module, m) {
     initialize_external_pybind_types();
+    // Release the module-global py::object handles (see pybind.cpp) before the
+    // interpreter finalizes. The capsule destructor runs at module teardown with
+    // the GIL held and the interpreter still alive; without it the globals'
+    // static destructors run Py_DECREF after Py_Finalize and abort the process.
+    m.add_object("_qilisdk_cleanup", py::capsule(&finalize_all_pybind_types));
     // Make the QTensor class available in Python as well as the various methods
     py::class_<QTensorCpp>(m, "QTensorCpp")
         .def("as_scipy", &QTensorCpp::as_scipy)

--- a/tests/unit_python/backends/test_lazy_imports.py
+++ b/tests/unit_python/backends/test_lazy_imports.py
@@ -1,0 +1,192 @@
+# Copyright 2025 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the lazy import of optional backends in :mod:`qilisdk.backends`.
+
+The optional backends (``CudaBackend``/``CudaSamplingMethod`` -> ``cudaq`` and
+``QutipBackend`` -> ``qutip``) must only pull in their heavy third-party
+dependency the first time the symbol is actually accessed, never merely because
+``qilisdk.backends`` (or the default ``QiliSim`` backend) was imported.
+
+The laziness guarantee is checked in a *fresh* subprocess interpreter: the pytest
+session itself already imports ``cudaq``/``qutip`` via the other backend test
+modules, so an in-process ``sys.modules`` check would be meaningless.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import qilisdk.backends as backends
+
+
+def _run_probe(body: str) -> dict:
+    """Run ``body`` in a fresh interpreter and return the JSON dict it prints.
+
+    The probe must print a single ``RESULT:<json>`` line to stdout; any other
+    output (logging, warnings) is ignored.
+    """
+    source = textwrap.dedent(
+        """
+        import json
+        import sys
+
+
+        def loaded(name):
+            return any(mod == name or mod.startswith(name + ".") for mod in sys.modules)
+
+        """
+    ) + textwrap.dedent(body)
+    completed = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for line in completed.stdout.splitlines():
+        if line.startswith("RESULT:"):
+            return json.loads(line[len("RESULT:") :])
+    raise AssertionError(f"probe produced no RESULT line.\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
+
+
+@pytest.mark.parametrize(
+    "import_statement",
+    [
+        "import qilisdk",
+        "import qilisdk.backends",
+        "from qilisdk.backends import QiliSim",
+        "from qilisdk.backends.qilisim import QiliSim",
+    ],
+)
+def test_importing_qilisdk_does_not_import_optional_backends(import_statement: str) -> None:
+    """Neither ``cudaq`` nor ``qutip`` is imported just by importing qilisdk/QiliSim."""
+    result = _run_probe(
+        f"""
+        {import_statement}
+        print("RESULT:" + json.dumps({{"cudaq": loaded("cudaq"), "qutip": loaded("qutip")}}))
+        """
+    )
+    assert result["cudaq"] is False
+    assert result["qutip"] is False
+
+
+def test_optional_symbols_advertised_without_importing_dependency() -> None:
+    """The lazy symbols are visible via ``__all__``/``dir`` without loading their deps."""
+    result = _run_probe(
+        """
+        import qilisdk.backends as backends
+
+        names = dir(backends)
+        print("RESULT:" + json.dumps({
+            "all": backends.__all__,
+            "in_dir": {name: (name in names) for name in ["CudaBackend", "CudaSamplingMethod", "QutipBackend"]},
+            "cudaq": loaded("cudaq"),
+            "qutip": loaded("qutip"),
+        }))
+        """
+    )
+    for symbol in ("CudaBackend", "CudaSamplingMethod", "QutipBackend"):
+        assert symbol in result["all"]
+        assert result["in_dir"][symbol] is True
+    # Advertising the names must not have triggered the heavy imports.
+    assert result["cudaq"] is False
+    assert result["qutip"] is False
+
+
+@pytest.mark.parametrize(
+    ("symbol", "dependency"),
+    [
+        ("QutipBackend", "qutip"),
+        ("CudaBackend", "cudaq"),
+        ("CudaSamplingMethod", "cudaq"),
+    ],
+)
+def test_accessing_symbol_imports_its_dependency_and_caches(symbol: str, dependency: str) -> None:
+    """Accessing an optional symbol triggers its dependency import and caches the symbol."""
+    if importlib.util.find_spec(dependency) is None:
+        pytest.skip(f"optional dependency {dependency!r} is not installed")
+
+    result = _run_probe(
+        f"""
+        import qilisdk.backends as backends
+
+        before = loaded({dependency!r})
+        obj = getattr(backends, {symbol!r})
+        print("RESULT:" + json.dumps({{
+            "before": before,
+            "after": loaded({dependency!r}),
+            "cached": {symbol!r} in vars(backends),
+        }}))
+        """
+    )
+    # It was not loaded before the access, and is loaded right after.
+    assert result["before"] is False
+    assert result["after"] is True
+    # The resolved symbol is cached as a real module attribute (so __getattr__
+    # is not consulted again for it).
+    assert result["cached"] is True
+
+
+def test_accessing_qutip_backend_does_not_import_cudaq() -> None:
+    """The optional backends are independent: reaching for QuTiP must not load ``cudaq``.
+
+    (The reverse direction is not asserted: ``cudaq`` imports ``qutip`` itself, as
+    its own transitive dependency, which is outside qilisdk's control.)
+    """
+    if importlib.util.find_spec("qutip") is None:
+        pytest.skip("optional dependency 'qutip' is not installed")
+
+    result = _run_probe(
+        """
+        import qilisdk.backends as backends
+
+        _ = backends.QutipBackend
+        print("RESULT:" + json.dumps({"qutip": loaded("qutip"), "cudaq": loaded("cudaq")}))
+        """
+    )
+    assert result["qutip"] is True
+    assert result["cudaq"] is False
+
+
+def test_module_getattr_resolves_and_caches_optional_symbol() -> None:
+    """The PEP 562 hook returns the symbol and caches it on the module."""
+    # Drop any cached value so the lazy hook is guaranteed to run here regardless
+    # of whether a previous test already resolved the symbol in this session.
+    vars(backends).pop("QutipBackend", None)
+    resolved = backends.QutipBackend
+    assert resolved is not None
+    assert "QutipBackend" in vars(backends)
+    # Once cached, normal attribute lookup returns the same object.
+    assert backends.QutipBackend is resolved
+
+
+def test_module_getattr_unknown_attribute_raises() -> None:
+    """Non-optional, unknown attributes raise ``AttributeError``."""
+    unknown = "TotallyUnknownBackend"
+    with pytest.raises(AttributeError, match=unknown):
+        getattr(backends, unknown)
+
+
+def test_module_dir_is_sorted_and_lists_all_symbols() -> None:
+    """``dir(qilisdk.backends)`` is sorted and includes eager and lazy symbols."""
+    names = dir(backends)
+    assert names == sorted(names)
+    for symbol in ("QiliSim", "AnalogMethod", "CudaBackend", "CudaSamplingMethod", "QutipBackend"):
+        assert symbol in names


### PR DESCRIPTION
The optional simulation backends are now imported lazily: their heavy third-party dependencies (`cudaq` for `CudaBackend`/`CudaSamplingMethod`, `qutip` for `QutipBackend`) are only loaded the first time the backend is actually accessed, not when `qilisdk.backends` (or the default `QiliSim`) is imported. This keeps import times and memory usage low when you only use one backend.

```python
import sys

from qilisdk.backends import QiliSim  # neither cudaq nor qutip is imported

assert "cudaq" not in sys.modules
assert "qutip" not in sys.modules

# The optional dependency is imported only on first access of its backend:
from qilisdk.backends import QutipBackend  # now qutip is imported

assert "qutip" in sys.modules
```