### PR TITLE
List the alternative requirements when no optional group is satisfied

### DIFF
--- a/changes/465.misc.md
+++ b/changes/465.misc.md
@@ -1,0 +1,1 @@
+The warning raised when an optional feature is unavailable because none of its alternative dependency groups is installed now lists the requirements each alternative wanted, instead of only saying that no group was satisfied.

--- a/src/qilisdk/_optionals.py
+++ b/src/qilisdk/_optionals.py
@@ -250,7 +250,11 @@ def import_optional_dependencies(feature: OptionalFeature) -> ImportedFeature:
             missing_by_group.append((g, unmet))
 
         if satisfied_group is None:
-            logger.warning("[Optionals] Optional feature {} unavailable, no dependency group satisfied", feature.name)
+            logger.warning(
+                "[Optionals] Optional feature {} unavailable, unsatisfied requirements {}",
+                feature.name,
+                " or ".join(str(unmet) for _, unmet in missing_by_group) or "none declared",
+            )
             all_unmet = [requirement for _, unmet in missing_by_group for requirement in unmet]
             stubs: dict[str, Any] = {s.name: make_stub(s.name, unmet=all_unmet) for s in feature.symbols}
             return ImportedFeature(name=feature.name, symbols=stubs)

--- a/tests/unit_python/test_optionals.py
+++ b/tests/unit_python/test_optionals.py
@@ -207,6 +207,40 @@ def test_any_mode_warning_names_every_alternative(caplog):  # ruff: ignore[redef
     ) in caplog.text
 
 
+def test_any_mode_warning_without_dependency_groups(caplog):  # ruff: ignore[redefined-while-unused]
+    """A feature that declares no alternatives at all still warns, without a dangling requirement list."""
+    feature = OptionalFeature(
+        name="empty",
+        mode=RequirementMode.ANY,
+        dependency_groups=[],
+        symbols=[Symbol(path="unused", name="Thing")],
+    )
+
+    imported = import_optional_dependencies(feature)
+
+    assert "Optional feature empty unavailable, unsatisfied requirements none declared" in caplog.text
+    with pytest.raises(OptionalDependencyError):
+        imported.symbols["Thing"]()
+
+
+def test_any_mode_second_alternative_resolves_the_symbol(caplog):  # ruff: ignore[redefined-while-unused]
+    """A later alternative satisfying the feature resolves the symbol and warns about nothing."""
+    feature = OptionalFeature(
+        name="either",
+        mode=RequirementMode.ANY,
+        dependency_groups=[
+            DependencyGroup(dists=["definitely-not-installed-dist-xyz"]),
+            DependencyGroup(dists=["numpy>=1.0.0"]),
+        ],
+        symbols=[Symbol(path="qilisdk._optionals", name="OptionalFeature")],
+    )
+
+    imported = import_optional_dependencies(feature)
+
+    assert imported.symbols["OptionalFeature"] is OptionalFeature
+    assert "unavailable" not in caplog.text
+
+
 def test_satisfied_floor_resolves_the_symbol() -> None:
     """A distribution that meets its floor lets the real symbol through."""
     feature = OptionalFeature(

--- a/tests/unit_python/test_optionals.py
+++ b/tests/unit_python/test_optionals.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from loguru_caplog import loguru_caplog as caplog  # ruff: ignore[unused-import]
 from packaging.requirements import Requirement
 
 from qilisdk._optionals import (
@@ -183,6 +184,27 @@ def test_missing_and_outdated_alternatives_are_both_reported() -> None:
     message = str(excinfo.value)
     assert f"numpy>=999.0.0 (found {installed})" in message
     assert "definitely-not-installed-dist-xyz (not installed)" in message
+
+
+def test_any_mode_warning_names_every_alternative(caplog):  # ruff: ignore[redefined-while-unused]
+    """The warning for an unavailable ANY feature says which requirements each alternative wanted."""
+    installed = importlib.metadata.version("numpy")
+    feature = OptionalFeature(
+        name="either",
+        mode=RequirementMode.ANY,
+        dependency_groups=[
+            DependencyGroup(dists=["numpy>=999.0.0"]),
+            DependencyGroup(dists=["definitely-not-installed-dist-xyz"]),
+        ],
+        symbols=[Symbol(path="unused", name="Thing")],
+    )
+
+    import_optional_dependencies(feature)
+
+    assert (
+        "Optional feature either unavailable, unsatisfied requirements "
+        f"['numpy>=999.0.0 (found {installed})'] or ['definitely-not-installed-dist-xyz (not installed)']"
+    ) in caplog.text
 
 
 def test_satisfied_floor_resolves_the_symbol() -> None:


### PR DESCRIPTION
When an optional feature needs any one of several dependency groups and none of them is installed, the warning only said "no dependency group satisfied", so you had to go read the feature definition to find out what to install. It now lists the requirements each alternative wanted, the same way the all-of case already did: `[Optionals] Optional feature cudaq unavailable, unsatisfied requirements ['cuda-quantum-cu12>=0.14.0 (not installed)'] or ['cuda-quantum-cu13>=0.14.0 (not installed)']`.
