### PR TITLE
Fix Multi Controlled Unitaries

### DIFF
--- a/changes/361.bugfix.md
+++ b/changes/361.bugfix.md
@@ -1,0 +1,1 @@
+A bug has been fixed in which decomposed multi-controlled gates produced a wrong unitary, specifically that since it used the square root of certain gates to build the decomposition, so phases were incorrectly ignored.

--- a/src/qilisdk/digital/circuit_transpiler_passes/decompose_multi_controlled_gates_pass.py
+++ b/src/qilisdk/digital/circuit_transpiler_passes/decompose_multi_controlled_gates_pass.py
@@ -22,13 +22,19 @@ from qilisdk.digital.gates import BasicGate, Controlled
 
 from .circuit_transpiler_pass import CircuitTranspilerPass
 from .numeric_helpers import (
+    _EPS,
+    _u3_and_phase_from_unitary,
     _unitary_sqrt_2x2,
-    _zyz_from_unitary,
+    _wrap_angle,
 )
 
 
 def _is_controlled(gate: Gate) -> TypeGuard[Controlled[BasicGate]]:
     return isinstance(gate, Controlled)
+
+
+# A gate paired with a global phase
+PhasedGate = tuple[BasicGate, float]
 
 
 class DecomposeMultiControlledGatesPass(CircuitTranspilerPass):
@@ -99,61 +105,94 @@ def _decompose(gate: Controlled) -> list[Gate]:
     last_control_qubit = gate.control_qubits[-1]
     remaining_control_qubits = gate.control_qubits[:-1]
 
-    square_root_gate = _sqrt_of(gate.basic_gate)
-    square_root_adjoint_gate = _adjoint_of(square_root_gate)
+    # We need the square root of the target gate, and its adjoint, to build the decomposition
+    # sqrt(U) = e^{i·square_root_phase} · square_root_gate
+    # square_root_gate† = e^{i·adjoint_phase} · square_root_adjoint_gate,
+    # hence sqrt(U)† = e^{i·(adjoint_phase - square_root_phase)} · square_root_adjoint_gate
+    square_root_gate, square_root_phase = _sqrt_of(gate.basic_gate)
+    square_root_adjoint_gate, adjoint_phase = _adjoint_of(square_root_gate)
+    square_root_adjoint_phase = adjoint_phase - square_root_phase
 
+    # Each C(e^{i·alpha}·G) equals C(G) preceded by U1(alpha) on the control qubits, so the leftover phases of the0
+    # square root and of its adjoint are emitted as multi-controlled U1 gates instead of being silently dropped
     decomposition_sequence: list[Gate] = []
     decomposition_sequence += _decompose(Controlled(last_control_qubit, basic_gate=square_root_gate))
+    decomposition_sequence += _phase_on_controls(square_root_phase, (last_control_qubit,))
     decomposition_sequence += _decompose(X(last_control_qubit).controlled(*remaining_control_qubits))
     decomposition_sequence += _decompose(Controlled(last_control_qubit, basic_gate=square_root_adjoint_gate))
+    decomposition_sequence += _phase_on_controls(square_root_adjoint_phase, (last_control_qubit,))
     decomposition_sequence += _decompose(X(last_control_qubit).controlled(*remaining_control_qubits))
     decomposition_sequence += _decompose(Controlled(*remaining_control_qubits, basic_gate=square_root_gate))
+    decomposition_sequence += _phase_on_controls(square_root_phase, remaining_control_qubits)
 
     return decomposition_sequence
 
 
-def _sqrt_of(gate: BasicGate) -> BasicGate:
-    """Return a gate V whose square equals the provided gate.
+def _phase_on_controls(phase: float, control_qubits: tuple[int, ...]) -> list[Gate]:
+    """Build the gates applying `e^{i·phase}` only when every control qubit is set.
+
+    Args:
+        phase (float): Phase to apply, in radians.
+        control_qubits (tuple[int, ...]): Qubits that must all be set for the phase to apply.
+
+    Returns:
+        list[Gate]: Empty list when the phase is negligible, otherwise a `C^(k-1)(U1(phase))` decomposition.
+    """
+    if abs(_wrap_angle(phase)) < _EPS:
+        return []
+
+    # A phase conditioned on k qubits is a U1 on any one of them, controlled by the remaining k - 1.
+    phase_gate = U1(control_qubits[-1], phi=phase)
+    if len(control_qubits) == 1:
+        return [phase_gate]
+    return _decompose(Controlled(*control_qubits[:-1], basic_gate=phase_gate))
+
+
+def _sqrt_of(gate: BasicGate) -> PhasedGate:
+    """Return a gate V and a phase alpha such that `(e^{i·alpha}·V)² ` equals the provided gate.
+
+    The phase is reported rather than discarded because a global phase on V becomes a relative phase once V is
+    placed under a control, which would otherwise make the decomposition compute a different unitary.
 
     Args:
         gate (BasicGate): Single-qubit gate to compute the principal square root for.
     Returns:
-        BasicGate: New primitive V that satisfies V · V ≡ gate.
+        PhasedGate: New primitive V and the residual phase alpha.
     """
     target_qubit = gate.qubits[0]
 
     # Identity: sqrt(I) = I
     if isinstance(gate, I):
-        return I(target_qubit)
+        return I(target_qubit), 0.0
 
-    # Direct parametric rotations.
+    # Direct parametric rotations: RX/RY/RZ are exactly half-angle closed.
     if isinstance(gate, RZ):
-        return RZ(target_qubit, phi=gate.phi / 2.0)
+        return RZ(target_qubit, phi=gate.phi / 2.0), 0.0
     if isinstance(gate, RX):
-        return RX(target_qubit, theta=gate.theta / 2.0)
+        return RX(target_qubit, theta=gate.theta / 2.0), 0.0
     if isinstance(gate, RY):
-        return RY(target_qubit, theta=gate.theta / 2.0)
+        return RY(target_qubit, theta=gate.theta / 2.0), 0.0
 
-    # Pauli gates via half-angle rotations.
+    # Pauli gates via half-angle rotations. Z is diagonal so it has an exact square root, while
+    # sqrt(X) = e^{i·pi/4}·RX(pi/2) and sqrt(Y) = e^{i·pi/4}·RY(pi/2) keep a quarter-turn phase.
     if isinstance(gate, Z):
-        return RZ(target_qubit, phi=math.pi / 2.0)
+        return S(target_qubit), 0.0
     if isinstance(gate, X):
-        return RX(target_qubit, theta=math.pi / 2.0)
+        return RX(target_qubit, theta=math.pi / 2.0), math.pi / 4.0
     if isinstance(gate, Y):
-        return RY(target_qubit, theta=math.pi / 2.0)
+        return RY(target_qubit, theta=math.pi / 2.0), math.pi / 4.0
 
     # Phase gate U1(phi) = diag(1, e^{iphi}), sqrt is U1(phi/2).
     if isinstance(gate, U1):
-        return RZ(target_qubit, phi=gate.phi / 2.0)
+        return U1(target_qubit, phi=gate.phi / 2.0), 0.0
 
-    # S and T: phase gates with known relation to RZ
-    # S = RZ(pi/2) ⇒ sqrt(S) = RZ(pi/4) ≡ T
+    # S = U1(pi/2) ⇒ sqrt(S) = U1(pi/4) ≡ T
     if isinstance(gate, S):
-        return T(target_qubit)
+        return T(target_qubit), 0.0
 
-    # T = RZ(pi/4) ⇒ sqrt(T) = RZ(pi/8)
+    # T = U1(pi/4) ⇒ sqrt(T) = U1(pi/8)
     if isinstance(gate, T):
-        return RZ(target_qubit, phi=math.pi / 8.0)
+        return U1(target_qubit, phi=math.pi / 8.0), 0.0
 
     # Build the 2x2 unitary matrix for gate
     if isinstance(gate, BasicGate) and gate.nqubits == 1:
@@ -164,61 +203,61 @@ def _sqrt_of(gate: BasicGate) -> BasicGate:
     # Compute a matrix square root V such that V @ V ≈ U.
     square_root_unitary = _unitary_sqrt_2x2(unitary_matrix)
 
-    # Express V as a U3 on the same qubit. This introduces a new gate in U3 form
+    # Express V as a phase times a U3 on the same qubit. This introduces a new gate in U3 form
     # for the *square root*, but leaves the original gate untouched.
-    theta, phi, gamma = _zyz_from_unitary(square_root_unitary)
-    return U3(target_qubit, theta=theta, phi=phi, gamma=gamma)
+    theta, phi, gamma, alpha = _u3_and_phase_from_unitary(square_root_unitary)
+    return U3(target_qubit, theta=theta, phi=phi, gamma=gamma), alpha
 
 
-def _adjoint_of(gate: BasicGate) -> BasicGate:
-    """Return the single-qubit adjoint (inverse) of a gate.
+def _adjoint_of(gate: BasicGate) -> PhasedGate:
+    """Return a gate W and a phase alpha such that `e^{i·alpha}·W` is the adjoint (inverse) of a gate.
 
     Args:
         gate (BasicGate): Gate whose inverse should be produced.
     Returns:
-        BasicGate: Gate that when composed with `gate` yields the identity.
+        PhasedGate: Gate W and the residual phase alpha.
     """
     target_qubit = gate.qubits[0]
 
     # Identity: self-adjoint.
     if isinstance(gate, I):
-        return I(target_qubit)
+        return I(target_qubit), 0.0
 
     # Pauli & Hadamard: self-adjoint.
     if isinstance(gate, X):
-        return X(target_qubit)
+        return X(target_qubit), 0.0
     if isinstance(gate, Y):
-        return Y(target_qubit)
+        return Y(target_qubit), 0.0
     if isinstance(gate, Z):
-        return Z(target_qubit)
+        return Z(target_qubit), 0.0
     if isinstance(gate, H):
-        return H(target_qubit)
+        return H(target_qubit), 0.0
 
     if isinstance(gate, RX):
-        return RX(target_qubit, theta=-gate.theta)
+        return RX(target_qubit, theta=-gate.theta), 0.0
     if isinstance(gate, RY):
-        return RY(target_qubit, theta=-gate.theta)
+        return RY(target_qubit, theta=-gate.theta), 0.0
     if isinstance(gate, RZ):
-        return RZ(target_qubit, phi=-gate.phi)
+        return RZ(target_qubit, phi=-gate.phi), 0.0
 
     if isinstance(gate, U1):
-        # U1(gamma)† = U1(-gamma)
-        return RZ(target_qubit, phi=-gate.phi)
+        # U1(phi)† = U1(-phi)
+        return U1(target_qubit, phi=-gate.phi), 0.0
     if isinstance(gate, U2):
-        # U2(phi, gamma)† = U3(pi/2, phi, gamma)† = U3(-pi/2, -phi, -gamma)
-        return U3(target_qubit, theta=-math.pi / 2.0, phi=-gate.gamma, gamma=-gate.phi)
+        # U2(phi, gamma)† = U3(pi/2, phi, gamma)† = U3(-pi/2, -gamma, -phi)
+        return U3(target_qubit, theta=-math.pi / 2.0, phi=-gate.gamma, gamma=-gate.phi), 0.0
     if isinstance(gate, U3):
         # U3(theta, phi, gamma)† = U3(-theta, -gamma, -phi)
-        return U3(target_qubit, theta=-gate.theta, phi=-gate.gamma, gamma=-gate.phi)
+        return U3(target_qubit, theta=-gate.theta, phi=-gate.gamma, gamma=-gate.phi), 0.0
 
-    # S, T: phase gates about Z.
-    # S = RZ(pi/2)  ⇒ S† = RZ(-pi/2)
+    # S, T: diagonal phase gates about Z.
+    # S = U1(pi/2) ⇒ S† = U1(-pi/2)
     if isinstance(gate, S):
-        return RZ(target_qubit, phi=-math.pi / 2.0)
+        return U1(target_qubit, phi=-math.pi / 2.0), 0.0
 
-    # T = RZ(pi/4)  ⇒ T† = RZ(-pi/4)
+    # T = U1(pi/4) ⇒ T† = U1(-pi/4)
     if isinstance(gate, T):
-        return RZ(target_qubit, phi=-math.pi / 4.0)
+        return U1(target_qubit, phi=-math.pi / 4.0), 0.0
 
     # ---------- Generic 1-qubit unitary via matrix adjoint ----------
 
@@ -227,7 +266,7 @@ def _adjoint_of(gate: BasicGate) -> BasicGate:
     else:
         raise NotImplementedError(f"_adjoint_1q only supports 1-qubit gates; got {type(gate).__name__}")
 
-    # Take the matrix adjoint U† and convert to ZYZ → U3.
+    # Take the matrix adjoint U† and convert to a phase times a U3.
     unitary_adjoint = unitary_matrix.conj().T
-    theta, phi, gamma = _zyz_from_unitary(unitary_adjoint)
-    return U3(target_qubit, theta=theta, phi=phi, gamma=gamma)
+    theta, phi, gamma, alpha = _u3_and_phase_from_unitary(unitary_adjoint)
+    return U3(target_qubit, theta=theta, phi=phi, gamma=gamma), alpha

--- a/src/qilisdk/digital/circuit_transpiler_passes/numeric_helpers.py
+++ b/src/qilisdk/digital/circuit_transpiler_passes/numeric_helpers.py
@@ -75,19 +75,77 @@ def _zyz_from_unitary(unitary: np.ndarray) -> tuple[float, float, float]:
     return (theta, phi, lam)
 
 
-def _unitary_sqrt_2x2(unitary: np.ndarray) -> np.ndarray:
-    """Compute the principal square root of a 2x2 unitary.
+def _u3_and_phase_from_unitary(unitary: np.ndarray) -> tuple[float, float, float, float]:
+    """Decompose a 2x2 unitary as ``exp(i*alpha) * U3(theta, phi, gamma)``.
+
+    Unlike :func:`_zyz_from_unitary`, the discarded global phase is returned instead of being dropped, so the
+    factorisation is exact. This matters whenever the gate is later placed under a control, where a global phase
+    becomes an observable relative phase.
 
     Args:
         unitary (np.ndarray): 2x2 unitary matrix.
     Returns:
-        np.ndarray: Matrix V such that V · V equals U.
+        tuple[float, float, float, float]: Tuple containing theta, phi, gamma and the residual phase alpha.
+    Raises:
+        ValueError: If matrix is not 2x2 or is singular.
     """
-    logger.trace("[NumericHelpers] Computing principal square root of 2x2 unitary")
-    w, V = np.linalg.eig(unitary)
-    ph = np.angle(w)
-    sqrt_w = np.exp(0.5j * ph)
-    return V @ np.diag(sqrt_w) @ np.linalg.inv(V)
+    logger.trace("[NumericHelpers] Recovering U3 angles and global phase from unitary")
+    if unitary.shape != (2, 2):
+        raise ValueError("Expected 2x2 unitary for U3 decomposition.")
+    if abs(np.linalg.det(unitary)) < _EPS:
+        raise ValueError("Matrix is singular.")
+
+    a00, a01 = unitary[0, 0], unitary[0, 1]
+    a10, a11 = unitary[1, 0], unitary[1, 1]
+
+    # theta == pi: the diagonal vanishes, so alpha can be absorbed into phi and gamma.
+    if abs(a00) < _EPS:
+        return (math.pi, _wrap_angle(float(np.angle(a10))), _wrap_angle(float(np.angle(-a01))), 0.0)
+
+    # U3 has a real non-negative top-left entry, so alpha is entirely fixed by it.
+    alpha = _wrap_angle(float(np.angle(a00)))
+    dephase = np.exp(-1j * alpha)
+
+    # theta == 0: the anti-diagonal vanishes and only phi + gamma is determined.
+    if abs(a01) < _EPS:
+        return (0.0, 0.0, _wrap_angle(float(np.angle(a11 * dephase))), alpha)
+
+    theta = 2.0 * math.atan2(float(np.abs(a01)), float(np.abs(a00)))
+    phi = _wrap_angle(float(np.angle(a10 * dephase)))
+    gamma = _wrap_angle(float(np.angle(-a01 * dephase)))
+    return (theta, phi, gamma, alpha)
+
+
+def _unitary_sqrt_2x2(unitary: np.ndarray) -> np.ndarray:
+    """Compute a unitary square root of a 2x2 unitary.
+
+    The closed form below is used instead of an eigendecomposition because `numpy.linalg.eig` returns an
+    ill-conditioned (non-orthogonal) eigenvector basis for degenerate spectra, which yields a non-unitary "square
+    root". Factoring the input as ``exp(i*delta) * A`` with ``A`` in SU(2) and applying the Cayley-Hamilton identity
+    ``(A + I)^2 = (tr(A) + 2) * A`` keeps the result exactly unitary for every input.
+
+    Args:
+        unitary (np.ndarray): 2x2 unitary matrix.
+    Returns:
+        np.ndarray: Unitary matrix V such that V · V equals U.
+    Raises:
+        ValueError: If matrix is not 2x2 or is not unitary.
+    """
+    logger.trace("[NumericHelpers] Computing square root of 2x2 unitary")
+    if unitary.shape != (2, 2):
+        raise ValueError("Expected 2x2 unitary for square root.")
+    if not np.allclose(unitary.conj().T @ unitary, np.eye(2), atol=1e-9):
+        raise ValueError("Expected a unitary matrix for square root.")
+
+    # Factor out the phase that makes the remainder special unitary, so that Cayley-Hamilton applies.
+    delta = 0.5 * float(np.angle(np.linalg.det(unitary)))
+    special = unitary * np.exp(-1j * delta)
+
+    # When trace == -2 the remainder is -I, whose square roots are degenerate; diag(i, -i) is one of them.
+    trace = float(np.real(np.trace(special)))
+    root = np.diag([1j, -1j]).astype(complex) if trace + 2.0 < _EPS else (special + np.eye(2)) / math.sqrt(trace + 2.0)
+
+    return root * np.exp(0.5j * delta)
 
 
 def _is_close_mod_2pi(a: float, b: float, eps: float = _EPS) -> bool:

--- a/tests/unit_python/digital/circuit_transpiler_passes/test_decompose_multi_controlled_gates_pass.py
+++ b/tests/unit_python/digital/circuit_transpiler_passes/test_decompose_multi_controlled_gates_pass.py
@@ -18,19 +18,61 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-from qilisdk.digital import RX, RY, RZ, U1, U2, U3, Circuit, H, I, S, T, X, Y, Z
+from qilisdk.digital import RX, RY, RZ, U1, U2, U3, Circuit, H, I, M, S, T, X, Y, Z
 from qilisdk.digital.circuit_transpiler_passes import DecomposeMultiControlledGatesPass
-from qilisdk.digital.circuit_transpiler_passes.decompose_multi_controlled_gates_pass import _adjoint_of, _sqrt_of
+from qilisdk.digital.circuit_transpiler_passes.decompose_multi_controlled_gates_pass import (
+    _adjoint_of,
+    _phase_on_controls,
+    _sqrt_of,
+)
 from qilisdk.digital.circuit_transpiler_passes.numeric_helpers import _wrap_angle, _zyz_from_unitary
 from qilisdk.digital.gates import BasicGate, Controlled, Gate
 
-from .utils import _sequences_equivalent, _unitaries_equivalent
+from .utils import _sequence_matrix, _sequences_equivalent
+
+ATOL = 1e-9
 
 
 def _run_pass_with_gate(gate: Gate, nqubits: int) -> Circuit:
     circuit = Circuit(nqubits)
     circuit.add(gate)
     return DecomposeMultiControlledGatesPass().run(circuit)
+
+
+class _MatrixGate(BasicGate):
+    """Single-qubit gate defined directly by an arbitrary 2x2 unitary.
+
+    Used to drive the generic (matrix-based) branches of the square-root and adjoint helpers with unitaries that no
+    named gate produces, including the degenerate diagonal and anti-diagonal shapes.
+    """
+
+    def __init__(self, qubit: int, unitary: np.ndarray) -> None:
+        super().__init__(target_qubits=(qubit,))
+        self._unitary = np.asarray(unitary, dtype=complex)
+
+    @property
+    def name(self) -> str:
+        return "MatrixGate"
+
+    def _generate_matrix(self) -> np.ndarray:
+        return self._unitary.copy()
+
+
+def _haar_unitary(seed: int) -> np.ndarray:
+    """Draw a Haar-random 2x2 unitary deterministically from `seed`."""
+    rng = np.random.default_rng(seed)
+    ginibre = rng.normal(size=(2, 2)) + 1j * rng.normal(size=(2, 2))
+    q, r = np.linalg.qr(ginibre)
+    return q * (np.diag(r) / np.abs(np.diag(r)))
+
+
+def _haar_gate_factory(seed: int):
+    """Build a factory producing a `_MatrixGate` holding the Haar unitary for `seed`."""
+
+    def factory(qubit: int) -> _MatrixGate:
+        return _MatrixGate(qubit, _haar_unitary(seed))
+
+    return factory
 
 
 GATE_FACTORIES = [
@@ -48,6 +90,54 @@ GATE_FACTORIES = [
     ("U2", lambda q: U2(q, phi=math.pi / 6.0, gamma=math.pi / 5.0)),
     ("U3", lambda q: U3(q, theta=math.pi / 3.0, phi=math.pi / 4.0, gamma=math.pi / 5.0)),
 ]
+
+# Angles that stress the wrap-around, zero-phase and half-turn edge cases of the helpers.
+EDGE_CASE_FACTORIES = [
+    ("RX(0)", lambda q: RX(q, theta=0.0)),
+    ("RX(pi)", lambda q: RX(q, theta=math.pi)),
+    ("RX(-pi)", lambda q: RX(q, theta=-math.pi)),
+    ("RX(2pi)", lambda q: RX(q, theta=2.0 * math.pi)),
+    ("RY(pi)", lambda q: RY(q, theta=math.pi)),
+    ("RY(-3pi/2)", lambda q: RY(q, theta=-3.0 * math.pi / 2.0)),
+    ("RZ(pi)", lambda q: RZ(q, phi=math.pi)),
+    ("RZ(-pi)", lambda q: RZ(q, phi=-math.pi)),
+    ("RZ(1e-9)", lambda q: RZ(q, phi=1e-9)),
+    ("U1(0)", lambda q: U1(q, phi=0.0)),
+    ("U1(pi)", lambda q: U1(q, phi=math.pi)),
+    ("U1(-pi)", lambda q: U1(q, phi=-math.pi)),
+    ("U1(2pi)", lambda q: U1(q, phi=2.0 * math.pi)),
+    ("U1(3pi/2)", lambda q: U1(q, phi=3.0 * math.pi / 2.0)),
+    ("U2(0,0)", lambda q: U2(q, phi=0.0, gamma=0.0)),
+    ("U2(pi,-pi)", lambda q: U2(q, phi=math.pi, gamma=-math.pi)),
+    ("U3(0,0,0)", lambda q: U3(q, theta=0.0, phi=0.0, gamma=0.0)),
+    ("U3(pi,0,0)", lambda q: U3(q, theta=math.pi, phi=0.0, gamma=0.0)),
+    ("U3(pi,pi/3,-pi/5)", lambda q: U3(q, theta=math.pi, phi=math.pi / 3.0, gamma=-math.pi / 5.0)),
+    ("U3(-pi/2,pi,pi)", lambda q: U3(q, theta=-math.pi / 2.0, phi=math.pi, gamma=math.pi)),
+    ("U3(2pi,0,0)", lambda q: U3(q, theta=2.0 * math.pi, phi=0.0, gamma=0.0)),
+]
+
+# Unitaries with no named-gate equivalent, exercising the generic matrix branches.
+CUSTOM_UNITARY_FACTORIES = [
+    (
+        "diagonal",
+        lambda q: _MatrixGate(q, np.diag([np.exp(0.37j), np.exp(-1.42j)])),
+    ),
+    (
+        "anti_diagonal",
+        lambda q: _MatrixGate(q, np.array([[0.0, np.exp(0.9j)], [np.exp(-2.1j), 0.0]])),
+    ),
+    (
+        "negative_identity",
+        lambda q: _MatrixGate(q, -np.eye(2)),
+    ),
+    (
+        "global_phase_only",
+        lambda q: _MatrixGate(q, np.exp(1.234j) * np.eye(2)),
+    ),
+    *[(f"haar_{seed}", _haar_gate_factory(seed)) for seed in range(6)],
+]
+
+ALL_FACTORIES = GATE_FACTORIES + EDGE_CASE_FACTORIES + CUSTOM_UNITARY_FACTORIES
 
 CONTROL_COUNTS = [2, 3, 4]
 
@@ -93,10 +183,417 @@ def test_multi_controlled_gates_match_original_unitary(factory_name: str, factor
     assert _sequences_equivalent([gate], transpiled.gates, nqubits, None), (
         f"Unitary equality for {factory_name} with {ncontrols} controls"
     )
+    # The decomposition must be exact, not just equal up to phases: a global phase on the square root becomes an
+    # observable relative phase once it sits under a control (see issue #339).
+    assert np.allclose(_sequence_matrix([gate], nqubits), _sequence_matrix(transpiled.gates, nqubits), atol=1e-9), (
+        f"Exact unitary equality for {factory_name} with {ncontrols} controls"
+    )
 
     for rewritten in transpiled.gates:
         if isinstance(rewritten, Controlled):
             assert len(rewritten.control_qubits) <= 1
+
+
+# ======================= exactness of the decomposed unitary =======================
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+@pytest.mark.parametrize("ncontrols", CONTROL_COUNTS)
+def test_decomposition_is_exactly_the_original_unitary(factory_name: str, factory, ncontrols: int) -> None:
+    """Every decomposition must reproduce the controlled unitary entry by entry, with no residual phase."""
+    gate = _build_controlled_gate(factory, ncontrols)
+    circuit = Circuit(ncontrols + 1)
+    circuit.add(gate)
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL), (
+        f"Exact unitary equality for {factory_name} with {ncontrols} controls"
+    )
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), [("X", X), ("H", H), ("T", T), ("haar_0", _haar_gate_factory(0))])
+def test_decomposition_is_exact_for_deep_recursion(factory_name: str, factory) -> None:
+    """Five controls exercise four levels of recursion, where dropped phases used to compound."""
+    ncontrols = 5
+    gate = _build_controlled_gate(factory, ncontrols)
+    circuit = Circuit(ncontrols + 1)
+    circuit.add(gate)
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL), (
+        f"Exact unitary equality for {factory_name} with {ncontrols} controls"
+    )
+
+
+# Control/target placements that are neither contiguous nor ordered.
+QUBIT_LAYOUTS = [
+    ((1, 0), 2),
+    ((2, 0), 1),
+    ((3, 1), 0),
+    ((0, 2), 3),
+    ((3, 0), 2),
+    ((2, 0, 3), 1),
+    ((3, 1, 0), 2),
+    ((1, 3, 2), 0),
+    ((3, 2, 1, 0), 4),
+    ((4, 0, 3, 1), 2),
+]
+
+
+@pytest.mark.parametrize(("controls", "target"), QUBIT_LAYOUTS)
+@pytest.mark.parametrize(("factory_name", "factory"), GATE_FACTORIES)
+def test_decomposition_is_exact_for_arbitrary_qubit_layouts(
+    controls: tuple[int, ...], target: int, factory_name: str, factory
+) -> None:
+    """The recursion peels controls off the end of the tuple, so ordering and gaps must not matter."""
+    nqubits = max((*controls, target)) + 1
+    circuit = Circuit(nqubits)
+    circuit.add(Controlled(*controls, basic_gate=factory(target)))
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL), (
+        f"Exact unitary equality for {factory_name} on controls {controls} / target {target}"
+    )
+
+
+@pytest.mark.parametrize("ncontrols", CONTROL_COUNTS)
+def test_decomposition_acts_as_identity_unless_all_controls_are_set(ncontrols: int) -> None:
+    """Outside the all-controls-set subspace the decomposition must be exactly the identity, not a phase."""
+    nqubits = ncontrols + 1
+    circuit = Circuit(nqubits)
+    circuit.add(Controlled(*range(ncontrols), basic_gate=H(ncontrols)))
+
+    matrix = DecomposeMultiControlledGatesPass().run(circuit).to_matrix()
+
+    # Qubit 0 is the most significant bit, so the triggered subspace is the top 2 rows/columns.
+    triggered = [index for index in range(1 << nqubits) if index >> 1 == (1 << ncontrols) - 1]
+    untriggered = [index for index in range(1 << nqubits) if index not in triggered]
+    inactive_block = matrix[np.ix_(untriggered, untriggered)]
+
+    assert np.allclose(inactive_block, np.eye(len(untriggered)), atol=ATOL)
+    assert np.allclose(matrix[np.ix_(untriggered, triggered)], 0.0, atol=ATOL)
+    assert np.allclose(matrix[np.ix_(triggered, untriggered)], 0.0, atol=ATOL)
+    assert np.allclose(matrix[np.ix_(triggered, triggered)], H(0).matrix, atol=ATOL)
+
+
+def test_decomposition_of_a_full_circuit_with_several_multi_controlled_gates() -> None:
+    """Phases must stay consistent when several decompositions are composed in one circuit."""
+    circuit = Circuit(4)
+    circuit.add(H(0))
+    circuit.add(Controlled(0, 1, basic_gate=X(2)))
+    circuit.add(RZ(3, phi=math.pi / 3.0))
+    circuit.add(Controlled(0, 1, 2, basic_gate=U3(3, theta=0.7, phi=-1.1, gamma=2.3)))
+    circuit.add(Controlled(3, 2, basic_gate=Z(0)))
+    circuit.add(Controlled(1, basic_gate=Y(0)))
+    circuit.add(Controlled(2, 3, 0, basic_gate=T(1)))
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL)
+
+
+@pytest.mark.parametrize("ncontrols", CONTROL_COUNTS)
+def test_nested_controlled_gate_is_decomposed_exactly(ncontrols: int) -> None:
+    """`Controlled` flattens nested controls, so a nested build must decompose like a flat one."""
+    target = ncontrols
+    nested: Controlled = Controlled(0, basic_gate=X(target))
+    for control in range(1, ncontrols):
+        nested = Controlled(control, basic_gate=nested)
+
+    circuit = Circuit(ncontrols + 1)
+    circuit.add(nested)
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL)
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), GATE_FACTORIES)
+def test_pass_is_idempotent(factory_name: str, factory) -> None:
+    """A second run has nothing left to decompose and must not perturb the unitary."""
+    gate = _build_controlled_gate(factory, 3)
+    once = _run_pass_with_gate(gate, 4)
+    twice = DecomposeMultiControlledGatesPass().run(once)
+
+    assert len(twice.gates) == len(once.gates)
+    assert np.allclose(once.to_matrix(), twice.to_matrix(), atol=ATOL), f"Idempotence failed for {factory_name}"
+
+
+# ======================= structural guarantees of the output =======================
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+@pytest.mark.parametrize("ncontrols", CONTROL_COUNTS)
+def test_output_gates_have_at_most_one_control(factory_name: str, factory, ncontrols: int) -> None:
+    transpiled = _run_pass_with_gate(_build_controlled_gate(factory, ncontrols), ncontrols + 1)
+
+    assert transpiled.gates, f"No gates produced for {factory_name}"
+    for rewritten in transpiled.gates:
+        if isinstance(rewritten, Controlled):
+            assert len(rewritten.control_qubits) == 1, f"Leftover multi-control for {factory_name}"
+            assert not isinstance(rewritten.basic_gate, Controlled)
+
+
+@pytest.mark.parametrize(("controls", "target"), QUBIT_LAYOUTS)
+def test_output_gates_only_touch_the_original_qubits(controls: tuple[int, ...], target: int) -> None:
+    nqubits = max((*controls, target)) + 1
+    circuit = Circuit(nqubits)
+    circuit.add(Controlled(*controls, basic_gate=H(target)))
+
+    transpiled = DecomposeMultiControlledGatesPass().run(circuit)
+
+    allowed = {*controls, target}
+    for rewritten in transpiled.gates:
+        assert set(rewritten.qubits) <= allowed
+
+
+def test_output_preserves_circuit_width_and_surrounding_gates() -> None:
+    circuit = Circuit(5)
+    circuit.add(RZ(4, phi=0.3))
+    circuit.add(Controlled(0, 1, 2, basic_gate=X(3)))
+    circuit.add(H(4))
+
+    transpiled = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert transpiled.nqubits == circuit.nqubits
+    assert isinstance(transpiled.gates[0], RZ)
+    assert isinstance(transpiled.gates[-1], H)
+    assert np.allclose(circuit.to_matrix(), transpiled.to_matrix(), atol=ATOL)
+
+
+# ======================= _sqrt_of / _adjoint_of =======================
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+def test_sqrt_of_gate_squares_back_exactly(factory_name: str, factory) -> None:
+    gate = factory(0)
+    sqrt_gate, phase = _sqrt_of(gate)
+    square_root = np.exp(1j * phase) * sqrt_gate.matrix
+
+    assert np.allclose(gate.matrix, square_root @ square_root, atol=ATOL), f"Sqrt failed for {factory_name}"
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+def test_sqrt_of_gate_is_unitary_and_keeps_the_target_qubit(factory_name: str, factory) -> None:
+    gate = factory(2)
+    sqrt_gate, _ = _sqrt_of(gate)
+
+    assert sqrt_gate.qubits == (2,), f"Target qubit changed for {factory_name}"
+    assert np.allclose(sqrt_gate.matrix.conj().T @ sqrt_gate.matrix, np.eye(2), atol=ATOL)
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+def test_adjoint_of_gate_inverts_exactly(factory_name: str, factory) -> None:
+    gate = factory(0)
+    adjoint_gate, phase = _adjoint_of(gate)
+    inverse = np.exp(1j * phase) * adjoint_gate.matrix
+
+    assert np.allclose(inverse @ gate.matrix, np.eye(2), atol=ATOL), f"Adjoint failed for {factory_name}"
+    assert np.allclose(gate.matrix @ inverse, np.eye(2), atol=ATOL), f"Adjoint failed for {factory_name}"
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+def test_adjoint_of_sqrt_composes_to_the_gate_inverse(factory_name: str, factory) -> None:
+    """This is exactly the composition the recursion relies on: sqrt(U)† · sqrt(U)† = U†."""
+    gate = factory(0)
+    sqrt_gate, sqrt_phase = _sqrt_of(gate)
+    adjoint_gate, adjoint_phase = _adjoint_of(sqrt_gate)
+    inverse_square_root = np.exp(1j * (adjoint_phase - sqrt_phase)) * adjoint_gate.matrix
+
+    assert np.allclose(inverse_square_root @ inverse_square_root, gate.matrix.conj().T, atol=ATOL), (
+        f"sqrt adjoint composition failed for {factory_name}"
+    )
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), ALL_FACTORIES)
+def test_double_adjoint_returns_the_original_gate(factory_name: str, factory) -> None:
+    gate = factory(0)
+    adjoint_gate, phase = _adjoint_of(gate)
+    twice_adjoint_gate, twice_phase = _adjoint_of(adjoint_gate)
+
+    assert np.allclose(np.exp(1j * (twice_phase - phase)) * twice_adjoint_gate.matrix, gate.matrix, atol=ATOL), (
+        f"Double adjoint failed for {factory_name}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("gate", "expected_type", "expected_parameters"),
+    [
+        (Z(0), S, {}),
+        (S(0), T, {}),
+        (T(0), U1, {"phi": math.pi / 8.0}),
+        (U1(0, phi=math.pi / 3.0), U1, {"phi": math.pi / 6.0}),
+        (I(0), I, {}),
+        (RX(0, theta=1.2), RX, {"theta": 0.6}),
+        (RY(0, theta=1.2), RY, {"theta": 0.6}),
+        (RZ(0, phi=1.2), RZ, {"phi": 0.6}),
+    ],
+)
+def test_sqrt_of_uses_the_exact_gate_and_reports_no_residual_phase(
+    gate: BasicGate, expected_type: type[BasicGate], expected_parameters: dict[str, float]
+) -> None:
+    """Diagonal and rotation gates have exact square roots, so no phase correction should be emitted."""
+    sqrt_gate, phase = _sqrt_of(gate)
+
+    assert isinstance(sqrt_gate, expected_type)
+    assert phase == 0.0
+    for name, value in expected_parameters.items():
+        assert np.isclose(getattr(sqrt_gate, name), value)
+
+
+@pytest.mark.parametrize(
+    ("gate", "expected_type", "expected_parameters"),
+    [
+        (U1(0, phi=math.pi / 3.0), U1, {"phi": -math.pi / 3.0}),
+        (S(0), U1, {"phi": -math.pi / 2.0}),
+        (T(0), U1, {"phi": -math.pi / 4.0}),
+        (RX(0, theta=1.2), RX, {"theta": -1.2}),
+        (RY(0, theta=1.2), RY, {"theta": -1.2}),
+        (RZ(0, phi=1.2), RZ, {"phi": -1.2}),
+        (X(0), X, {}),
+        (Y(0), Y, {}),
+        (Z(0), Z, {}),
+        (H(0), H, {}),
+        (I(0), I, {}),
+        (U3(0, theta=0.4, phi=0.5, gamma=0.6), U3, {"theta": -0.4, "phi": -0.6, "gamma": -0.5}),
+    ],
+)
+def test_adjoint_of_uses_the_exact_gate_and_reports_no_residual_phase(
+    gate: BasicGate, expected_type: type[BasicGate], expected_parameters: dict[str, float]
+) -> None:
+    adjoint_gate, phase = _adjoint_of(gate)
+
+    assert isinstance(adjoint_gate, expected_type)
+    assert phase == 0.0
+    for name, value in expected_parameters.items():
+        assert np.isclose(getattr(adjoint_gate, name), value)
+
+
+@pytest.mark.parametrize(("factory_name", "factory"), [("X", X), ("Y", Y)])
+def test_sqrt_of_pauli_x_and_y_reports_the_quarter_turn_phase(factory_name: str, factory) -> None:
+    """sqrt(X) and sqrt(Y) are only RX(pi/2) / RY(pi/2) up to e^{i·pi/4}; that phase must be reported."""
+    sqrt_gate, phase = _sqrt_of(factory(0))
+
+    assert np.isclose(phase, math.pi / 4.0), f"Wrong residual phase for {factory_name}"
+    assert not np.allclose(sqrt_gate.matrix @ sqrt_gate.matrix, factory(0).matrix, atol=ATOL)
+
+
+def test_sqrt_of_u2_and_h_report_a_non_zero_phase() -> None:
+    """Gates routed through the generic U3 branch generally carry a residual phase; it must not be dropped."""
+    for gate in (H(0), U2(0, phi=math.pi / 6.0, gamma=math.pi / 5.0)):
+        sqrt_gate, phase = _sqrt_of(gate)
+        square_root = np.exp(1j * phase) * sqrt_gate.matrix
+        assert isinstance(sqrt_gate, U3)
+        assert not np.isclose(phase, 0.0)
+        assert np.allclose(square_root @ square_root, gate.matrix, atol=ATOL)
+
+
+# ======================= _phase_on_controls =======================
+
+
+@pytest.mark.parametrize("seed", range(40))
+def test_random_haar_controlled_gates_decompose_exactly(seed: int) -> None:
+    """Randomised sweep over Haar unitaries, control counts and qubit layouts, seeded for reproducibility."""
+    rng = np.random.default_rng(seed)
+    ncontrols = int(rng.integers(2, 5))
+    nqubits = ncontrols + 1 + int(rng.integers(0, 2))
+    qubits = [int(q) for q in rng.permutation(nqubits)]
+    controls, target = tuple(qubits[:ncontrols]), qubits[ncontrols]
+
+    circuit = Circuit(nqubits)
+    circuit.add(Controlled(*controls, basic_gate=_MatrixGate(target, _haar_unitary(1000 + seed))))
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL), (
+        f"Exact unitary equality failed for seed {seed} (controls {controls}, target {target})"
+    )
+
+
+@pytest.mark.parametrize("seed", range(40))
+def test_random_named_gate_circuits_decompose_exactly(seed: int) -> None:
+    """Randomised sweep over multi-gate circuits mixing controlled and plain gates at random angles."""
+    rng = np.random.default_rng(10_000 + seed)
+
+    def random_gate(qubit: int) -> BasicGate:
+        angles = [float(rng.uniform(-4.0 * math.pi, 4.0 * math.pi)) for _ in range(3)]
+        candidates = [
+            RX(qubit, theta=angles[0]),
+            RY(qubit, theta=angles[0]),
+            RZ(qubit, phi=angles[0]),
+            U1(qubit, phi=angles[0]),
+            U2(qubit, phi=angles[0], gamma=angles[1]),
+            U3(qubit, theta=angles[0], phi=angles[1], gamma=angles[2]),
+            [I, X, Y, Z, H, S, T][int(rng.integers(0, 7))](qubit),
+        ]
+        return candidates[int(rng.integers(0, len(candidates)))]
+
+    nqubits = int(rng.integers(3, 6))
+    circuit = Circuit(nqubits)
+    for _ in range(int(rng.integers(1, 5))):
+        qubits = [int(q) for q in rng.permutation(nqubits)]
+        ncontrols = int(rng.integers(1, nqubits))
+        circuit.add(Controlled(*qubits[:ncontrols], basic_gate=random_gate(qubits[ncontrols])))
+        circuit.add(random_gate(int(rng.integers(0, nqubits))))
+
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert np.allclose(circuit.to_matrix(), decomposed.to_matrix(), atol=ATOL), f"Failed for seed {seed}"
+
+
+def test_empty_circuit_is_returned_unchanged() -> None:
+    transpiled = DecomposeMultiControlledGatesPass().run(Circuit(3))
+
+    assert transpiled.nqubits == 3
+    assert transpiled.gates == []
+
+
+def test_measurement_gates_pass_through() -> None:
+    circuit = Circuit(3)
+    circuit.add(Controlled(0, 1, basic_gate=X(2)))
+    circuit.add(M(0, 1, 2))
+
+    transpiled = DecomposeMultiControlledGatesPass().run(circuit)
+
+    assert isinstance(transpiled.gates[-1], M)
+    assert sum(isinstance(gate, M) for gate in transpiled.gates) == 1
+
+
+# ======================= _phase_on_controls =======================
+
+
+@pytest.mark.parametrize("phase", [0.0, 2.0 * math.pi, -2.0 * math.pi, 4.0 * math.pi, 1e-15])
+def test_phase_on_controls_emits_nothing_for_a_trivial_phase(phase: float) -> None:
+    assert _phase_on_controls(phase, (0, 1, 2)) == []
+
+
+def test_phase_on_controls_with_a_single_control_is_a_bare_u1() -> None:
+    gates = _phase_on_controls(0.75, (3,))
+
+    assert len(gates) == 1
+    assert isinstance(gates[0], U1)
+    assert gates[0].qubits == (3,)
+    assert np.isclose(gates[0].phi, 0.75)
+
+
+@pytest.mark.parametrize("ncontrols", [1, 2, 3, 4])
+@pytest.mark.parametrize("phase", [0.75, math.pi, -math.pi / 3.0])
+def test_phase_on_controls_applies_the_phase_only_when_every_control_is_set(ncontrols: int, phase: float) -> None:
+    controls = tuple(range(ncontrols))
+    circuit = Circuit(ncontrols)
+    for gate in _phase_on_controls(phase, controls):
+        circuit.add(gate)
+
+    expected = np.eye(1 << ncontrols, dtype=complex)
+    expected[-1, -1] = np.exp(1j * phase)
+
+    assert np.allclose(circuit.to_matrix(), expected, atol=ATOL)
+    for gate in circuit.gates:
+        if isinstance(gate, Controlled):
+            assert len(gate.control_qubits) == 1
 
 
 @pytest.mark.parametrize(("factory_name", "factory"), GATE_FACTORIES)
@@ -109,6 +606,17 @@ def test_single_control_gate_is_not_modified(factory_name: str, factory) -> None
     assert isinstance(rewritten, Controlled)
     assert rewritten.control_qubits == gate.control_qubits
     assert rewritten.basic_gate.name == gate.basic_gate.name
+
+
+def test_toffoli_decomposition_has_no_spurious_relative_phase() -> None:
+    """Regression test for issue #339: the |11x> block used to pick up an extra -i."""
+    circuit = Circuit(3)
+    circuit.add(Controlled(0, 1, basic_gate=X(2)))
+
+    reference = circuit.to_matrix()
+    decomposed = DecomposeMultiControlledGatesPass().run(circuit).to_matrix()
+
+    assert np.allclose(reference, decomposed)
 
 
 def test_other_gates_remain_unchanged() -> None:
@@ -152,8 +660,9 @@ def test_zyz_unitary_errors():
 @pytest.mark.parametrize(("factory_name", "factory"), GATE_FACTORIES)
 def test_adjoint_of_gate(factory_name: str, factory) -> None:
     gate = factory(0)
-    adjoint_gate = _adjoint_of(gate)
-    assert _unitaries_equivalent(gate.matrix.conj().T, adjoint_gate.matrix), (
+    adjoint_gate, phase = _adjoint_of(gate)
+    # The reported phase must make the factorisation exact, not merely equal up to a global phase.
+    assert np.allclose(gate.matrix.conj().T, np.exp(1j * phase) * adjoint_gate.matrix), (
         f"Adjoint computation failed for {factory_name}"
     )
 
@@ -161,9 +670,10 @@ def test_adjoint_of_gate(factory_name: str, factory) -> None:
 @pytest.mark.parametrize(("factory_name", "factory"), GATE_FACTORIES)
 def test_sqrt_of_gate(factory_name: str, factory) -> None:
     gate = factory(0)
-    sqrt_gate = _sqrt_of(gate)
-    reconstructed = sqrt_gate.matrix @ sqrt_gate.matrix
-    assert _unitaries_equivalent(gate.matrix, reconstructed), f"Sqrt computation failed for {factory_name}"
+    sqrt_gate, phase = _sqrt_of(gate)
+    square_root = np.exp(1j * phase) * sqrt_gate.matrix
+    # V · V must reproduce the gate exactly; a leftover global phase becomes a relative phase under a control.
+    assert np.allclose(gate.matrix, square_root @ square_root), f"Sqrt computation failed for {factory_name}"
 
 
 def test_sqrt_of_gate_errors():
@@ -185,8 +695,8 @@ def test_adjoint_of_generic_gate():
     custom_gate.matrix = custom_matrix
     custom_gate.qubits = (0,)
     custom_gate.nqubits = 1
-    adjoint_gate = _adjoint_of(custom_gate)
-    assert _unitaries_equivalent(custom_matrix.conj().T, adjoint_gate.matrix), (
+    adjoint_gate, phase = _adjoint_of(custom_gate)
+    assert np.allclose(custom_matrix.conj().T, np.exp(1j * phase) * adjoint_gate.matrix), (
         "Adjoint computation failed for generic gate"
     )
 

--- a/tests/unit_python/digital/circuit_transpiler_passes/test_numeric_helpers.py
+++ b/tests/unit_python/digital/circuit_transpiler_passes/test_numeric_helpers.py
@@ -25,6 +25,8 @@ from qilisdk.digital.circuit_transpiler_passes.numeric_helpers import (
     _mat_RZ,
     _mat_U3,
     _round_float,
+    _u3_and_phase_from_unitary,
+    _unitary_sqrt_2x2,
 )
 from qilisdk.digital.gates import RX, RY, RZ, U3
 
@@ -62,3 +64,78 @@ def test_u3_matrix_helper_matches_gate_matrix() -> None:
     theta, phi, lam = (math.pi / 3.0, -math.pi / 4.0, math.pi / 7.0)
 
     assert np.allclose(_mat_U3(theta, phi, lam), U3(0, theta=theta, phi=phi, gamma=lam).matrix)
+
+
+@pytest.mark.parametrize(
+    ("name", "unitary"),
+    [
+        ("generic", np.exp(0.3j) * _mat_U3(math.pi / 3.0, -math.pi / 4.0, math.pi / 7.0)),
+        ("identity", np.eye(2, dtype=complex)),
+        ("diagonal", np.exp(0.7j) * np.diag([1.0, np.exp(1.1j)]).astype(complex)),
+        ("anti_diagonal", np.array([[0.0, np.exp(0.4j)], [np.exp(-1.2j), 0.0]], dtype=complex)),
+        ("hadamard", np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex) / math.sqrt(2.0)),
+    ],
+)
+def test_u3_and_phase_from_unitary_is_exact(name: str, unitary: np.ndarray) -> None:
+    theta, phi, gamma, alpha = _u3_and_phase_from_unitary(unitary)
+
+    reconstructed = np.exp(1j * alpha) * U3(0, theta=theta, phi=phi, gamma=gamma).matrix
+    assert np.allclose(unitary, reconstructed), f"Phased U3 reconstruction failed for {name}"
+
+
+def test_u3_and_phase_from_unitary_rejects_non_2x2() -> None:
+    with pytest.raises(ValueError, match="Expected 2x2 unitary"):
+        _u3_and_phase_from_unitary(np.ones((3, 2), dtype=complex))
+
+
+def test_u3_and_phase_from_unitary_rejects_singular() -> None:
+    with pytest.raises(ValueError, match="Matrix is singular"):
+        _u3_and_phase_from_unitary(np.array([[1, 0], [0, 0]], dtype=complex))
+
+
+def _haar_unitary(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    ginibre = rng.normal(size=(2, 2)) + 1j * rng.normal(size=(2, 2))
+    q, r = np.linalg.qr(ginibre)
+    return q * (np.diag(r) / np.abs(np.diag(r)))
+
+
+SQRT_INPUTS = [
+    ("identity", np.eye(2, dtype=complex)),
+    ("negative_identity", -np.eye(2, dtype=complex)),  # degenerate spectrum, trace == -2
+    ("phased_identity", np.exp(1.234j) * np.eye(2, dtype=complex)),
+    ("pauli_x", np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)),
+    ("pauli_y", np.array([[0.0, -1j], [1j, 0.0]], dtype=complex)),
+    ("pauli_z", np.diag([1.0, -1.0]).astype(complex)),
+    ("hadamard", np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex) / math.sqrt(2.0)),
+    ("rz_pi", _mat_RZ(math.pi)),
+    ("ry_two_pi", _mat_RY(2.0 * math.pi)),  # equals -I up to rounding
+    ("rx_two_pi", _mat_RX(2.0 * math.pi)),
+    ("u3_half_turn", _mat_U3(math.pi, math.pi / 3.0, -math.pi / 5.0)),
+    *[(f"haar_{seed}", _haar_unitary(seed)) for seed in range(8)],
+]
+
+
+@pytest.mark.parametrize(("name", "unitary"), SQRT_INPUTS)
+def test_unitary_sqrt_squares_back_to_the_input(name: str, unitary: np.ndarray) -> None:
+    root = _unitary_sqrt_2x2(unitary)
+
+    assert np.allclose(root @ root, unitary, atol=1e-9), f"Square root does not square back for {name}"
+
+
+@pytest.mark.parametrize(("name", "unitary"), SQRT_INPUTS)
+def test_unitary_sqrt_is_itself_unitary(name: str, unitary: np.ndarray) -> None:
+    """A non-unitary "square root" cannot be turned into a gate, even when it squares back correctly."""
+    root = _unitary_sqrt_2x2(unitary)
+
+    assert np.allclose(root.conj().T @ root, np.eye(2), atol=1e-9), f"Square root is not unitary for {name}"
+
+
+def test_unitary_sqrt_rejects_non_2x2() -> None:
+    with pytest.raises(ValueError, match="Expected 2x2 unitary"):
+        _unitary_sqrt_2x2(np.eye(3, dtype=complex))
+
+
+def test_unitary_sqrt_rejects_non_unitary() -> None:
+    with pytest.raises(ValueError, match="Expected a unitary matrix"):
+        _unitary_sqrt_2x2(np.array([[1.0, 2.0], [0.0, 1.0]], dtype=complex))


### PR DESCRIPTION
A bug has been fixed in which decomposed multi-controlled gates produced a wrong unitary, specifically that since it used the square root of certain gates to build the decomposition, so phases were incorrectly ignored.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/339