### PR TITLE
OpenQASM fixes

### DIFF
--- a/changes/456.bugfix.md
+++ b/changes/456.bugfix.md
@@ -1,0 +1,5 @@
+A number of small bugs have been fixed with the OpenQASM 2 and 3 conversion routines:
+
+ - Registers are no longer assumed to be called "c" and "q" in OpenQASM 2 code.
+ - Adjoints are now handled correctly, specifically that they no longer use the unicode dagger symbol which caused problems on reimport.
+ - All supported gates now survive a round-trip.

--- a/src/qilisdk/utils/openqasm/openqasm2.py
+++ b/src/qilisdk/utils/openqasm/openqasm2.py
@@ -83,7 +83,7 @@ _REVERSE_QASM2_ADJOINT_MAP: dict[str, type[BasicGate]] = {name: gate for gate, n
 _QASM2_TOFFOLI_NQUBITS = 3
 
 # A valid OpenQASM 2.0 gate name, which every gate name is checked against before being written out.
-_QASM2_GATE_NAME = re.compile(r"[a-z][A-Za-z0-9_]*")
+_QASM2_GATE_NAME = re.compile(r"[a-z]\w*", re.ASCII)
 
 _ALLOWED_QASM2_FUNCTIONS = {
     "sin": math.sin,
@@ -202,8 +202,6 @@ def _parse_qasm2_gate_line(line: str) -> tuple[str, str | None, str] | None:
                     raise ValueError(f"Parameter expression nesting deeper than {_MAX_DEPTH} levels is not supported.")
             elif char == ")":
                 depth -= 1
-                if depth < 0:
-                    raise ValueError(f"Invalid gate syntax: {line}")
                 if depth == 0:
                     closing_index = index
                     break

--- a/src/qilisdk/utils/openqasm/openqasm2.py
+++ b/src/qilisdk/utils/openqasm/openqasm2.py
@@ -20,9 +20,32 @@ from loguru import logger
 
 from qilisdk.digital.circuit import Circuit
 from qilisdk.digital.exceptions import UnsupportedGateError
-from qilisdk.digital.gates import CNOT, CZ, RX, RY, RZ, U1, U2, U3, Gate, H, M, S, T, X, Y, Z
+from qilisdk.digital.gates import (
+    CNOT,
+    CZ,
+    RX,
+    RY,
+    RZ,
+    SWAP,
+    U1,
+    U2,
+    U3,
+    Adjoint,
+    BasicGate,
+    Controlled,
+    Gate,
+    H,
+    I,
+    M,
+    S,
+    T,
+    X,
+    Y,
+    Z,
+)
 
 OPENQASM2_MAP: dict[type[Gate], str] = {
+    I: "id",
     X: "x",
     Y: "y",
     Z: "z",
@@ -37,7 +60,30 @@ OPENQASM2_MAP: dict[type[Gate], str] = {
     U3: "u3",
     CNOT: "cx",
     CZ: "cz",
+    SWAP: "swap",
 }
+
+# Gate names accepted on import on top of those in OPENQASM2_MAP, here the identity as QiliSDK used to export it.
+_QASM2_IMPORT_ALIASES: dict[str, type[Gate]] = {"i": I}
+
+# OpenQASM 2.0 has no inverse modifier, so the adjoint of these gates is written under a dedicated name instead.
+_QASM2_ADJOINT_MAP: dict[type[BasicGate], str] = {S: "sdg", T: "tdg"}
+
+# Gates that are their own adjoint, and so are written out unchanged.
+_QASM2_SELF_ADJOINT: frozenset[type[Gate]] = frozenset({I, X, Y, Z, H, CNOT, CZ, SWAP})
+
+# Gates whose adjoint is the same gate with every parameter negated.
+_QASM2_NEGATED_ADJOINT: frozenset[type[Gate]] = frozenset({RX, RY, RZ, U1})
+
+# Lookups from an OpenQASM 2.0 gate name to the gate, or to the gate whose adjoint it is.
+_REVERSE_QASM2_MAP: dict[str, type[Gate]] = {name: gate for gate, name in OPENQASM2_MAP.items()} | _QASM2_IMPORT_ALIASES
+_REVERSE_QASM2_ADJOINT_MAP: dict[str, type[BasicGate]] = {name: gate for gate, name in _QASM2_ADJOINT_MAP.items()}
+
+# The Toffoli gate is the only gate acting on more than two qubits that is supported.
+_QASM2_TOFFOLI_NQUBITS = 3
+
+# A valid OpenQASM 2.0 gate name, which every gate name is checked against before being written out.
+_QASM2_GATE_NAME = re.compile(r"[a-z][A-Za-z0-9_]*")
 
 _ALLOWED_QASM2_FUNCTIONS = {
     "sin": math.sin,
@@ -120,6 +166,7 @@ def _evaluate_qasm2_ast(node: ast.AST, original_expr: str) -> float:
 
 def _parse_qasm2_gate_line(line: str) -> tuple[str, str | None, str] | None:
     """Parse a QASM gate line with bounded parenthesis nesting.
+
     Returns:
         tuple[str, str | None, str] | None: the gate name, the string representing the parameter if available, and the rest.
 
@@ -137,8 +184,13 @@ def _parse_qasm2_gate_line(line: str) -> tuple[str, str | None, str] | None:
     if name_match is None:
         return None
     gate_name = name_match.group(1)
-    rest = body[name_match.end() :].strip()
 
+    # Anything other than a parameter list or a separator after the name means the name itself is malformed.
+    separator = body[name_match.end() : name_match.end() + 1]
+    if separator not in {"", "(", " ", "\t"}:
+        raise ValueError(f"Invalid gate name in: {line}")
+
+    rest = body[name_match.end() :].strip()
     params_str = None
     if rest.startswith("("):
         depth = 0
@@ -167,12 +219,55 @@ def _parse_qasm2_gate_line(line: str) -> tuple[str, str | None, str] | None:
     return gate_name, params_str, rest
 
 
+def _qasm2_name_and_parameters(gate: Gate) -> tuple[str, list[float]]:
+    """Resolve the OpenQASM 2.0 name and parameters of a gate.
+
+    OpenQASM 2.0 has no inverse modifier, so the adjoint of a gate has to be expressed as another gate instead.
+
+    Args:
+        gate: the gate to export.
+
+    Raises:
+        UnsupportedGateError: if the gate cannot be expressed in OpenQASM 2.0.
+
+    Returns:
+        tuple[str, list[float]]: the OpenQASM 2.0 gate name, and the parameters to export it with.
+    """
+    if isinstance(gate, Adjoint):
+        inner = gate.basic_gate
+        inner_type = type(inner)
+        if isinstance(inner, Adjoint):
+            # The adjoint of an adjoint is the gate itself.
+            return _qasm2_name_and_parameters(inner.basic_gate)
+        if inner_type in _QASM2_ADJOINT_MAP:
+            return _QASM2_ADJOINT_MAP[inner_type], []
+        if inner_type in _QASM2_SELF_ADJOINT:
+            return OPENQASM2_MAP[inner_type], []
+        if inner_type in _QASM2_NEGATED_ADJOINT:
+            return OPENQASM2_MAP[inner_type], [-value for value in inner.get_parameter_values()]
+        if inner_type is U3:
+            theta, phi, gamma = inner.get_parameter_values()
+            return "u3", [-theta, -gamma, -phi]
+        if inner_type is U2:
+            phi, gamma = inner.get_parameter_values()
+            return "u3", [-math.pi / 2, -gamma, -phi]
+        raise UnsupportedGateError(f"Cannot express the adjoint of the {inner.name} gate in OpenQASM 2.0.")
+
+    name = OPENQASM2_MAP.get(type(gate), gate.name.lower())
+    if _QASM2_GATE_NAME.fullmatch(name) is None:
+        raise UnsupportedGateError(f"Cannot express the {gate.name} gate in OpenQASM 2.0.")
+    return name, gate.get_parameter_values() if gate.is_parameterized else []
+
+
 def to_qasm2(circuit: Circuit) -> str:
     """
     Convert the circuit to an OpenQASM 2.0 formatted string.
 
     Args:
         circuit: The circuit to convert to OpenQASM 2.0.
+
+    Raises:
+        UnsupportedGateError: If a gate of the circuit cannot be expressed in OpenQASM 2.0.
 
     Returns:
         str: The OpenQASM 2.0 representation of the circuit.
@@ -200,14 +295,15 @@ def to_qasm2(circuit: Circuit) -> str:
                 qasm_lines.extend(measurements)
         else:
             # Map the internal gate name to its QASM equivalent.
-            qasm_name = OPENQASM2_MAP.get(type(gate), gate.name.lower())
+            qasm_name, parameters = _qasm2_name_and_parameters(gate)
             # Format parameter string, if any.
-            param_str = ""
-            if gate.is_parameterized:
-                parameters = ", ".join(str(p) for p in gate.get_parameter_values())
-                param_str = f"({parameters})"
+            param_str = f"({', '.join(str(p) for p in parameters)})" if parameters else ""
+            # An adjoint does not expose the control qubits of the gate it wraps, so take the qubits from that gate.
+            gate_to_export = gate
+            while isinstance(gate_to_export, Adjoint):
+                gate_to_export = gate_to_export.basic_gate
             # Format qubit operands.
-            qubit_str = ", ".join(f"q[{q}]" for q in gate.qubits)
+            qubit_str = ", ".join(f"q[{q}]" for q in gate_to_export.qubits)
             qasm_lines.append(f"{qasm_name}{param_str} {qubit_str};")
 
     return "\n".join(qasm_lines)
@@ -232,10 +328,13 @@ def from_qasm2(qasm_str: str) -> Circuit:
     Parse an OpenQASM 2.0 string and create a corresponding Circuit instance.
 
     This parser supports the following instructions:
-        - Quantum register declaration (e.g., "qreg q[3];")
-        - Classical register declaration (ignored)
-        - Gate instructions (one-qubit and two-qubit gates)
+        - Quantum register declaration (e.g., "qreg q[3];"), of which there may be only one
+        - Classical register declaration (e.g., "creg c[3];")
+        - Gate instructions (one-qubit and two-qubit gates, plus the three-qubit "ccx" gate)
         - Measurement instructions (e.g., "measure q[0] -> c[0];")
+
+    The registers may be given any name, and any instruction that refers to a register that was never declared
+    raises rather than being skipped.
 
     Args:
         qasm_str (str): The QASM string to parse.
@@ -244,10 +343,9 @@ def from_qasm2(qasm_str: str) -> Circuit:
         Circuit: The constructed Circuit object.
     """  # ruff: ignore[docstring-missing-exception]
     logger.info("[OpenQASM2] Importing circuit from OpenQASM 2.0")
-    # Mapping from QASM gate names (lowercase) to internal gate names.
-    reverse_qasm2_map = {v: k for k, v in OPENQASM2_MAP.items()}
-
     circuit = None
+    qreg_name = ""
+    creg_names: set[str] = set()
     lines = qasm_str.splitlines()
     logger.debug("[OpenQASM2] Parsing {} lines of OpenQASM 2.0", len(lines))
     for raw_line in lines:
@@ -257,79 +355,94 @@ def from_qasm2(qasm_str: str) -> Circuit:
             line = line.split("//", 1)[0].strip()
         if not line or line.startswith("//"):
             continue
+
         # Skip header and include lines.
         if line.startswith(("OPENQASM", "include")):
             continue
+
         # Parse quantum register declaration.
         if line.startswith("qreg"):
             # e.g., "qreg q[3];"
-            m = re.match(r"qreg\s+\w+\[(\d+)\];", line)
+            m = re.match(r"qreg\s+(\w+)\s*\[(\d+)\]\s*;", line)
             if m:
-                nqubits = int(m.group(1))
-                circuit = Circuit(nqubits)
+                if circuit is not None:
+                    raise ValueError("Only a single quantum register is supported.")
+                qreg_name = m.group(1)
+                circuit = Circuit(int(m.group(2)))
             continue
-        # Skip classical register declaration.
+
+        # Parse classical register declaration, whose name is needed to recognise measurements.
         if line.startswith("creg"):
+            # e.g., "creg c[3];"
+            m = re.match(r"creg\s+(\w+)\s*\[\d+\]\s*;", line)
+            if m:
+                creg_names.add(m.group(1))
             continue
+
         # Process measurement instructions.
         if line.startswith("measure"):
+            if circuit is None:
+                raise ValueError("Quantum register must be declared before measurement.")
             # e.g., "measure q[0] -> c[0];"
-            m = re.match(r"measure\s+q\[(\d+)\]\s*->\s*c\[\d+\];", line)
-            if m:
+            m = re.fullmatch(r"measure\s+(\w+)\s*\[(\d+)\]\s*->\s*(\w+)\s*\[\d+\]\s*;", line)
+            if m is not None:
                 # TODO(vyron): Check consecutive lines of measurement and combine into single M.
-                q_index = int(m.group(1))
-                if circuit is None:
-                    raise ValueError("Quantum register must be declared before measurement.")
-                circuit.add(M(q_index))
+                quantum_name, classical_name, measured = m.group(1), m.group(3), (int(m.group(2)),)
             else:
-                # Special case: "measure q -> c;" means measure all qubits
-                m_all = re.match(r"measure\s+q\s*->\s*c\s*;", line)
-                if m_all:
-                    if circuit is None:
-                        raise ValueError("Quantum register must be declared before measurement.")
-                    circuit.add(M(*list(range(circuit.nqubits))))
+                # Special case: "measure q -> c;" means measure all qubits.
+                m = re.fullmatch(r"measure\s+(\w+)\s*->\s*(\w+)\s*;", line)
+                if m is None:
+                    raise ValueError(f"Invalid measurement instruction: {line}")
+                quantum_name, classical_name, measured = m.group(1), m.group(2), tuple(range(circuit.nqubits))
+            if quantum_name != qreg_name:
+                raise ValueError(f"Undeclared quantum register '{quantum_name}' in measurement: {line}")
+            if classical_name not in creg_names:
+                raise ValueError(f"Undeclared classical register '{classical_name}' in measurement: {line}")
+            circuit.add(M(*measured))
             continue
+
         # Process gate instructions.
         gate_data = _parse_qasm2_gate_line(line)
         if gate_data:
             qasm_gate_name, params_str, operands_str = gate_data
+            if circuit is None:
+                raise ValueError("Quantum register must be declared before adding gates.")
+            gate_name = qasm_gate_name.lower()
 
-            # Convert QASM gate name to internal gate name.
-            gate_class = reverse_qasm2_map.get(qasm_gate_name.lower())
-            if gate_class is None:
-                raise UnsupportedGateError(f"Unknown gate: {qasm_gate_name}")
-
-            # Extract qubit indices.
-            qubit_matches = re.findall(r"q\[(\d+)\]", operands_str)
-            qubits = [int(q) for q in qubit_matches]
+            # Extract qubit indices, which have to belong to the declared quantum register.
+            qubits = [int(index) for index in re.findall(rf"{re.escape(qreg_name)}\s*\[(\d+)\]", operands_str)]
+            if not qubits:
+                raise ValueError(f"Gate operands do not refer to the quantum register '{qreg_name}': {line}")
 
             # Parse parameters, if any.
             parameters = []
             if params_str:
                 parameters = [_evaluate_qasm2_expression(p) for p in params_str.split(",") if p.strip()]
 
-            # Instantiate the gate based on the number of qubits.
-            # For one-qubit gates.
-            if len(qubits) == 1:
-                if gate_class.PARAMETER_NAMES:
-                    # Build a dictionary of parameter names to values.
-                    param_dict = {name: parameters[i] for i, name in enumerate(gate_class.PARAMETER_NAMES)}
-                    gate_instance = gate_class(qubits[0], **param_dict)  # ty: ignore[too-many-positional-arguments]
-                else:
-                    gate_instance = gate_class(qubits[0])  # ty: ignore[too-many-positional-arguments]
-            # For two-qubit gates.
-            elif len(qubits) == 2:  # ruff: ignore[magic-value-comparison]
-                if gate_class.PARAMETER_NAMES:
-                    param_dict = {name: parameters[i] for i, name in enumerate(gate_class.PARAMETER_NAMES)}
-                    gate_instance = gate_class(qubits[0], qubits[1], **param_dict)  # ty: ignore[too-many-positional-arguments]
-                else:
-                    gate_instance = gate_class(qubits[0], qubits[1])  # ty: ignore[too-many-positional-arguments]
-            else:
+            # The Toffoli gate is the only supported gate acting on more than two qubits.
+            if gate_name == "ccx":
+                if len(qubits) != _QASM2_TOFFOLI_NQUBITS:
+                    raise UnsupportedGateError(f"The ccx gate acts on three qubits, got {len(qubits)}.")
+                circuit.add(Controlled(qubits[0], qubits[1], basic_gate=X(qubits[2])))
+                continue
+            if len(qubits) not in {1, 2}:
                 raise UnsupportedGateError("Only one- and two-qubit gates are supported.")
 
-            if circuit is None:
-                raise ValueError("Quantum register must be declared before adding gates.")
-            circuit.add(gate_instance)
+            # Gates that OpenQASM 2.0 names in place of an inverse modifier, such as "sdg" for the adjoint of S.
+            adjoint_of = _REVERSE_QASM2_ADJOINT_MAP.get(gate_name)
+            if adjoint_of is not None:
+                circuit.add(Adjoint(adjoint_of(qubits[0])))  # ty: ignore[invalid-argument-type]
+                continue
+
+            # Convert QASM gate name to internal gate name.
+            gate_class = _REVERSE_QASM2_MAP.get(gate_name)
+            if gate_class is None:
+                raise UnsupportedGateError(f"Unknown gate: {qasm_gate_name}")
+
+            # Build a dictionary of parameter names to values.
+            param_dict = {name: parameters[i] for i, name in enumerate(gate_class.PARAMETER_NAMES)}
+            circuit.add(gate_class(*qubits, **param_dict))
+
     if circuit is None:
         raise ValueError("No quantum register declaration found in QASM.")
     logger.debug("[OpenQASM2] Imported circuit with {} qubits and {} gates", circuit.nqubits, len(circuit.gates))

--- a/src/qilisdk/utils/openqasm/openqasm3.py
+++ b/src/qilisdk/utils/openqasm/openqasm3.py
@@ -103,7 +103,7 @@ _QASM3_CNOT_NQUBITS = 2
 _QASM3_CONTROL_MODIFIERS = frozenset({"ctrl", "negctrl"})
 
 # A valid OpenQASM 3.0 gate name, which every gate name is checked against before being written out.
-_QASM3_GATE_NAME = re.compile(r"[A-Za-z][A-Za-z0-9_]*")
+_QASM3_GATE_NAME = re.compile(r"[A-Za-z]\w*", re.ASCII)
 
 
 class OpenQasmParser:

--- a/src/qilisdk/utils/openqasm/openqasm3.py
+++ b/src/qilisdk/utils/openqasm/openqasm3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
+import re
 from copy import copy
 from pathlib import Path
 from typing import Any
@@ -65,7 +66,44 @@ from openqasm3.ast import (
 from openqasm3.parser import parse
 
 from qilisdk.core import Parameter
-from qilisdk.digital import CNOT, CZ, RX, RY, RZ, U1, U2, U3, Adjoint, Circuit, Controlled, Gate, H, M, S, T, X, Y, Z
+from qilisdk.digital import (
+    CNOT,
+    CZ,
+    RX,
+    RY,
+    RZ,
+    SWAP,
+    U1,
+    U2,
+    U3,
+    Adjoint,
+    Circuit,
+    Controlled,
+    Gate,
+    H,
+    I,
+    M,
+    S,
+    T,
+    X,
+    Y,
+    Z,
+)
+from qilisdk.digital.exceptions import UnsupportedGateError
+
+# Gates whose OpenQASM 3.0 name is not simply their lowercased QiliSDK name.
+_OPENQASM3_NAMES: dict[type[Gate], str] = {I: "id"}
+
+# The names of the OpenQASM 3.0 gates that act on more than one qubit and are not built from modifiers.
+_QASM3_TOFFOLI_NAMES = frozenset({"ccx", "toffoli"})
+_QASM3_CNOT_NAMES = frozenset({"cx", "cnot"})
+_QASM3_CNOT_NQUBITS = 2
+
+# The modifiers that add a control qubit to a gate.
+_QASM3_CONTROL_MODIFIERS = frozenset({"ctrl", "negctrl"})
+
+# A valid OpenQASM 3.0 gate name, which every gate name is checked against before being written out.
+_QASM3_GATE_NAME = re.compile(r"[A-Za-z][A-Za-z0-9_]*")
 
 
 class OpenQasmParser:
@@ -556,6 +594,12 @@ class OpenQasmParser:
 
     @staticmethod
     def _str_to_gate(gate_name: str, qubit: int, arguments: list[float]) -> Gate:
+        if gate_name in {"id", "i"}:
+            return I(qubit)
+        if gate_name == "sdg":
+            return Adjoint(S(qubit))
+        if gate_name == "tdg":
+            return Adjoint(T(qubit))
         if gate_name == "x":
             return X(qubit)
         if gate_name == "y":
@@ -587,48 +631,52 @@ class OpenQasmParser:
     ) -> list[Gate]:
         # Process the gate info
         gate_name = gate_name.lower()
-        gates_to_return = []
-        num_controls_total = 0
-        for modifier in modifiers:
-            if modifier in {"ctrl", "negctrl"}:
-                num_controls_total += 1
-        qubits_without_controls = qubits[num_controls_total:]
+        num_controls = sum(1 for modifier in modifiers if modifier in _QASM3_CONTROL_MODIFIERS)
+        targets = qubits[num_controls:]
 
-        # The gate itself
-        if gate_name == "cx" or (gate_name == "x" and "ctrl" in modifiers):
-            gates_to_return.append(CNOT(*qubits))
+        # The gate itself, which is broadcast over each of its target qubits if it is a one-qubit gate
+        if gate_name == "x" and "ctrl" in modifiers and len(qubits) == _QASM3_CNOT_NQUBITS:
+            # A single controlled X is a CNOT, which absorbs the control modifier
+            main_gates: list[Gate] = [CNOT(*qubits)]
             modifiers = [modifier for modifier in modifiers if modifier != "ctrl"]
+        elif gate_name in _QASM3_CNOT_NAMES:
+            main_gates = [CNOT(*targets)]
         elif gate_name == "cz":
-            gates_to_return.append(CZ(*qubits))
-            modifiers = [modifier for modifier in modifiers if modifier != "ctrl"]
+            main_gates = [CZ(*targets)]
+        elif gate_name == "swap":
+            main_gates = [SWAP(*targets)]
+        elif gate_name in _QASM3_TOFFOLI_NAMES:
+            main_gates = [Controlled(targets[0], targets[1], basic_gate=X(targets[2]))]
         else:
-            for qubit in qubits_without_controls:
-                gates_to_return.append(self._str_to_gate(gate_name, qubit, arguments))
+            main_gates = [self._str_to_gate(gate_name, qubit, arguments) for qubit in targets]
+
+        # Each control modifier controls on the next of the leading qubits, wherever it sits among the modifiers
+        controls_left = iter(qubits)
+        control_qubits = [next(controls_left) if modifier in _QASM3_CONTROL_MODIFIERS else -1 for modifier in modifiers]
 
         # Apply modifiers if we have them
-        main_gates = copy(gates_to_return)
         gates_to_return = []
-        for j in range(len(main_gates)):
-            main_gate = main_gates[j]
+        for main_gate in main_gates:
+            modified_gate = main_gate
             gates_to_prepend = []
             gates_to_append = []
             num_repeats = 1
             for i in range(len(modifiers) - 1, -1, -1):
                 if modifiers[i] == "ctrl":
-                    main_gate = Controlled(qubits[i], basic_gate=main_gate)  # ty:ignore[invalid-argument-type]
+                    modified_gate = Controlled(control_qubits[i], basic_gate=modified_gate)  # ty:ignore[invalid-argument-type]
                 elif modifiers[i] == "negctrl":
-                    main_gate = Controlled(qubits[i], basic_gate=main_gate)  # ty:ignore[invalid-argument-type]
-                    gates_to_prepend.append(X(qubits[i]))
-                    gates_to_append.append(X(qubits[i]))
+                    modified_gate = Controlled(control_qubits[i], basic_gate=modified_gate)  # ty:ignore[invalid-argument-type]
+                    gates_to_prepend.append(X(control_qubits[i]))
+                    gates_to_append.append(X(control_qubits[i]))
                 elif modifiers[i] == "inv":
-                    main_gate = Adjoint(main_gate)  # ty:ignore[invalid-argument-type]
+                    modified_gate = Adjoint(modified_gate)  # ty:ignore[invalid-argument-type]
                 elif modifiers[i] == "pow":
                     num_repeats += 1
                 else:
                     raise ValueError(f"Unsupported gate modifier: {modifiers[i]}")  # pragma: no cover
             for _ in range(num_repeats):
                 gates_to_return.extend(gates_to_prepend)
-                gates_to_return.append(main_gate)
+                gates_to_return.append(modified_gate)
                 gates_to_return.extend(gates_to_append)
 
         return gates_to_return
@@ -1159,6 +1207,17 @@ class OpenQasmParser:
 
     @staticmethod
     def to_qasm3(circuit: Circuit) -> str:
+        """Convert a Circuit object to its OpenQASM 3.0 string representation.
+
+        Args:
+            circuit: The Circuit object to convert.
+
+        Raises:
+            UnsupportedGateError: If a gate of the circuit cannot be expressed in OpenQASM 3.0.
+
+        Returns:
+            str: The OpenQASM 3.0 representation of the circuit.
+        """
         logger.info("[OpenQASM3] Exporting circuit to OpenQASM 3.0")
         logger.debug("[OpenQASM3] Exporting {} gates on {} qubits", len(circuit.gates), circuit.nqubits)
         qasm3 = "OPENQASM 3.0;\n"
@@ -1167,20 +1226,31 @@ class OpenQasmParser:
             qasm3 += f"qubit[{circuit.nqubits}] q;\n"
         for gate in circuit.gates:
             logger.trace("[OpenQASM3] Exporting gate {} on qubits {}", gate.name, gate.qubits)
-            qasm_gate_name = gate.name.lower()
-            if gate.name == "CNOT":
-                qasm_gate_name = "x"
+            if isinstance(gate, M):
+                qasm3 += "measure q[" + ",".join([str(qb) for qb in gate.qubits]) + "];\n"
+                continue
+            # Controls and adjoints are written out as OpenQASM 3.0 modifiers on the gate they wrap
+            base_gate: Gate = gate
+            modifiers: list[str] = []
+            control_qubits: tuple[int, ...] = ()
+            while isinstance(base_gate, (Controlled, Adjoint)):
+                if isinstance(base_gate, Controlled):
+                    # A Controlled gate holds the control qubits of the gate it wraps as well as its own
+                    num_own_controls = len(base_gate.control_qubits) - len(base_gate.basic_gate.control_qubits)
+                    modifiers.extend(["ctrl @"] * num_own_controls)
+                    control_qubits += base_gate.control_qubits[:num_own_controls]
+                else:
+                    modifiers.append("inv @")
+                base_gate = base_gate.basic_gate
+            qasm_gate_name = _OPENQASM3_NAMES.get(type(base_gate), base_gate.name.lower())
+            if _QASM3_GATE_NAME.fullmatch(qasm_gate_name) is None:
+                raise UnsupportedGateError(f"Cannot express the {gate.name} gate in OpenQASM 3.0.")
             qasm_parameter_str = ""
-            if gate.is_parameterized:
-                qasm_parameter_str = "(" + ", ".join([str(param) for param in gate.get_parameter_values()]) + ")"
-            qasm_control_str = "".join(["ctrl @ " for _ in gate.control_qubits])
-            qasm_qubits_str = ", ".join([f"q[{qb}]" for qb in gate.qubits])
-            if gate.name == "M":
-                qasm_gate_name = "measure"
-                qasm_qubits_str = "q[" + ",".join([str(qb) for qb in gate.qubits]) + "]"
-            qasm_gate_string = f"{qasm_control_str}{qasm_gate_name}{qasm_parameter_str} {qasm_qubits_str}"
-            qasm_gate_string = qasm_gate_string.strip()
-            qasm3 += f"{qasm_gate_string};\n"
+            if base_gate.is_parameterized:
+                qasm_parameter_str = "(" + ", ".join([str(param) for param in base_gate.get_parameter_values()]) + ")"
+            qasm_modifier_str = "".join([f"{modifier} " for modifier in modifiers])
+            qasm_qubits_str = ", ".join([f"q[{qb}]" for qb in control_qubits + base_gate.qubits])
+            qasm3 += f"{qasm_modifier_str}{qasm_gate_name}{qasm_parameter_str} {qasm_qubits_str};\n"
         return qasm3.strip()
 
 

--- a/tests/unit_python/utils/test_openqasm2.py
+++ b/tests/unit_python/utils/test_openqasm2.py
@@ -17,11 +17,33 @@
 import math
 import re
 
+import numpy as np
 import pytest
 
 from qilisdk.digital.circuit import Circuit
 from qilisdk.digital.exceptions import UnsupportedGateError
-from qilisdk.digital.gates import CNOT, CZ, RX, RY, RZ, U1, U2, U3, H, M, S, T, X, Y, Z
+from qilisdk.digital.gates import (
+    CNOT,
+    CZ,
+    RX,
+    RY,
+    RZ,
+    SWAP,
+    U1,
+    U2,
+    U3,
+    Adjoint,
+    Controlled,
+    Exponential,
+    H,
+    I,
+    M,
+    S,
+    T,
+    X,
+    Y,
+    Z,
+)
 from qilisdk.utils.openqasm import from_qasm2, from_qasm2_file, to_qasm2, to_qasm2_file
 from qilisdk.utils.openqasm import openqasm2 as openqasm2_utils
 
@@ -467,3 +489,215 @@ def test_parse_qasm2_gate_line_branches():
 
     with pytest.raises(ValueError, match="Unclosed parameter expression"):
         openqasm2_utils._parse_qasm2_gate_line("rx(pi/2 q[0];")
+
+
+# --- Register names other than "q" and "c" (SDK-455) ---
+def test_from_qasm2_honours_custom_register_names():
+    """Measurements of registers not named "q" and "c" must be imported, not silently dropped."""
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            'include "qelib1.inc";',
+            "qreg qubits[2];",
+            "creg meas[2];",
+            "h qubits[0];",
+            "measure qubits[0] -> meas[0];",
+            "measure qubits[1] -> meas[1];",
+        ]
+    )
+    circuit = from_qasm2(qasm_str)
+    assert circuit.nqubits == 2
+    assert [gate.name for gate in circuit.gates] == ["H", "M", "M"]
+    assert circuit.gates[1].qubits == (0,)
+    assert circuit.gates[2].qubits == (1,)
+
+
+def test_from_qasm2_honours_custom_register_names_when_measuring_everything():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg qubits[2];",
+            "creg meas[2];",
+            "measure qubits -> meas;",
+        ]
+    )
+    circuit = from_qasm2(qasm_str)
+    assert [gate.name for gate in circuit.gates] == ["M"]
+    assert circuit.gates[0].qubits == (0, 1)
+
+
+def test_from_qasm2_rejects_undeclared_quantum_register_in_measurement():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg q[1];",
+            "creg c[1];",
+            "measure other[0] -> c[0];",
+        ]
+    )
+    with pytest.raises(ValueError, match="Undeclared quantum register 'other'"):
+        from_qasm2(qasm_str)
+
+
+def test_from_qasm2_rejects_undeclared_classical_register_in_measurement():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg q[1];",
+            "creg c[1];",
+            "measure q[0] -> other[0];",
+        ]
+    )
+    with pytest.raises(ValueError, match="Undeclared classical register 'other'"):
+        from_qasm2(qasm_str)
+
+
+def test_from_qasm2_rejects_malformed_measurement():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg q[1];",
+            "creg c[1];",
+            "measure q[0];",
+        ]
+    )
+    with pytest.raises(ValueError, match="Invalid measurement instruction"):
+        from_qasm2(qasm_str)
+
+
+def test_from_qasm2_rejects_gate_on_undeclared_register():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg q[1];",
+            "h other[0];",
+        ]
+    )
+    with pytest.raises(ValueError, match="do not refer to the quantum register 'q'"):
+        from_qasm2(qasm_str)
+
+
+def test_from_qasm2_rejects_a_second_quantum_register():
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg a[1];",
+            "qreg b[1];",
+        ]
+    )
+    with pytest.raises(ValueError, match="Only a single quantum register is supported"):
+        from_qasm2(qasm_str)
+
+
+# --- Adjoint gates, which OpenQASM 2.0 has no inverse modifier for (SDK-455) ---
+@pytest.mark.parametrize(
+    ("gate", "expected_line"),
+    [
+        (Adjoint(S(0)), "sdg q[0];"),
+        (Adjoint(T(0)), "tdg q[0];"),
+        (Adjoint(H(0)), "h q[0];"),
+        (Adjoint(I(0)), "id q[0];"),
+        (Adjoint(SWAP(0, 1)), "swap q[0], q[1];"),
+        (Adjoint(CNOT(0, 1)), "cx q[0], q[1];"),
+        (Adjoint(CZ(0, 1)), "cz q[0], q[1];"),
+        (Adjoint(Adjoint(S(0))), "s q[0];"),
+        (Adjoint(RX(0, theta=0.5)), "rx(-0.5) q[0];"),
+        (Adjoint(RZ(0, phi=0.5)), "rz(-0.5) q[0];"),
+        (Adjoint(U1(0, phi=0.5)), "u1(-0.5) q[0];"),
+        (Adjoint(U3(0, theta=0.1, phi=0.2, gamma=0.3)), "u3(-0.1, -0.3, -0.2) q[0];"),
+        (Adjoint(U2(0, phi=0.2, gamma=0.3)), f"u3({-math.pi / 2}, -0.3, -0.2) q[0];"),
+    ],
+)
+def test_to_qasm2_never_exports_an_adjoint_dagger(gate, expected_line):
+    """The unicode dagger of an adjoint gate name is not valid OpenQASM 2.0 and must never be written out."""
+    circuit = Circuit(2)
+    circuit.add(gate)
+    qasm_str = to_qasm2(circuit)
+    assert "†" not in qasm_str
+    assert qasm_str.splitlines()[-1] == expected_line
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        Adjoint(S(0)),
+        Adjoint(T(0)),
+        Adjoint(RX(0, theta=0.5)),
+        Adjoint(U3(0, theta=0.1, phi=0.2, gamma=0.3)),
+        Adjoint(U2(0, phi=0.2, gamma=0.3)),
+        Adjoint(CNOT(0, 1)),
+    ],
+)
+def test_qasm2_round_trip_preserves_an_adjoint_matrix(gate):
+    """An adjoint gate must come back as the same unitary, rather than as the gate it is the adjoint of."""
+    circuit = Circuit(2)
+    circuit.add(gate)
+    reconstructed = from_qasm2(to_qasm2(circuit))
+    assert len(reconstructed.gates) == 1
+    assert np.allclose(reconstructed.gates[0].matrix, gate.matrix)
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        Adjoint(Controlled(0, basic_gate=H(1))),
+        Controlled(0, basic_gate=Adjoint(S(1))),
+        Exponential(X(0)),
+    ],
+)
+def test_to_qasm2_raises_on_gates_it_cannot_name(gate):
+    circuit = Circuit(2)
+    circuit.add(gate)
+    with pytest.raises(UnsupportedGateError, match="Cannot express"):
+        to_qasm2(circuit)
+
+
+def test_from_qasm2_rejects_an_unparseable_gate_name():
+    """A dagger written by an older QiliSDK must not be silently truncated to the gate it is the adjoint of."""
+    qasm_str = "\n".join(
+        [
+            "OPENQASM 2.0;",
+            "qreg q[1];",
+            "s† q[0];",
+        ]
+    )
+    with pytest.raises(ValueError, match="Invalid gate name"):
+        from_qasm2(qasm_str)
+
+
+@pytest.mark.parametrize(("qasm_name", "gate"), [("sdg", S(0)), ("tdg", T(0))])
+def test_from_qasm2_reads_dagger_gate_names(qasm_name, gate):
+    circuit = from_qasm2("\n".join(["OPENQASM 2.0;", "qreg q[1];", f"{qasm_name} q[0];"]))
+    assert len(circuit.gates) == 1
+    assert np.allclose(circuit.gates[0].matrix, Adjoint(gate).matrix)
+
+
+# --- Gates of our own that could not be re-imported (SDK-455) ---
+@pytest.mark.parametrize(
+    ("gate", "expected_line"),
+    [
+        (I(0), "id q[0];"),
+        (SWAP(0, 1), "swap q[0], q[1];"),
+        (Controlled(1, basic_gate=Controlled(2, basic_gate=X(0))), "ccx q[1], q[2], q[0];"),
+    ],
+)
+def test_qasm2_round_trip_of_our_own_gates(gate, expected_line):
+    circuit = Circuit(3)
+    circuit.add(gate)
+    qasm_str = to_qasm2(circuit)
+    assert qasm_str.splitlines()[-1] == expected_line
+    reconstructed = from_qasm2(qasm_str)
+    assert len(reconstructed.gates) == 1
+    assert reconstructed.gates[0].name == gate.name
+    assert reconstructed.gates[0].qubits == gate.qubits
+
+
+def test_from_qasm2_still_reads_the_identity_written_as_i():
+    circuit = from_qasm2("\n".join(["OPENQASM 2.0;", "qreg q[1];", "i q[0];"]))
+    assert [gate.name for gate in circuit.gates] == ["I"]
+
+
+def test_from_qasm2_rejects_a_toffoli_on_the_wrong_number_of_qubits():
+    qasm_str = "\n".join(["OPENQASM 2.0;", "qreg q[2];", "ccx q[0], q[1];"])
+    with pytest.raises(UnsupportedGateError, match="acts on three qubits, got 2"):
+        from_qasm2(qasm_str)

--- a/tests/unit_python/utils/test_openqasm3.py
+++ b/tests/unit_python/utils/test_openqasm3.py
@@ -17,10 +17,34 @@ import math
 import pathlib
 import tempfile
 
+import numpy as np
 import pytest
 
 from qilisdk.core import Parameter
-from qilisdk.digital import CNOT, CZ, RX, RY, RZ, U1, U2, U3, Adjoint, Circuit, Controlled, H, M, S, T, X, Y, Z
+from qilisdk.digital import (
+    CNOT,
+    CZ,
+    RX,
+    RY,
+    RZ,
+    SWAP,
+    U1,
+    U2,
+    U3,
+    Adjoint,
+    Circuit,
+    Controlled,
+    Exponential,
+    H,
+    I,
+    M,
+    S,
+    T,
+    X,
+    Y,
+    Z,
+)
+from qilisdk.digital.exceptions import UnsupportedGateError
 from qilisdk.utils.openqasm import from_qasm3, from_qasm3_file, to_qasm3, to_qasm3_file
 
 
@@ -1933,3 +1957,158 @@ def test_not_iterable_loop():
                 x q[0];
             }
         """)
+
+
+# --- Adjoint gates, which must be written out as the "inv @" modifier (SDK-455) ---
+@pytest.mark.parametrize(
+    ("gate", "expected_line"),
+    [
+        (Adjoint(S(0)), "inv @ s q[0];"),
+        (Adjoint(T(0)), "inv @ t q[0];"),
+        (Adjoint(Adjoint(H(0))), "inv @ inv @ h q[0];"),
+        (Adjoint(RX(0, theta=0.5)), "inv @ rx(0.5) q[0];"),
+        (Adjoint(CNOT(0, 1)), "inv @ ctrl @ x q[0], q[1];"),
+        (Controlled(0, basic_gate=Adjoint(S(1))), "ctrl @ inv @ s q[0], q[1];"),
+    ],
+)
+def test_to_qasm3_never_exports_an_adjoint_dagger(gate, expected_line):
+    """The unicode dagger of an adjoint gate name is not valid OpenQASM 3.0 and must never be written out."""
+    circuit = Circuit(2)
+    circuit.add(gate)
+    qasm_str = to_qasm3(circuit)
+    assert "†" not in qasm_str
+    assert qasm_str.splitlines()[-1] == expected_line
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [
+        Adjoint(S(0)),
+        Adjoint(T(0)),
+        Adjoint(Adjoint(H(0))),
+        Adjoint(RX(0, theta=0.5)),
+        Adjoint(CNOT(0, 1)),
+        Controlled(0, basic_gate=Adjoint(S(1))),
+    ],
+)
+def test_qasm3_round_trip_preserves_an_adjoint_matrix(gate):
+    """An adjoint gate must come back as the same unitary, rather than as the gate it is the adjoint of."""
+    circuit = Circuit(2)
+    circuit.add(gate)
+    reconstructed = from_qasm3(to_qasm3(circuit))
+    assert len(reconstructed.gates) == 1
+    assert np.allclose(reconstructed.gates[0].matrix, gate.matrix)
+
+
+def test_to_qasm3_raises_on_gates_it_cannot_name():
+    circuit = Circuit(1)
+    circuit.add(Exponential(X(0)))
+    with pytest.raises(UnsupportedGateError, match="Cannot express"):
+        to_qasm3(circuit)
+
+
+@pytest.mark.parametrize("qasm_name", ["sdg", "tdg"])
+def test_from_qasm3_reads_dagger_gate_names(qasm_name):
+    c = from_qasm3(f"""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[1] q;
+            {qasm_name} q[0];
+        """)
+    expected = Circuit(1)
+    expected.add(Adjoint(S(0)) if qasm_name == "sdg" else Adjoint(T(0)))
+    assert c == expected
+
+
+# --- Gates of our own that could not be re-imported (SDK-455) ---
+@pytest.mark.parametrize(
+    ("gate", "expected_line"),
+    [
+        (I(0), "id q[0];"),
+        (SWAP(0, 1), "swap q[0], q[1];"),
+        (CNOT(0, 1), "ctrl @ x q[0], q[1];"),
+        (CZ(0, 1), "ctrl @ z q[0], q[1];"),
+        (Controlled(1, basic_gate=Controlled(2, basic_gate=X(0))), "ctrl @ ctrl @ x q[1], q[2], q[0];"),
+    ],
+)
+def test_qasm3_round_trip_of_our_own_gates(gate, expected_line):
+    """A controlled gate must not count its controls twice, so that it can be read back in."""
+    circuit = Circuit(3)
+    circuit.add(gate)
+    qasm_str = to_qasm3(circuit)
+    assert qasm_str.splitlines()[-1] == expected_line
+    reconstructed = from_qasm3(qasm_str)
+    assert len(reconstructed.gates) == 1
+    assert reconstructed.gates[0].name == gate.name
+    assert reconstructed.gates[0].qubits == gate.qubits
+    assert np.allclose(reconstructed.gates[0].matrix, gate.matrix)
+
+
+@pytest.mark.parametrize("qasm_name", ["ccx", "toffoli"])
+def test_from_qasm3_reads_a_toffoli_by_name(qasm_name):
+    c = from_qasm3(f"""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[3] q;
+            {qasm_name} q[0], q[1], q[2];
+        """)
+    expected = Circuit(3)
+    expected.add(Controlled(0, 1, basic_gate=X(2)))
+    assert c == expected
+
+
+@pytest.mark.parametrize("qasm_name", ["cx", "cnot"])
+def test_from_qasm3_reads_a_cnot_by_name(qasm_name):
+    c = from_qasm3(f"""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[2] q;
+            {qasm_name} q[0], q[1];
+        """)
+    expected = Circuit(2)
+    expected.add(CNOT(0, 1))
+    assert c == expected
+
+
+@pytest.mark.parametrize("qasm_name", ["id", "i"])
+def test_from_qasm3_reads_the_identity(qasm_name):
+    c = from_qasm3(f"""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[1] q;
+            {qasm_name} q[0];
+        """)
+    expected = Circuit(1)
+    expected.add(I(0))
+    assert c == expected
+
+
+def test_from_qasm3_controls_a_two_qubit_gate():
+    """A control modifier on a two-qubit gate adds a control, rather than being absorbed by the gate."""
+    c = from_qasm3("""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[3] q;
+            ctrl @ cz q[0], q[1], q[2];
+            ctrl @ swap q[0], q[1], q[2];
+        """)
+    expected = Circuit(3)
+    expected.add(Controlled(0, basic_gate=CZ(1, 2)))
+    expected.add(Controlled(0, basic_gate=SWAP(1, 2)))
+    assert c == expected
+
+
+def test_from_qasm3_control_modifier_after_another_modifier():
+    """Control modifiers take the leading qubits in order, wherever they sit among the other modifiers."""
+    c = from_qasm3("""
+            OPENQASM 3.0;
+            include "stdgates.inc";
+            qubit[2] q;
+            inv @ ctrl @ s q[0], q[1];
+            pow(2) @ ctrl @ h q[0], q[1];
+        """)
+    expected = Circuit(2)
+    expected.add(Adjoint(Controlled(0, basic_gate=S(1))))
+    expected.add(Controlled(0, basic_gate=H(1)))
+    expected.add(Controlled(0, basic_gate=H(1)))
+    assert c == expected


### PR DESCRIPTION
A number of small bugs have been fixed with the OpenQASM 2 and 3 conversion routines:

 - Registers are no longer assumed to be called "c" and "q" in OpenQASM 2 code.
 - Adjoints are now handled correctly, specifically that they no longer use the unicode dagger symbol which caused problems on reimport.
 - All supported gates now survive a round-trip.
 
Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/455