### PR TITLE
Trim the CI matrices and gate on aggregate checks

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,9 +15,6 @@ concurrency:
   group: code-quality-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     name: Lint
@@ -47,7 +44,7 @@ jobs:
       # code, so linting needs neither the extension built nor the dependencies.
       - name: Install the linters
         run: |
-          uv sync --frozen --only-group dev --no-install-project
+          uv sync --frozen --only-group dev --no-install-project --no-build
           echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
@@ -80,6 +77,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -119,6 +119,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
 
     steps:
       - name: Check the results

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -11,22 +11,23 @@ on:
       - "synchronize"
       - "ready_for_review"
 
+concurrency:
+  group: code-quality-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
-  code-quality:
-    name: Code Quality for Python ${{ matrix.python-version }}
+  lint:
+    name: Lint
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    env:
-      HOME_REPO: /home/repo
-
-    strategy:
-      matrix:
-        python-version:
-          - "3.11"
-          - "3.12"
-          - "3.13"
+    permissions:
+      contents: read
+      pull-requests: write  # cpp-linter posts its report as a PR comment
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -40,13 +41,13 @@ jobs:
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
 
-      - name: Install the project
+      # Ruff takes its target version from pyproject.toml and never imports the
+      # code, so linting needs neither the extension built nor the dependencies.
+      - name: Install the linters
         run: |
-          uv sync --frozen --group dev --extra all-cu13 \
-            -Ccmake.build-type=Debug \
-            -Ccmake.define.CMAKE_CXX_FLAGS_DEBUG=-O0
+          uv sync --frozen --only-group dev --no-install-project
           echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
@@ -55,9 +56,6 @@ jobs:
 
       - name: Format
         run: ruff format --diff --output-format=github .
-
-      - name: Type Checking
-        run: ty check --output-format=github
 
       - name: Cpp Linter
         uses: cpp-linter/cpp-linter-action@cab1143a2c149bc41e85b070a9de81716974c18f  # v2.21.0
@@ -68,3 +66,61 @@ jobs:
           style: 'file'
           tidy-checks: ''
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+
+      # clang-tidy has no compile database here, so it reports missing system
+      # headers as errors and cannot gate anything. Formatting can, and does.
+      - name: Check formatting
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: |
+          echo "::error::clang-format wants to reformat some of the changed files, see the Cpp Linter step"
+          exit 1
+
+  types:
+    name: Types
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+          python-version: "3.13"
+
+      - name: Install the project
+        run: |
+          uv sync --frozen --group dev --extra all-cu13 \
+            -Ccmake.build-type=Debug \
+            -Ccmake.define.CMAKE_CXX_FLAGS_DEBUG=-O0
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      # ty resolves the standard library for the version it is told to assume, so
+      # one environment covers every version we support.
+      - name: Type Checking
+        run: |
+          for version in 3.11 3.12 3.13; do
+            echo "::group::ty check --python-version $version"
+            ty check --output-format=github --python-version "$version"
+            echo "::endgroup::"
+          done
+
+  code-quality:
+    name: Code Quality
+    needs: [lint, types]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check the results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/platform_builds.yml
+++ b/.github/workflows/platform_builds.yml
@@ -11,18 +11,34 @@ on:
       - "synchronize"
       - "ready_for_review"
 
+concurrency:
+  group: platform-builds-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   smoke-build:
     name: Build & Smoke for Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
     strategy:
       fail-fast: false
       matrix:
+        # What breaks a build here is the toolchain, not the Python version:
+        # pybind11 covers the C API differences and no Python code branches on the
+        # version. So a PR builds every OS on the newest version plus the floor on
+        # Linux, and main builds the full set. Release wheels are covered by
+        # cibuildwheel in publish.yml.
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
-        python-version:
-          - "3.11"
-          - "3.12"
-          - "3.13"
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.13"]') }}
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -37,6 +53,8 @@ jobs:
             **/uv.lock
           python-version: ${{ matrix.python-version }}
 
+      # No extras, so this is also the only place we check that the core install
+      # works on its own. Tests always install everything.
       - name: Install qilisdk
         shell: bash
         run: |
@@ -54,3 +72,15 @@ jobs:
         run: |
           python -c "import qilisdk; print('QiliSDK imported successfully')"
           python -c "from qilisdk.backends import QiliSim; print('QiliSim imported successfully')"
+
+  platform-builds:
+    name: Platform Builds
+    needs: [smoke-build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check the results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/platform_builds.yml
+++ b/.github/workflows/platform_builds.yml
@@ -15,15 +15,15 @@ concurrency:
   group: platform-builds-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   smoke-build:
     name: Build & Smoke for Python ${{ matrix.python-version }} on ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -79,6 +79,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
 
     steps:
       - name: Check the results

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,14 +27,12 @@ concurrency:
   group: publish-${{ github.event.release.tag_name || github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-
 jobs:
   # Fails in seconds on a bad dispatch, instead of after the wheel builds.
   check-inputs:
     name: Check inputs
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check the repository input
         if: ${{ (inputs.platform || 'pypi') == 'aws' && !inputs.repository }}
@@ -46,6 +44,8 @@ jobs:
     name: Build wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: [check-inputs]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -82,6 +82,8 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     needs: [check-inputs]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,25 @@ concurrency:
   group: publish-${{ github.event.release.tag_name || github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
+  # Fails in seconds on a bad dispatch, instead of after the wheel builds.
+  check-inputs:
+    name: Check inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the repository input
+        if: ${{ (inputs.platform || 'pypi') == 'aws' && !inputs.repository }}
+        run: |
+          echo "::error::Publishing to aws needs a CodeArtifact repository. Re-run with the repository input set."
+          exit 1
+
   build-wheels:
     name: Build wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: [check-inputs]
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +65,11 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }}
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          # Import the repaired wheel, which is the artifact users get. Nothing
+          # else in CI loads it, so this is where a bad delvewheel repair or a
+          # broken rpath shows up. Cross-compiled macOS wheels cannot run here.
+          CIBW_TEST_COMMAND: 'python -c "import qilisdk; from qilisdk.backends import QiliSim"'
+          CIBW_TEST_SKIP: "*-macosx_x86_64"
         with:
           output-dir: dist
       - name: Upload wheels
@@ -61,6 +81,7 @@ jobs:
   build-sdist:
     name: Build sdist
     runs-on: ubuntu-latest
+    needs: [check-inputs]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -134,11 +155,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Check the repository input
-        if: ${{ !inputs.repository }}
-        run: |
-          echo "::error::Publishing to aws needs a CodeArtifact repository. Re-run with the repository input set."
-          exit 1
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -9,8 +9,6 @@ jobs:
   deploy-documentation: 
     name: Deploying Documentation
     runs-on: ubuntu-latest
-    env:
-      HOME_REPO: /home/repo
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ concurrency:
   group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Testing for Python ${{ matrix.python-version }}
@@ -22,18 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    env:
-      HOME_REPO: /home/repo
-
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - python-version: "3.11"
-            coverage: false
-          - python-version: "3.12"
-            coverage: false
-          - python-version: "3.13"
-            coverage: true
+        # Nothing in src/ branches on the Python version, so a PR runs the oldest
+        # and the newest version we support and main fills in the middle. 3.13
+        # is the one that carries coverage and the C++ suite.
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.11", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -50,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install qilisdk with coverage
-        if: matrix.coverage
+        if: matrix.python-version == '3.13'
         run: |
           uv sync --frozen --group dev --extra all-cu13 --reinstall-package qilisdk \
             -Ccmake.build-type=Debug \
@@ -61,7 +59,7 @@ jobs:
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Install qilisdk
-        if: ${{ !matrix.coverage }}
+        if: matrix.python-version != '3.13'
         run: |
           uv sync --frozen --group dev --extra all-cu13 --reinstall-package qilisdk \
             -Ccmake.build-type=Release
@@ -69,25 +67,25 @@ jobs:
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run Python tests
-        if: ${{ !matrix.coverage }}
+        if: matrix.python-version != '3.13'
         run: pytest -n auto tests/unit_python/
 
       - name: Run Python tests with coverage
-        if: matrix.coverage
+        if: matrix.python-version == '3.13'
         run: pytest -n auto --cov=qilisdk --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy tests/unit_python/
 
       - name: Run C++ tests
-        if: matrix.coverage
+        if: matrix.python-version == '3.13'
         run: |
           GCOV_PREFIX=$(pwd)/tests/unit_cpp/coverage GCOV_PREFIX_STRIP=5 ./tests/unit_cpp/test_cpp
           gcovr --exclude '.*googletest.*' --exclude '/usr/.*' --gcov-ignore-errors=all --exclude-unreachable-branches --exclude-throw-branches --xml coverage_cpp.xml
 
       - name: Combine coverage reports
-        if: matrix.coverage
+        if: matrix.python-version == '3.13'
         run: gcovr --gcov-ignore-errors=all --xml combined_coverage.xml --cobertura-add-tracefile coverage.xml --cobertura-add-tracefile coverage_cpp.xml
 
       - name: Upload coverage to Codecov
-        if: matrix.coverage
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: combined_coverage.xml
@@ -95,7 +93,19 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.coverage }}
+        if: ${{ !cancelled() && matrix.python-version == '3.13' }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  all-tests:
+    name: Tests
+    needs: [tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check the results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,10 @@ concurrency:
   group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # The version that carries coverage and the C++ suite.
+  COVERAGE_PYTHON: "3.13"
+
 jobs:
   tests:
     name: Testing for Python ${{ matrix.python-version }}
@@ -29,8 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         # Nothing in src/ branches on the Python version, so a PR runs the oldest
-        # and the newest version we support and main fills in the middle. 3.13
-        # is the one that carries coverage and the C++ suite.
+        # and the newest version we support and main fills in the middle.
         python-version: ${{ github.event_name == 'push' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.11", "3.13"]') }}
 
     steps:
@@ -48,7 +51,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install qilisdk with coverage
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == env.COVERAGE_PYTHON
         run: |
           uv sync --frozen --group dev --extra all-cu13 --reinstall-package qilisdk \
             -Ccmake.build-type=Debug \
@@ -59,7 +62,7 @@ jobs:
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Install qilisdk
-        if: matrix.python-version != '3.13'
+        if: matrix.python-version != env.COVERAGE_PYTHON
         run: |
           uv sync --frozen --group dev --extra all-cu13 --reinstall-package qilisdk \
             -Ccmake.build-type=Release
@@ -67,25 +70,25 @@ jobs:
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run Python tests
-        if: matrix.python-version != '3.13'
+        if: matrix.python-version != env.COVERAGE_PYTHON
         run: pytest -n auto tests/unit_python/
 
       - name: Run Python tests with coverage
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == env.COVERAGE_PYTHON
         run: pytest -n auto --cov=qilisdk --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy tests/unit_python/
 
       - name: Run C++ tests
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == env.COVERAGE_PYTHON
         run: |
           GCOV_PREFIX=$(pwd)/tests/unit_cpp/coverage GCOV_PREFIX_STRIP=5 ./tests/unit_cpp/test_cpp
           gcovr --exclude '.*googletest.*' --exclude '/usr/.*' --gcov-ignore-errors=all --exclude-unreachable-branches --exclude-throw-branches --xml coverage_cpp.xml
 
       - name: Combine coverage reports
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == env.COVERAGE_PYTHON
         run: gcovr --gcov-ignore-errors=all --xml combined_coverage.xml --cobertura-add-tracefile coverage.xml --cobertura-add-tracefile coverage_cpp.xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == env.COVERAGE_PYTHON
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: combined_coverage.xml
@@ -93,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.python-version == '3.13' }}
+        if: ${{ !cancelled() && matrix.python-version == env.COVERAGE_PYTHON }}
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,15 @@ concurrency:
   group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 jobs:
   tests:
     name: Testing for Python ${{ matrix.python-version }}
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -104,6 +104,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
 
     steps:
       - name: Check the results

--- a/changes/404.misc.md
+++ b/changes/404.misc.md
@@ -1,0 +1,1 @@
+Trimmed the CI matrices, gated each workflow on a single aggregate check, and made clang-format failures and unimportable wheels fail the build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,6 @@ exclude = ["tests"]
 [tool.ruff]
 line-length = 120
 output-format = "concise"
-target-version = "py313"
 
 [tool.ruff.lint]
 preview = true


### PR DESCRIPTION
Closes #403.

A PR used to start 18 jobs and about 44 minutes of runner time, almost all of it the same C++ build repeated. Each workflow now ends in one aggregate gate job, so the ruleset can require `Code Quality`, `Tests` and `Platform Builds` instead of naming every matrix leg. Code Quality is split into a lint job that installs no project and a type job that runs `ty` once per supported version in a single environment, Tests and Platform Builds run the oldest and newest Python on PRs and the full set on main, and the ruff target version now comes from `requires-python` so 3.12-only syntax cannot pass lint. clang-format failures now fail the job, which they never did. On the publish side the wheels get imported before upload and a bad CodeArtifact input fails up front instead of after the builds. Nine jobs on a PR instead of eighteen.

The ruleset needs its required checks switched to the three gate names when this merges, and open PRs will need a rebase to report them.
