### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keeps GitHub Actions dependencies up to date, including the SHA-pinned
+# reference to the shared backport workflow (qilimanjaro-tech/workflows) and the
+# action versions used across the other workflows. Bumps are grouped into a
+# single weekly PR.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 5

--- a/changes/292.misc.md
+++ b/changes/292.misc.md
@@ -1,0 +1,1 @@
+Added Dependabot configuration to keep the repository's GitHub Actions dependencies up to date.


### PR DESCRIPTION
Adds `.github/dependabot.yml` so Dependabot keeps the repository's GitHub Actions dependencies up to date, including the SHA-pinned reference to the shared reusable backport workflow. Updates are grouped into a single weekly pull request.

Closes #293.
