### PR TITLE
[ISSUE-331] Add Single-Pauli Hamiltonian Constructors

### DIFF
--- a/changes/332.feature.md
+++ b/changes/332.feature.md
@@ -1,0 +1,7 @@
+Some more constructors for Hamiltonians have been added, now for single Paulis, which should be used over the loose X, Y and Z constructors from before, since those can be confused with the X, Y and Z from the digital module. The old functions remain there for backwards compatability, but we might depreciate them at some point. The new usage is as follows:
+
+```python
+from qilisdk.analog import Hamiltonian
+h = Hamiltonian.X(0) + 2 * Hamiltonian.Z(1)
+print(h)
+```

--- a/docs/locale/ca/LC_MESSAGES/modules/analog/analog_hamiltonian.po
+++ b/docs/locale/ca/LC_MESSAGES/modules/analog/analog_hamiltonian.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-16 12:04+0200\n"
+"POT-Creation-Date: 2026-08-06 15:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ca\n"
@@ -42,55 +42,79 @@ msgstr "Construcció"
 #: ../../modules/analog/analog_hamiltonian.rst:9
 msgid ""
 "To construct a Hamiltonian with a single Pauli, you can use the "
-"constructors ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``. From these single-"
-"qubit operators, you can build multi-qubit Hamiltonians using arithmetic "
-"operations. The operations follow Python syntax, for example: ``2 * Z(0) "
-"+ Z(1)`` and ``Z(0) * Z(1)`` build multi-qubit Hamiltonians."
+"constructors "
+":meth:`Hamiltonian.X(i)<qilisdk.analog.hamiltonian.Hamiltonian.X>`, "
+":meth:`Hamiltonian.Y(i)<qilisdk.analog.hamiltonian.Hamiltonian.Y>`, "
+":meth:`Hamiltonian.Z(i)<qilisdk.analog.hamiltonian.Hamiltonian.Z>`, "
+":meth:`Hamiltonian.I(i)<qilisdk.analog.hamiltonian.Hamiltonian.I>`."
 msgstr ""
 "Per construir un Hamiltonià amb un sol Pauli, podeu fer servir els "
-"constructors ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``. A partir d'aquests "
-"operadors d'un sol qubit, podeu construir Hamiltonians de múltiples "
-"qubits mitjançant operacions aritmètiques. Les operacions segueixen la "
-"sintaxi de Python; per exemple: ``2 * Z(0) + Z(1)`` i ``Z(0) * Z(1)`` "
-"construeixen Hamiltonians de múltiples qubits."
+"constructors "
+":meth:`Hamiltonian.X(i)<qilisdk.analog.hamiltonian.Hamiltonian.X>`, "
+":meth:`Hamiltonian.Y(i)<qilisdk.analog.hamiltonian.Hamiltonian.Y>`, "
+":meth:`Hamiltonian.Z(i)<qilisdk.analog.hamiltonian.Hamiltonian.Z>`, "
+":meth:`Hamiltonian.I(i)<qilisdk.analog.hamiltonian.Hamiltonian.I>`."
 
-#: ../../modules/analog/analog_hamiltonian.rst:14
+#: ../../modules/analog/analog_hamiltonian.rst:15
+msgid ""
+"From these single-qubit operators, you can build multi-qubit Hamiltonians"
+" using arithmetic operations. The operations follow Python syntax, for "
+"example:"
+msgstr ""
+"A partir d'aquests operadors d'un sol qubit, podeu construir Hamiltonians "
+"de múltiples qubits mitjançant operacions aritmètiques. Les operacions "
+"segueixen la sintaxi de Python; per exemple:"
+
+#: ../../modules/analog/analog_hamiltonian.rst:23
+msgid ""
+"The shorter module-level functions ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``"
+" remain available and behave identically, but they are discouraged "
+"because they clash with the ``X``, ``Y`` and ``Z`` *gates* from "
+":mod:`qilisdk.digital`. They may be deprecated in a future release."
+msgstr ""
+"Les funcions més curtes a nivell de mòdul ``X(i)``, ``Y(i)``, ``Z(i)``, "
+"``I(i)`` continuen disponibles i es comporten de manera idèntica, però no "
+"es recomanen perquè entren en conflicte amb les *portes* ``X``, ``Y`` i "
+"``Z`` de :mod:`qilisdk.digital`. Podrien quedar obsoletes en una versió "
+"futura."
+
+#: ../../modules/analog/analog_hamiltonian.rst:28
 msgid "List of Operations"
 msgstr "Llista d'operacions"
 
-#: ../../modules/analog/analog_hamiltonian.rst:16
+#: ../../modules/analog/analog_hamiltonian.rst:30
 msgid "**Arithmetic operations**:"
 msgstr "**Operacions aritmètiques**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:18
+#: ../../modules/analog/analog_hamiltonian.rst:32
 msgid "Addition: ``H1 + H2``"
 msgstr "Suma: ``H1 + H2``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:19
+#: ../../modules/analog/analog_hamiltonian.rst:33
 msgid "Scalar multiplication: ``5 * H``"
 msgstr "Multiplicació escalar: ``5 * H``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:20
+#: ../../modules/analog/analog_hamiltonian.rst:34
 msgid "multiplication: ``H0 * H1``"
 msgstr "Multiplicació: ``H0 * H1``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:21
+#: ../../modules/analog/analog_hamiltonian.rst:35
 msgid "Subtraction: ``H1 - H2``"
 msgstr "Resta: ``H1 - H2``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:22
+#: ../../modules/analog/analog_hamiltonian.rst:36
 msgid "Division by scalar: ``H / 5``"
 msgstr "Divisió per escalar: ``H / 5``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:23
+#: ../../modules/analog/analog_hamiltonian.rst:37
 msgid "Negation: ``-H``"
 msgstr "Negació: ``-H``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:25
+#: ../../modules/analog/analog_hamiltonian.rst:39
 msgid "**Extra Symbolic Operators**:"
 msgstr "**Operadors simbòlics addicionals**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:27
+#: ../../modules/analog/analog_hamiltonian.rst:41
 msgid ""
 "commutator: "
 ":meth:`H1.commutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.commutator>`"
@@ -98,7 +122,7 @@ msgstr ""
 "commutador: "
 ":meth:`H1.commutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.commutator>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:28
+#: ../../modules/analog/analog_hamiltonian.rst:42
 msgid ""
 "anticommutator: "
 ":meth:`H1.anticommutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.anticommutator>`"
@@ -106,7 +130,7 @@ msgstr ""
 "anticommutador: "
 ":meth:`H1.anticommutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.anticommutator>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:29
+#: ../../modules/analog/analog_hamiltonian.rst:43
 msgid ""
 "vector_norm: "
 ":meth:`H.vector_norm()<qilisdk.analog.hamiltonian.Hamiltonian.vector_norm>`"
@@ -114,7 +138,7 @@ msgstr ""
 "norma_vectorial: "
 ":meth:`H.vector_norm()<qilisdk.analog.hamiltonian.Hamiltonian.vector_norm>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:30
+#: ../../modules/analog/analog_hamiltonian.rst:44
 msgid ""
 "frobenius_norm: "
 ":meth:`H.frobenius_norm()<qilisdk.analog.hamiltonian.Hamiltonian.frobenius_norm>`"
@@ -122,15 +146,15 @@ msgstr ""
 "norma_frobenius: "
 ":meth:`H.frobenius_norm()<qilisdk.analog.hamiltonian.Hamiltonian.frobenius_norm>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:31
+#: ../../modules/analog/analog_hamiltonian.rst:45
 msgid "trace: :meth:`H.trace()<qilisdk.analog.hamiltonian.Hamiltonian.trace>`"
 msgstr "traça: :meth:`H.trace()<qilisdk.analog.hamiltonian.Hamiltonian.trace>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:33
+#: ../../modules/analog/analog_hamiltonian.rst:47
 msgid "**Exporting Hamiltonians**:"
 msgstr "**Exportació de Hamiltonians**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:35
+#: ../../modules/analog/analog_hamiltonian.rst:49
 msgid ""
 "to matrix: "
 ":meth:`H.to_matrix(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_matrix>`"
@@ -138,7 +162,7 @@ msgstr ""
 "a matriu: "
 ":meth:`H.to_matrix(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_matrix>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:36
+#: ../../modules/analog/analog_hamiltonian.rst:50
 msgid ""
 "to qtensor: "
 ":meth:`H.to_qtensor(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_qtensor>`"
@@ -146,11 +170,11 @@ msgstr ""
 "a qtensor: "
 ":meth:`H.to_qtensor(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_qtensor>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:38
+#: ../../modules/analog/analog_hamiltonian.rst:52
 msgid "**Importing Hamiltonians**:"
 msgstr "**Importació de Hamiltonians**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:40
+#: ../../modules/analog/analog_hamiltonian.rst:54
 msgid ""
 "from qtensor: "
 ":meth:`Hamiltonian.from_qtensor(qtensor)<qilisdk.analog.hamiltonian.Hamiltonian.from_qtensor>`"
@@ -158,7 +182,7 @@ msgstr ""
 "des de qtensor: "
 ":meth:`Hamiltonian.from_qtensor(qtensor)<qilisdk.analog.hamiltonian.Hamiltonian.from_qtensor>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:41
+#: ../../modules/analog/analog_hamiltonian.rst:55
 msgid ""
 "from string: "
 ":meth:`Hamiltonian.parse(hamiltonian_string)<qilisdk.analog.hamiltonian.Hamiltonian.parse>`"
@@ -166,15 +190,15 @@ msgstr ""
 "des de cadena: "
 ":meth:`Hamiltonian.parse(hamiltonian_string)<qilisdk.analog.hamiltonian.Hamiltonian.parse>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:44
+#: ../../modules/analog/analog_hamiltonian.rst:58
 msgid "Example: Ising Hamiltonian"
 msgstr "Exemple: Hamiltonià d'Ising"
 
-#: ../../modules/analog/analog_hamiltonian.rst:46
+#: ../../modules/analog/analog_hamiltonian.rst:60
 msgid "To define an Ising Hamiltonian of the form:"
 msgstr "Per definir un Hamiltonià d'Ising de la forma:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:48
+#: ../../modules/analog/analog_hamiltonian.rst:62
 msgid ""
 "H_{\\text{Ising}}  =  - \\sum_{\\langle i, j \\rangle} J_{ij} \\sigma^Z_i"
 " \\sigma^Z_j - \\sum_j h_j \\sigma^Z_j"
@@ -182,11 +206,11 @@ msgstr ""
 "H_{\\text{Ising}}  =  - \\sum_{\\langle i, j \\rangle} J_{ij} \\sigma^Z_i"
 " \\sigma^Z_j - \\sum_j h_j \\sigma^Z_j"
 
-#: ../../modules/analog/analog_hamiltonian.rst:52
+#: ../../modules/analog/analog_hamiltonian.rst:66
 msgid "you can use the Pauli ``Z`` operators from the library:"
 msgstr "podeu fer servir els operadors de Pauli ``Z`` de la biblioteca:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:68
+#: ../../modules/analog/analog_hamiltonian.rst:82
 msgid "**Output:**"
 msgstr "**Sortida:**"
 

--- a/docs/locale/es/LC_MESSAGES/modules/analog/analog_hamiltonian.po
+++ b/docs/locale/es/LC_MESSAGES/modules/analog/analog_hamiltonian.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: QiliSDK \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-16 12:04+0200\n"
+"POT-Creation-Date: 2026-08-06 15:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -42,55 +42,79 @@ msgstr "Construcción"
 #: ../../modules/analog/analog_hamiltonian.rst:9
 msgid ""
 "To construct a Hamiltonian with a single Pauli, you can use the "
-"constructors ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``. From these single-"
-"qubit operators, you can build multi-qubit Hamiltonians using arithmetic "
-"operations. The operations follow Python syntax, for example: ``2 * Z(0) "
-"+ Z(1)`` and ``Z(0) * Z(1)`` build multi-qubit Hamiltonians."
+"constructors "
+":meth:`Hamiltonian.X(i)<qilisdk.analog.hamiltonian.Hamiltonian.X>`, "
+":meth:`Hamiltonian.Y(i)<qilisdk.analog.hamiltonian.Hamiltonian.Y>`, "
+":meth:`Hamiltonian.Z(i)<qilisdk.analog.hamiltonian.Hamiltonian.Z>`, "
+":meth:`Hamiltonian.I(i)<qilisdk.analog.hamiltonian.Hamiltonian.I>`."
 msgstr ""
 "Para construir un Hamiltoniano con un único Pauli, se pueden usar los "
-"constructores ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``. A partir de estos "
-"operadores de un qubit, se pueden construir Hamiltonianos de múltiples "
-"qubits mediante operaciones aritméticas. Las operaciones siguen la "
-"sintaxis de Python; por ejemplo: ``2 * Z(0) + Z(1)`` y ``Z(0) * Z(1)`` "
-"construyen un Hamiltoniano de múltiples qubits."
+"constructores "
+":meth:`Hamiltonian.X(i)<qilisdk.analog.hamiltonian.Hamiltonian.X>`, "
+":meth:`Hamiltonian.Y(i)<qilisdk.analog.hamiltonian.Hamiltonian.Y>`, "
+":meth:`Hamiltonian.Z(i)<qilisdk.analog.hamiltonian.Hamiltonian.Z>`, "
+":meth:`Hamiltonian.I(i)<qilisdk.analog.hamiltonian.Hamiltonian.I>`."
 
-#: ../../modules/analog/analog_hamiltonian.rst:14
+#: ../../modules/analog/analog_hamiltonian.rst:15
+msgid ""
+"From these single-qubit operators, you can build multi-qubit Hamiltonians"
+" using arithmetic operations. The operations follow Python syntax, for "
+"example:"
+msgstr ""
+"A partir de estos operadores de un qubit, se pueden construir "
+"Hamiltonianos de múltiples qubits mediante operaciones aritméticas. Las "
+"operaciones siguen la sintaxis de Python; por ejemplo:"
+
+#: ../../modules/analog/analog_hamiltonian.rst:23
+msgid ""
+"The shorter module-level functions ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``"
+" remain available and behave identically, but they are discouraged "
+"because they clash with the ``X``, ``Y`` and ``Z`` *gates* from "
+":mod:`qilisdk.digital`. They may be deprecated in a future release."
+msgstr ""
+"Las funciones más cortas a nivel de módulo ``X(i)``, ``Y(i)``, ``Z(i)``, "
+"``I(i)`` siguen disponibles y se comportan de forma idéntica, pero no se "
+"recomiendan porque entran en conflicto con las *puertas* ``X``, ``Y`` y "
+"``Z`` de :mod:`qilisdk.digital`. Podrían quedar obsoletas en una versión "
+"futura."
+
+#: ../../modules/analog/analog_hamiltonian.rst:28
 msgid "List of Operations"
 msgstr "Lista de operaciones"
 
-#: ../../modules/analog/analog_hamiltonian.rst:16
+#: ../../modules/analog/analog_hamiltonian.rst:30
 msgid "**Arithmetic operations**:"
 msgstr "**Operaciones aritméticas**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:18
+#: ../../modules/analog/analog_hamiltonian.rst:32
 msgid "Addition: ``H1 + H2``"
 msgstr "Suma: ``H1 + H2``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:19
+#: ../../modules/analog/analog_hamiltonian.rst:33
 msgid "Scalar multiplication: ``5 * H``"
 msgstr "Multiplicación escalar: ``5 * H``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:20
+#: ../../modules/analog/analog_hamiltonian.rst:34
 msgid "multiplication: ``H0 * H1``"
 msgstr "Multiplicación: ``H0 * H1``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:21
+#: ../../modules/analog/analog_hamiltonian.rst:35
 msgid "Subtraction: ``H1 - H2``"
 msgstr "Resta: ``H1 - H2``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:22
+#: ../../modules/analog/analog_hamiltonian.rst:36
 msgid "Division by scalar: ``H / 5``"
 msgstr "División por escalar: ``H / 5``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:23
+#: ../../modules/analog/analog_hamiltonian.rst:37
 msgid "Negation: ``-H``"
 msgstr "Negación: ``-H``"
 
-#: ../../modules/analog/analog_hamiltonian.rst:25
+#: ../../modules/analog/analog_hamiltonian.rst:39
 msgid "**Extra Symbolic Operators**:"
 msgstr "**Operadores Simbólicos Adicionales**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:27
+#: ../../modules/analog/analog_hamiltonian.rst:41
 msgid ""
 "commutator: "
 ":meth:`H1.commutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.commutator>`"
@@ -98,7 +122,7 @@ msgstr ""
 "conmutador: "
 ":meth:`H1.commutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.commutator>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:28
+#: ../../modules/analog/analog_hamiltonian.rst:42
 msgid ""
 "anticommutator: "
 ":meth:`H1.anticommutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.anticommutator>`"
@@ -106,7 +130,7 @@ msgstr ""
 "anticonmutador: "
 ":meth:`H1.anticommutator(H2)<qilisdk.analog.hamiltonian.Hamiltonian.anticommutator>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:29
+#: ../../modules/analog/analog_hamiltonian.rst:43
 msgid ""
 "vector_norm: "
 ":meth:`H.vector_norm()<qilisdk.analog.hamiltonian.Hamiltonian.vector_norm>`"
@@ -114,7 +138,7 @@ msgstr ""
 "norma vectorial: "
 ":meth:`H.vector_norm()<qilisdk.analog.hamiltonian.Hamiltonian.vector_norm>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:30
+#: ../../modules/analog/analog_hamiltonian.rst:44
 msgid ""
 "frobenius_norm: "
 ":meth:`H.frobenius_norm()<qilisdk.analog.hamiltonian.Hamiltonian.frobenius_norm>`"
@@ -122,15 +146,15 @@ msgstr ""
 "norma de Frobenius: "
 ":meth:`H.frobenius_norm()<qilisdk.analog.hamiltonian.Hamiltonian.frobenius_norm>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:31
+#: ../../modules/analog/analog_hamiltonian.rst:45
 msgid "trace: :meth:`H.trace()<qilisdk.analog.hamiltonian.Hamiltonian.trace>`"
 msgstr "traza: :meth:`H.trace()<qilisdk.analog.hamiltonian.Hamiltonian.trace>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:33
+#: ../../modules/analog/analog_hamiltonian.rst:47
 msgid "**Exporting Hamiltonians**:"
 msgstr "**Exportación de Hamiltonianos**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:35
+#: ../../modules/analog/analog_hamiltonian.rst:49
 msgid ""
 "to matrix: "
 ":meth:`H.to_matrix(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_matrix>`"
@@ -138,7 +162,7 @@ msgstr ""
 "a matriz: "
 ":meth:`H.to_matrix(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_matrix>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:36
+#: ../../modules/analog/analog_hamiltonian.rst:50
 msgid ""
 "to qtensor: "
 ":meth:`H.to_qtensor(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_qtensor>`"
@@ -146,11 +170,11 @@ msgstr ""
 "a qtensor: "
 ":meth:`H.to_qtensor(nqubits)<qilisdk.analog.hamiltonian.Hamiltonian.to_qtensor>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:38
+#: ../../modules/analog/analog_hamiltonian.rst:52
 msgid "**Importing Hamiltonians**:"
 msgstr "**Importación de Hamiltonianos**:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:40
+#: ../../modules/analog/analog_hamiltonian.rst:54
 msgid ""
 "from qtensor: "
 ":meth:`Hamiltonian.from_qtensor(qtensor)<qilisdk.analog.hamiltonian.Hamiltonian.from_qtensor>`"
@@ -158,7 +182,7 @@ msgstr ""
 "desde qtensor: "
 ":meth:`Hamiltonian.from_qtensor(qtensor)<qilisdk.analog.hamiltonian.Hamiltonian.from_qtensor>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:41
+#: ../../modules/analog/analog_hamiltonian.rst:55
 msgid ""
 "from string: "
 ":meth:`Hamiltonian.parse(hamiltonian_string)<qilisdk.analog.hamiltonian.Hamiltonian.parse>`"
@@ -166,15 +190,15 @@ msgstr ""
 "desde cadena de texto: "
 ":meth:`Hamiltonian.parse(hamiltonian_string)<qilisdk.analog.hamiltonian.Hamiltonian.parse>`"
 
-#: ../../modules/analog/analog_hamiltonian.rst:44
+#: ../../modules/analog/analog_hamiltonian.rst:58
 msgid "Example: Ising Hamiltonian"
 msgstr "Ejemplo: Hamiltoniano de Ising"
 
-#: ../../modules/analog/analog_hamiltonian.rst:46
+#: ../../modules/analog/analog_hamiltonian.rst:60
 msgid "To define an Ising Hamiltonian of the form:"
 msgstr "Para definir un Hamiltoniano de Ising de la forma:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:48
+#: ../../modules/analog/analog_hamiltonian.rst:62
 msgid ""
 "H_{\\text{Ising}}  =  - \\sum_{\\langle i, j \\rangle} J_{ij} \\sigma^Z_i"
 " \\sigma^Z_j - \\sum_j h_j \\sigma^Z_j"
@@ -182,11 +206,11 @@ msgstr ""
 "H_{\\text{Ising}}  =  - \\sum_{\\langle i, j \\rangle} J_{ij} \\sigma^Z_i"
 " \\sigma^Z_j - \\sum_j h_j \\sigma^Z_j"
 
-#: ../../modules/analog/analog_hamiltonian.rst:52
+#: ../../modules/analog/analog_hamiltonian.rst:66
 msgid "you can use the Pauli ``Z`` operators from the library:"
 msgstr "puede utilizar los operadores de Pauli ``Z`` de la biblioteca:"
 
-#: ../../modules/analog/analog_hamiltonian.rst:68
+#: ../../modules/analog/analog_hamiltonian.rst:82
 msgid "**Output:**"
 msgstr "**Salida:**"
 

--- a/docs/modules/analog/analog_hamiltonian.rst
+++ b/docs/modules/analog/analog_hamiltonian.rst
@@ -6,9 +6,23 @@ The :class:`~qilisdk.analog.hamiltonian.Hamiltonian` class represents a symbolic
 Constructing
 ======================
 
-To construct a Hamiltonian with a single Pauli, you can use the constructors ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)``. 
+To construct a Hamiltonian with a single Pauli, you can use the constructors
+:meth:`Hamiltonian.X(i)<qilisdk.analog.hamiltonian.Hamiltonian.X>`,
+:meth:`Hamiltonian.Y(i)<qilisdk.analog.hamiltonian.Hamiltonian.Y>`,
+:meth:`Hamiltonian.Z(i)<qilisdk.analog.hamiltonian.Hamiltonian.Z>`,
+:meth:`Hamiltonian.I(i)<qilisdk.analog.hamiltonian.Hamiltonian.I>`.
+
 From these single-qubit operators, you can build multi-qubit Hamiltonians using arithmetic operations.
-The operations follow Python syntax, for example: ``2 * Z(0) + Z(1)`` and ``Z(0) * Z(1)`` build multi-qubit Hamiltonians.
+The operations follow Python syntax, for example:
+
+.. code-block:: python
+
+    from qilisdk.analog import Hamiltonian
+    H = Hamiltonian.X(0) * Hamiltonian.X(1) + Hamiltonian.Z(1)
+
+The shorter module-level functions ``X(i)``, ``Y(i)``, ``Z(i)``, ``I(i)`` remain available and behave
+identically, but they are discouraged because they clash with the ``X``, ``Y`` and ``Z`` *gates* from
+:mod:`qilisdk.digital`. They may be deprecated in a future release.
 
 List of Operations
 ======================
@@ -53,14 +67,14 @@ you can use the Pauli ``Z`` operators from the library:
 
 .. code-block:: python
 
-    from qilisdk.analog import Z
+    from qilisdk.analog import Hamiltonian
 
     nqubits = 3
     J = {(0, 1): 1, (0, 2): 2, (1, 2): 4}
     h = {0: 1, 1: 2, 2: 3}
 
-    coupling = sum(weight * Z(i) * Z(j) for (i, j), weight in J.items())
-    fields = sum(weight * Z(i) for i, weight in h.items())
+    coupling = sum(weight * Hamiltonian.Z(i) * Hamiltonian.Z(j) for (i, j), weight in J.items())
+    fields = sum(weight * Hamiltonian.Z(i) for i, weight in h.items())
 
     H = -(coupling + fields)
     print(H)

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -77,20 +77,65 @@ def _get_pauli(name: str, qubit: int) -> PauliOperator:
 ###############################################################################
 # Public Factory Functions
 ###############################################################################
-def Z(qubit: int) -> Hamiltonian:
-    return _get_pauli("Z", qubit).to_hamiltonian()
+
+
+def I(qubit: int = 0) -> Hamiltonian:  # noqa: E743
+    """Build a Hamiltonian consisting of a single identity acting on ``qubit``.
+
+    Note: prefer :meth:`Hamiltonian.I<qilisdk.analog.hamiltonian.Hamiltonian.I>`.
+
+    Args:
+        qubit (int, optional): Index of the qubit the operator acts on. Defaults to 0.
+
+    Returns:
+        Hamiltonian: The Hamiltonian ``I(qubit)``.
+    """
+    return _get_pauli("I", qubit).to_hamiltonian()
 
 
 def X(qubit: int) -> Hamiltonian:
+    """Build a Hamiltonian consisting of a single Pauli X acting on ``qubit``.
+
+    Note: prefer :meth:`Hamiltonian.X<qilisdk.analog.hamiltonian.Hamiltonian.X>`, which avoids any
+    ambiguity with the ``X`` gate from :mod:`qilisdk.digital`.
+
+    Args:
+        qubit (int): Index of the qubit the operator acts on.
+
+    Returns:
+        Hamiltonian: The Hamiltonian ``X(qubit)``.
+    """
     return _get_pauli("X", qubit).to_hamiltonian()
 
 
 def Y(qubit: int) -> Hamiltonian:
+    """Build a Hamiltonian consisting of a single Pauli Y acting on ``qubit``.
+
+    Note: prefer :meth:`Hamiltonian.Y<qilisdk.analog.hamiltonian.Hamiltonian.Y>`, which avoids any
+    ambiguity with the ``Y`` gate from :mod:`qilisdk.digital`.
+
+    Args:
+        qubit (int): Index of the qubit the operator acts on.
+
+    Returns:
+        Hamiltonian: The Hamiltonian ``Y(qubit)``.
+    """
     return _get_pauli("Y", qubit).to_hamiltonian()
 
 
-def I(qubit: int = 0) -> Hamiltonian:  # noqa: E743
-    return _get_pauli("I", qubit).to_hamiltonian()
+def Z(qubit: int) -> Hamiltonian:
+    """Build a Hamiltonian consisting of a single Pauli Z acting on ``qubit``.
+
+    Note: prefer :meth:`Hamiltonian.Z<qilisdk.analog.hamiltonian.Hamiltonian.Z>`, which avoids any
+    ambiguity with the ``Z`` gate from :mod:`qilisdk.digital`.
+
+    Args:
+        qubit (int): Index of the qubit the operator acts on.
+
+    Returns:
+        Hamiltonian: The Hamiltonian ``Z(qubit)``.
+    """
+    return _get_pauli("Z", qubit).to_hamiltonian()
 
 
 ###############################################################################
@@ -109,7 +154,8 @@ class PauliOperator(ABC):
 
     Flyweight usage: do NOT instantiate directly—use PauliX(q), PauliY(q), etc.
 
-    Note: You can also use the factory functions X(q), Y(q), Z(q), I(q) to get a Hamiltonian object.
+    Note: You can also use Hamiltonian.X(q), Hamiltonian.Y(q), Hamiltonian.Z(q), Hamiltonian.I(q)
+    (or the older factory functions X(q), Y(q), Z(q), I(q)) to get a Hamiltonian object.
     """
 
     _NAME: ClassVar[str]
@@ -256,9 +302,9 @@ class Hamiltonian(Parameterizable):
     Example:
         .. code-block:: python
 
-            from qilisdk.analog.hamiltonian import Hamiltonian, X, Z
+            from qilisdk.analog import Hamiltonian
 
-            H = X(0) * X(1) + Z(1)
+            H = Hamiltonian.X(0) * Hamiltonian.X(1) + Hamiltonian.Z(1)
     """
 
     _EPS: float = 1e-14
@@ -590,6 +636,82 @@ class Hamiltonian(Parameterizable):
                 partitions.append({term: coeff})
 
         return partitions
+
+    @staticmethod
+    def I(qubit: int = 0) -> Hamiltonian:  # noqa: E743
+        """Build a Hamiltonian consisting of a single identity acting on ``qubit``.
+
+        Example:
+            .. code-block:: python
+
+                from qilisdk.analog import Hamiltonian
+
+                H = Hamiltonian.I(0)
+
+        Args:
+            qubit (int, optional): Index of the qubit the operator acts on. Defaults to 0.
+
+        Returns:
+            Hamiltonian: The Hamiltonian ``I(qubit)``.
+        """
+        return _get_pauli("I", qubit).to_hamiltonian()
+
+    @staticmethod
+    def X(qubit: int) -> Hamiltonian:
+        """Build a Hamiltonian consisting of a single Pauli X acting on ``qubit``.
+
+        Example:
+            .. code-block:: python
+
+                from qilisdk.analog import Hamiltonian
+
+                H = Hamiltonian.X(0)
+
+        Args:
+            qubit (int): Index of the qubit the operator acts on.
+
+        Returns:
+            Hamiltonian: The Hamiltonian ``X(qubit)``.
+        """
+        return _get_pauli("X", qubit).to_hamiltonian()
+
+    @staticmethod
+    def Y(qubit: int) -> Hamiltonian:
+        """Build a Hamiltonian consisting of a single Pauli Y acting on ``qubit``.
+
+        Example:
+            .. code-block:: python
+
+                from qilisdk.analog import Hamiltonian
+
+                H = Hamiltonian.Y(0)
+
+        Args:
+            qubit (int): Index of the qubit the operator acts on.
+
+        Returns:
+            Hamiltonian: The Hamiltonian ``Y(qubit)``.
+        """
+        return _get_pauli("Y", qubit).to_hamiltonian()
+
+    @staticmethod
+    def Z(qubit: int) -> Hamiltonian:
+        """Build a Hamiltonian consisting of a single Pauli Z acting on ``qubit``.
+
+        Example:
+            .. code-block:: python
+
+                from qilisdk.analog import Hamiltonian
+
+                H = Hamiltonian.Z(0)
+
+        Args:
+            qubit (int): Index of the qubit the operator acts on.
+
+        Returns:
+            Hamiltonian: The Hamiltonian ``Z(qubit)``.
+        """
+        return _get_pauli("Z", qubit).to_hamiltonian()
 
     @classmethod
     def from_qtensor(cls, tensor: QTensor, tol: float | None = None, prune: float | None = None) -> Hamiltonian:

--- a/tests/unit_python/analog/test_hamiltionian.py
+++ b/tests/unit_python/analog/test_hamiltionian.py
@@ -855,3 +855,37 @@ def test_pauli_operator_rejects_negative_qubit():
     """QSDK-05: a Pauli operator must reject a negative qubit at construction."""
     with pytest.raises(ValueError, match="non-negative"):
         PauliX(-1)
+
+
+@pytest.mark.parametrize(
+    ("static_constructor", "factory", "pauli"),
+    [
+        (Hamiltonian.X, X, PauliX),
+        (Hamiltonian.Y, Y, PauliY),
+        (Hamiltonian.Z, Z, PauliZ),
+        (Hamiltonian.I, I, PauliI),
+    ],
+)
+def test_hamiltonian_static_pauli_constructors(static_constructor, factory, pauli):
+    for qubit in (0, 3):
+        H = static_constructor(qubit)
+        assert isinstance(H, Hamiltonian)
+        assert factory(qubit) == H
+        assert H.elements == factory(qubit).elements
+        assert next(iter(H.elements))[0].name == pauli(qubit).name
+
+
+def test_hamiltonian_static_identity_defaults_to_qubit_zero():
+    assert Hamiltonian.I() == I()
+
+
+def test_hamiltonian_static_constructors_compose():
+    H = Hamiltonian.X(0) * Hamiltonian.X(1) + 2 * Hamiltonian.Z(1) - Hamiltonian.Y(2) / 2
+
+    assert X(0) * X(1) + 2 * Z(1) - Y(2) / 2 == H
+
+
+def test_hamiltonian_static_constructors_reject_negative_qubit():
+    for constructor in (Hamiltonian.X, Hamiltonian.Y, Hamiltonian.Z, Hamiltonian.I):
+        with pytest.raises(ValueError, match="non-negative"):
+            constructor(-1)


### PR DESCRIPTION
Some more constructors for Hamiltonians have been added, now for single Paulis, which should be used over the loose X, Y and Z constructors from before, since those can be confused with the X, Y and Z from the digital module. The old functions remain there for backwards compatability, but we might depreciate them at some point. The new usage is as follows:

```python
from qilisdk.analog import Hamiltonian
h = Hamiltonian.X(0) + 2 * Hamiltonian.Z(1)
print(h)
```

This resolves https://github.com/qilimanjaro-tech/qilisdk/issues/331