### PR TITLE
Marginalizing Sampling Probabilities 

### DIFF
--- a/changes/395.bugfix.md
+++ b/changes/395.bugfix.md
@@ -1,0 +1,1 @@
+`SamplingReadoutResult.probabilities` now correctly marginalizes as `SamplingReadoutResult.samples` does for circuits with partial measurements. Previously `.probabilities` would return the raw distribution without any post-processing, i.e. returning `{"00": 0.5, "11": 0.5}` rather than `{"0_": 0.5, "1_": 0.5}` for a Bell state with a single measurement on the first qubit.

--- a/src/qilisdk/readout/readout_result.py
+++ b/src/qilisdk/readout/readout_result.py
@@ -18,7 +18,7 @@ import heapq
 import operator
 from dataclasses import dataclass
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Generic, Never, Protocol, Self, TypeGuard, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Never, Protocol, Self, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
 from loguru import logger
@@ -31,6 +31,8 @@ from qilisdk.yaml import yaml
 from .readout import ExpectationReadout, ReadoutMethod, SamplingReadout, StateTomographyReadout
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from qilisdk.core.types import Number
 
 
@@ -102,20 +104,26 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
 
     @staticmethod
     def _filter_samples(
-        samples_to_filter: dict[str, int], qubits_to_measure: list[int], expand_samples: bool = True
-    ) -> dict[str, int]:
+        samples_to_filter: Mapping[str, int | float], qubits_to_measure: list[int], expand_samples: bool = True
+    ) -> dict[str, Any]:
         """
         Filter the input samples to include only the requested qubits.
 
+        Values of bitstrings that only differ on unmeasured qubits are accumulated, so counts (or probabilities) are
+        marginalized over the qubits that were not measured.
+
+        Note that this can either be counts or probabilities as the values, the operation is the same,
+        we just sum based on the keys.
+
         Args:
-            samples_to_filter (dict[str, int]): The original samples to be filtered.
+            samples_to_filter (dict[str, int | float]): The original samples to be filtered.
             qubits_to_measure (list[int]): The list of qubit indices that were measured.
             expand_samples (bool): Whether to include placeholders for unmeasured qubits in the filtered results.
 
         Returns:
-            dict[str, int]: The filtered samples containing only the requested qubits.
+            dict[str, int | float]: The filtered samples containing only the requested qubits.
         """
-        filtered_samples: dict[str, int] = {}
+        filtered_samples: dict[str, int | float] = {}
         for bitstring, count in samples_to_filter.items():
             if expand_samples:
                 filtered_bitstring = "".join(
@@ -128,20 +136,23 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
 
     @staticmethod
     def _expand_samples(
-        samples_to_expand: dict[str, int], qubits_to_measure: list[int], nqubits_total: int
-    ) -> dict[str, int]:
+        samples_to_expand: Mapping[str, int | float], qubits_to_measure: list[int], nqubits_total: int
+    ) -> dict[str, Any]:
         """
         Expand the input samples to include placeholders for unmeasured qubits.
 
+        Note that this can either be counts or probabilities as the values, the operation is the same,
+        we just sum based on the keys.
+
         Args:
-            samples_to_expand (dict[str, int]): The original samples to be expanded.
+            samples_to_expand (dict[str, int | float]): The original samples to be expanded.
             qubits_to_measure (list[int]): The list of qubit indices that were measured.
             nqubits_total (int): The total number of qubits in the system.
 
         Returns:
-            dict[str, int]: The expanded samples containing placeholders for unmeasured qubits.
+            dict[str, int | float]: The expanded samples containing placeholders for unmeasured qubits.
         """
-        expanded_samples: dict[str, int] = {}
+        expanded_samples: dict[str, int | float] = {}
         for bitstring, count in samples_to_expand.items():
             bitstring_remaining = bitstring
             expanded_bitstring = ""
@@ -157,11 +168,11 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
     @classmethod
     def _adjust_samples(
         cls,
-        samples_to_filter: dict[str, int],
+        samples_to_filter: Mapping[str, int | float],
         qubits_to_measure: list[int],
         nqubits: int | None = None,
         expand_samples: bool = True,
-    ) -> dict[str, int]:
+    ) -> dict[str, Any]:
         """
         Adjust the input samples to match the requested qubits to measure and total number of qubits.
 
@@ -171,14 +182,17 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
         - If the input samples have more qubits than requested, it filters out the unmeasured qubits.
         - If the input samples have fewer qubits than requested, it expands them by adding placeholders for the unmeasured qubits.
 
+        Note that this can either be counts or probabilities as the values, the operation is the same,
+        we just sum based on the keys.
+
         Args:
-            samples_to_filter (dict[str, int]): The original samples to be adjusted.
+            samples_to_filter (dict[str, int | float]): The original samples to be adjusted.
             qubits_to_measure (list[int]): The list of qubit indices that were measured.
             nqubits (int | None): The total number of qubits in the system.
             expand_samples (bool): Whether to expand samples with placeholders for unmeasured qubits.
 
         Returns:
-            dict[str, int]: The adjusted samples matching the requested qubits and total number of qubits.
+            dict[str, int | float]: The adjusted samples matching the requested qubits and total number of qubits.
         """
         if len(samples_to_filter) >= 1:
             nqubits_samples = len(next(iter(samples_to_filter.keys())))
@@ -189,7 +203,7 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
             # Assuming 3 qubits, if asked for 0 and 1 and we have xx, return xx_
             if nqubits_samples < nqubits_total and expand_samples:
                 return cls._expand_samples(samples_to_filter, qubits_to_measure, nqubits_total)
-        return samples_to_filter
+        return cast("dict[str, Any]", samples_to_filter)
 
     @classmethod
     def from_samples(
@@ -235,12 +249,12 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
 
         expand_samples = expand_samples if expand_samples is not None else True
 
-        # Calculate probabilities
+        # Adjust the samples first so the probabilities are marginalized over the unmeasured qubits
+        if qubits_to_measure is not None:
+            samples = cls._adjust_samples(samples, qubits_to_measure, nqubits_total, expand_samples=expand_samples)
         probabilities: dict[str, float] = {
             bitstring: (counts / nshots if nshots and nshots > 0 else 0.0) for bitstring, counts in samples.items()
         }
-        if qubits_to_measure is not None:
-            samples = cls._adjust_samples(samples, qubits_to_measure, nqubits_total, expand_samples=expand_samples)
         return cls(samples=samples, probabilities=probabilities)
 
     @classmethod
@@ -256,6 +270,9 @@ class SamplingReadoutResult(ReadoutResult[SamplingReadout]):
         samples: dict[str, int] = _samples_from_probabilities(probabilities, nshots=sampling_readout.nshots)
         if qubits_to_measure is not None:
             samples = cls._adjust_samples(samples, qubits_to_measure, state.nqubits, expand_samples=expand_samples)
+            probabilities = cls._adjust_samples(
+                probabilities, qubits_to_measure, state.nqubits, expand_samples=expand_samples
+            )
         return cls(samples=samples, probabilities=probabilities)
 
     def __init__(self, samples: dict[str, int], probabilities: dict[str, float] | None = None) -> None:

--- a/tests/unit_python/readout/test_readout_result.py
+++ b/tests/unit_python/readout/test_readout_result.py
@@ -567,6 +567,48 @@ def test_expand_samples_no_expand():
     assert result.samples == {"0": 60, "1": 40}
 
 
+def test_probabilities_share_keys_with_samples_on_partial_measurement():
+    result = SamplingReadoutResult.from_samples(samples={"000": 40, "010": 60}, qubits_to_measure=[0, 1], nqubits=3)
+    assert result.samples == {"00_": 40, "01_": 60}
+    assert result.probabilities == {"00_": 0.4, "01_": 0.6}
+    assert result.get_probability("00_") == pytest.approx(0.4)
+    assert result.get_probability("01_") == pytest.approx(0.6)
+
+
+def test_probabilities_marginalize_over_unmeasured_qubits():
+    # "000" and "001" only differ on the unmeasured qubit 2, so their counts and probabilities are summed.
+    result = SamplingReadoutResult.from_samples(
+        samples={"000": 30, "001": 10, "010": 60}, qubits_to_measure=[0, 1], nqubits=3
+    )
+    assert result.samples == {"00_": 40, "01_": 60}
+    assert result.probabilities == {"00_": 0.4, "01_": 0.6}
+
+
+def test_probabilities_share_keys_with_already_filtered_samples():
+    # The C++ backends hand over keys that are already filtered to the measured qubits.
+    result = SamplingReadoutResult.from_samples(samples={"01": 55, "11": 45}, qubits_to_measure=[0, 1], nqubits=3)
+    assert result.samples == {"01_": 55, "11_": 45}
+    assert result.probabilities == {"01_": 0.55, "11_": 0.45}
+
+
+def test_probabilities_share_keys_with_samples_no_expand():
+    result = SamplingReadoutResult.from_samples(
+        samples={"000": 40, "010": 60}, qubits_to_measure=[0, 1], nqubits=3, expand_samples=False
+    )
+    assert result.samples == {"00": 40, "01": 60}
+    assert result.probabilities == {"00": 0.4, "01": 0.6}
+
+
+def test_from_state_probabilities_share_keys_with_samples():
+    readout = SamplingReadout(nshots=100)
+    state = (ket(0, 1) + ket(1, 1) + ket(1, 0)).normalized()
+    result = SamplingReadoutResult.from_state(sampling_readout=readout, state=state, qubits_to_measure=[0])
+    assert set(result.samples) == {"0_", "1_"}
+    # Marginalized exactly from the state: |01> for qubit 0 == 0, |10> + |11> for qubit 0 == 1.
+    assert result.probabilities == pytest.approx({"0_": 1 / 3, "1_": 2 / 3})
+    assert result.get_probability("1_") == pytest.approx(2 / 3)
+
+
 def test_filter_empty_samples():
     # need to create an object that "is obj" is True, but behaves like an empty dict for the methods used in from_samples
     samples_dict = MagicMock()


### PR DESCRIPTION
`SamplingReadoutResult.probabilities` now correctly marginalizes as `SamplingReadoutResult.samples` does for circuits with partial measurements. Previously `.probabilities` would return the raw distribution without any post-processing, i.e. returning `{"00": 0.5, "11": 0.5}` rather than `{"0_": 0.5, "1_": 0.5}` for a Bell state with a single measurement on the first qubit.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/391