### PR TITLE
[Bug-466] fixing the plotting in the experiments

### DIFF
--- a/changes/467.bugfix.1.md
+++ b/changes/467.bugfix.1.md
@@ -1,0 +1,3 @@
+`ExperimentResult.plot()` now lays out the figure before writing it to disk, so a saved plot looks like the one on screen.
+
+Two separate problems: `_plot_2d` called `tight_layout()` *after* saving, so the file kept the untidied layout while the displayed figure got the tidy one, and `_plot_1d` never called it at all. In both cases a secondary axis label pushed the title off the top of the canvas, so every saved figure with a `twiny`/`twinx` axis came out with its title clipped. Re-saving an affected figure is enough to fix it.

--- a/changes/467.bugfix.2.md
+++ b/changes/467.bugfix.2.md
@@ -1,0 +1,32 @@
+On a 1D `ExperimentResult.plot()` with a secondary x axis, the fit curve was drawn on the secondary axis instead of the primary one, in the secondary axis' coordinates, which placed it far outside the visible range: the fit did not appear at all.
+
+`add_fit` is handed no axes, so an implementation can only draw on pyplot's current axes, and `Axes.twiny()` had already made the secondary axis current by the time it was called. The fit is now performed before the secondary axis is created, so the current axes is the primary one:
+
+```python
+import numpy as np
+
+from qilisdk.experiments import Dimension, ExperimentResult
+
+
+class ResonatorSpectroscopy(ExperimentResult):
+    plot_title = "resonator_spectroscopy"
+
+    @staticmethod
+    def add_fit(x_values, y_values, initial_guess=None):
+        import matplotlib.pyplot as plt
+
+        plt.plot(x_values, y_values, "-", color="red", label="fit")
+
+
+frequency = np.linspace(4.0e9, 5.0e9, 8)
+data = np.stack([np.linspace(0.1, 1.0, 8), np.linspace(-0.5, 0.5, 8)], axis=-1)
+result = ResonatorSpectroscopy(
+    qubit=0,
+    averages=1,
+    data=data,
+    dims=[Dimension(["Frequency (Hz)", "Flux bias (V)"], [frequency, np.linspace(-1.0, 1.0, 8)])],
+)
+result.plot(fit=True)  # the fit curve is now visible over the data
+```
+
+Fitting first also keeps the secondary axis aligned when the fit is evaluated on a grid reaching past the measured points, since the secondary axis is positioned from the primary axis limits and those limits grow to fit the curve.

--- a/changes/467.bugfix.md
+++ b/changes/467.bugfix.md
@@ -1,0 +1,33 @@
+2D `ExperimentResult.plot()` maps were mirrored whenever a sweep ran downwards, and every 2D map had slightly wrong cell geometry. The plot built its mesh edges with `np.linspace(values.min(), values.max(), len(values) + 1)`, which always ascends, while the data was painted in the order it was measured.
+
+Any experiment sweeping a parameter from high to low (for example a flux bias ramped down) therefore produced a map flipped about the midpoint of that axis, with correct-looking tick labels and no warning. **Anyone who has published or fitted a figure from a descending sweep should re-plot it.** Only the rendering was affected: the stored data is intact, so re-plotting an existing `ExperimentResult` is enough to recover the correct figure.
+
+The same edge calculation also treated the first and last swept points as the outer edges of the mesh rather than as cell centres, so `n` points were drawn as `n` cells of width `(n - 1) * step / n`: the axis was compressed and shifted by half a cell, and non-uniformly spaced sweeps (a log sweep, say) were redrawn as an even grid. The error is negligible for a few thousand points but reaches 9% at 11 points.
+
+Each cell is now centred on the point it was measured at, so descending and non-uniformly spaced sweeps are drawn correctly:
+
+```python
+import numpy as np
+
+from qilisdk.experiments import Dimension, ExperimentResult
+
+
+class TwoToneVsFluxBias(ExperimentResult):
+    plot_title = "two_tone_vs_flux_bias"
+
+
+flux = np.arange(0.515, 0.48, -0.0035)  # a ramp played downwards
+frequency = np.arange(-0.2e9, -0.05e9, 1e6)
+data = np.zeros((len(flux), len(frequency), 2))
+data[0, :, 0] = 50.0  # a feature measured at flux[0] == 0.515
+
+result = TwoToneVsFluxBias(
+    qubit=0,
+    averages=1,
+    data=data,
+    dims=[Dimension(["Flux bias (V)"], [flux]), Dimension(["Frequency (Hz)"], [frequency])],
+)
+result.plot()  # the feature now renders at 0.515, not at 0.480
+```
+
+Secondary (twin) axes were fixed alongside: they took their limits from the smallest and largest secondary values, which flipped a secondary axis running opposite to its primary one, and left it misaligned with the primary axis. They are now placed by mapping the primary axis limits onto the secondary values, so both axes label the same positions.

--- a/src/qilisdk/experiments/experiment_result.py
+++ b/src/qilisdk/experiments/experiment_result.py
@@ -54,6 +54,35 @@ DimensionOverride = Callable[[Dimension], Dimension]
 """Callable that takes a Dimension and returns a transformed Dimension."""
 
 
+def _secondary_axis_limits(
+    primary: np.ndarray, secondary: np.ndarray, primary_limits: tuple[float, float]
+) -> tuple[float, float]:
+    """Map the limits of a primary axis onto the values of its secondary twin axis.
+
+    A twin axis relabels the very same positions as the primary axis, so its limits are the
+    secondary values at the primary limits, taken from the linear map anchored on the first
+    and last swept point. Using the smallest and largest secondary values instead would flip
+    a secondary axis that runs opposite to the primary one, for example a current ramped down
+    while the bias it sets is swept up.
+
+    Args:
+        primary (np.ndarray): Values swept along the primary axis.
+        secondary (np.ndarray): Values swept along the secondary axis, paired point by point
+            with `primary`.
+        primary_limits (tuple[float, float]): Limits currently displayed by the primary axis.
+
+    Returns:
+        tuple[float, float]: The limits to display on the secondary axis.
+    """
+    first, last = float(primary[0]), float(primary[-1])
+    secondary_first, secondary_last = float(secondary[0]), float(secondary[-1])
+    if first == last:
+        return secondary_first, secondary_last
+    slope = (secondary_last - secondary_first) / (last - first)
+    low, high = primary_limits
+    return secondary_first + (low - first) * slope, secondary_first + (high - first) * slope
+
+
 @yaml.register_class
 class ExperimentResult(FunctionalResult):
     """Base class for storing and visualizing experiment results.
@@ -184,15 +213,18 @@ class ExperimentResult(FunctionalResult):
             ax1.plot(x_values[0], s21, "--", color="grey", linewidth=0.8, zorder=1)
         ax1.plot(x_values[0], s21, ".")
 
+        if fit:
+            self.add_fit(x_values[0], s21, initial_guess=initial_guess)
+
         if len(x_labels) > 1:
             ax2 = ax1.twiny()
             ax2.set_xlabel(x_labels[1])
-            ax2.set_xlim(min(x_values[1]), max(x_values[1]))
-            ax2.set_xticks(np.linspace(min(x_values[1]), max(x_values[1]), num=6))
+            secondary_x_limits = _secondary_axis_limits(x_values[0], x_values[1], ax1.get_xlim())
+            ax2.set_xlim(secondary_x_limits)
+            ax2.set_xticks(np.linspace(*secondary_x_limits, num=6))
             ax2.ticklabel_format(axis="x", style="sci", scilimits=(-3, 3))
 
-        if fit:
-            self.add_fit(x_values[0], s21, initial_guess=initial_guess)
+        fig.tight_layout()
 
         if save_to:
             self._save_figure(fig, save_to)
@@ -235,37 +267,37 @@ class ExperimentResult(FunctionalResult):
         z_dim = z_override(z_dim_input) if z_override else z_dim_input
         z_values = z_dim.values[0]
 
-        x_edges = np.linspace(x_values[0].min(), x_values[0].max(), len(x_values[0]) + 1)
-        y_edges = np.linspace(y_values[0].min(), y_values[0].max(), len(y_values[0]) + 1)
-
         fig, ax1 = plt.subplots()
         ax1.set_title(f"{self.plot_title} - Qubit {self.qubit}")
         ax1.set_xlabel(x_labels[0])
         ax1.set_ylabel(y_labels[0])
         ax1.ticklabel_format(axis="both", style="sci", scilimits=(-3, 3))
 
-        mesh = ax1.pcolormesh(x_edges, y_edges, z_values.T, cmap="viridis", shading="auto")
+        mesh = ax1.pcolormesh(x_values[0], y_values[0], z_values.T, cmap="viridis", shading="nearest")
         colorbar_label = z_dim.labels[0]
         fig.colorbar(mesh, ax=ax1, label=colorbar_label)
 
         if len(x_labels) > 1:
             ax2 = ax1.twiny()
             ax2.set_xlabel(x_labels[1])
-            ax2.set_xlim(min(x_values[1]), max(x_values[1]))
-            ax2.set_xticks(np.linspace(min(x_values[1]), max(x_values[1]), num=6))
+            secondary_x_limits = _secondary_axis_limits(x_values[0], x_values[1], ax1.get_xlim())
+            ax2.set_xlim(secondary_x_limits)
+            ax2.set_xticks(np.linspace(*secondary_x_limits, num=6))
             ax2.ticklabel_format(axis="x", style="sci", scilimits=(-3, 3))
 
         if len(y_labels) > 1:
             ax3 = ax1.twinx()
             ax3.set_ylabel(y_labels[1])
-            ax3.set_ylim(min(y_values[1]), max(y_values[1]))
-            ax3.set_yticks(np.linspace(min(y_values[1]), max(y_values[1]), num=6))
+            secondary_y_limits = _secondary_axis_limits(y_values[0], y_values[1], ax1.get_ylim())
+            ax3.set_ylim(secondary_y_limits)
+            ax3.set_yticks(np.linspace(*secondary_y_limits, num=6))
             ax3.ticklabel_format(axis="y", style="sci", scilimits=(-3, 3))
+
+        fig.tight_layout()
 
         if save_to:
             self._save_figure(fig, save_to)
 
-        plt.tight_layout()
         plt.show()
         plt.close(fig)
 

--- a/tests/unit_python/experiments/test_experiments.py
+++ b/tests/unit_python/experiments/test_experiments.py
@@ -18,6 +18,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from loguru import logger
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 
 from qilisdk.experiments import Dimension, ExperimentResult
 
@@ -57,6 +59,22 @@ class OverriddenResult(RecordingResult):
     dims_override: ClassVar[list] = [_relabel("x override"), _relabel("y override"), _relabel("z override")]
 
 
+class WideFitResult(ExperimentResult):
+    """Result whose `add_fit` draws through pyplot, over a grid wider than the measured points.
+
+    Both are what a real fit does: the signature hands the implementer no axes to draw on, and a
+    fitted curve is normally evaluated on a denser grid that reaches a little past the data.
+    """
+
+    plot_title = "wide_fit_experiment"
+
+    @staticmethod
+    def add_fit(x_values: np.ndarray, y_values: np.ndarray, initial_guess: list[float] | None = None) -> None:
+        span = np.ptp(x_values)
+        wider = np.linspace(x_values.min() - 0.1 * span, x_values.max() + 0.1 * span, 50)
+        plt.plot(wider, np.full_like(wider, y_values.mean()), "-", label="fit")
+
+
 @pytest.fixture(autouse=True)
 def _clear_fit_calls():
     RecordingResult.fit_calls.clear()
@@ -80,6 +98,42 @@ def _data_2d(n: int = 5, m: int = 4) -> np.ndarray:
     real = np.linspace(0.1, 1.0, n * m).reshape(n, m)
     imag = np.linspace(-0.5, 0.5, n * m).reshape(n, m)
     return np.stack([real, imag], axis=-1)
+
+
+def _mesh_edges(figure) -> tuple[np.ndarray, np.ndarray]:
+    """Return the x and y cell edges of the colour mesh drawn on a figure, in drawn order."""
+    coordinates = figure.axes[0].collections[0].get_coordinates()
+    return np.asarray(coordinates[0, :, 0]), np.asarray(coordinates[:, 0, 1])
+
+
+def _expected_edges(values: np.ndarray) -> np.ndarray:
+    """Cell edges placing every swept value on its own cell: midpoints, outer edges half a step out."""
+    return np.concatenate(
+        [
+            [values[0] - (values[1] - values[0]) / 2],
+            (values[:-1] + values[1:]) / 2,
+            [values[-1] + (values[-1] - values[-2]) / 2],
+        ]
+    )
+
+
+def _axes_by_label(figure, label: str):
+    """Return the axes carrying `label` on either of its axis labels."""
+    return next(axes for axes in figure.axes if label in {axes.get_xlabel(), axes.get_ylabel()})
+
+
+def _positions(values: np.ndarray, limits: tuple[float, float]) -> np.ndarray:
+    """Where the swept values sit across the axes, as a fraction of the axis width."""
+    low, high = limits
+    return (values - low) / (high - low)
+
+
+def _title_and_figure_top(figure) -> tuple[float, float]:
+    """Return the top of the axes title and the top of the figure canvas, in display units."""
+    FigureCanvasAgg(figure)  # `plot` closed the figure, so re-attach a renderer to measure it
+    figure.canvas.draw()
+    title = figure.axes[0].title.get_window_extent(figure.canvas.get_renderer())
+    return title.y1, figure.bbox.y1
 
 
 def test_dimension_initialization():
@@ -308,6 +362,221 @@ def test_plot_2d_secondary_axes(captured_figures):
     }
     assert "Flux current (A)" in labels
     assert "IF frequency (Hz)" in labels
+
+
+def test_plot_2d_descending_sweep_is_not_mirrored(captured_figures):
+    """A sweep played downwards is painted where it was measured, not flipped about its midpoint."""
+    flux = np.arange(0.515, 0.48, -0.0035)
+    frequency = np.linspace(-0.2e9, -0.05e9, 4)
+    data = np.zeros((len(flux), len(frequency), 2))
+    data[0, :, 0] = 50.0  # a single bright column, measured at the very first flux point
+    dims = [
+        Dimension(labels=["Flux bias (V)"], values=[flux]),
+        Dimension(labels=["Frequency (Hz)"], values=[frequency]),
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=data, dims=dims)
+
+    result.plot()
+
+    figure = captured_figures[0]
+    x_edges, _ = _mesh_edges(figure)
+    np.testing.assert_allclose(x_edges, _expected_edges(flux))
+    drawn = np.asarray(figure.axes[0].collections[0].get_array()).reshape(len(frequency), len(flux))
+    bright = int(np.argmax(drawn[0]))
+    assert min(x_edges[bright], x_edges[bright + 1]) < flux[0] < max(x_edges[bright], x_edges[bright + 1])
+
+
+def test_plot_2d_cells_span_a_full_sweep_step(captured_figures):
+    """Each cell is one sweep step wide and centred on its point, so the map is not compressed."""
+    flux = np.linspace(-0.5, 0.5, 5)
+    frequency = np.linspace(4.0e9, 5.0e9, 4)
+    dims = [
+        Dimension(labels=["Flux bias (V)"], values=[flux]),
+        Dimension(labels=["Frequency (Hz)"], values=[frequency]),
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_2d(), dims=dims)
+
+    result.plot()
+
+    x_edges, y_edges = _mesh_edges(captured_figures[0])
+    np.testing.assert_allclose(np.diff(x_edges), 0.25)
+    np.testing.assert_allclose(np.diff(y_edges), 1.0e9 / 3)
+    np.testing.assert_allclose([x_edges[0], x_edges[-1]], [-0.625, 0.625])
+
+
+def test_plot_2d_non_uniform_sweep_keeps_its_spacing(captured_figures):
+    """A non-uniformly spaced sweep keeps its spacing instead of being redrawn as an even grid."""
+    flux = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    frequency = np.array([4.0e9, 4.1e9, 4.3e9, 4.7e9])
+    dims = [
+        Dimension(labels=["Flux bias (V)"], values=[flux]),
+        Dimension(labels=["Frequency (Hz)"], values=[frequency]),
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_2d(), dims=dims)
+
+    result.plot()
+
+    x_edges, y_edges = _mesh_edges(captured_figures[0])
+    np.testing.assert_allclose(x_edges, [0.5, 1.5, 3.0, 6.0, 12.0, 20.0])
+    np.testing.assert_allclose(y_edges, _expected_edges(frequency))
+
+
+def test_plot_2d_secondary_axes_track_the_primary_ones(captured_figures):
+    """Secondary axes that run opposite to their primary still label the same positions."""
+    flux = np.linspace(-0.5, 0.5, 5)
+    current = np.linspace(1.0, -1.0, 5)  # ramped down while the bias it sets is swept up
+    frequency = np.linspace(4.0e9, 5.0e9, 4)
+    if_frequency = np.linspace(2.0e8, 1.0e8, 4)
+    dims = [
+        Dimension(labels=["Flux bias (V)", "Flux current (A)"], values=[flux, current]),
+        Dimension(labels=["Frequency (Hz)", "IF frequency (Hz)"], values=[frequency, if_frequency]),
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_2d(), dims=dims)
+
+    result.plot()
+
+    figure = captured_figures[0]
+    primary = figure.axes[0]
+    secondary_x = _axes_by_label(figure, "Flux current (A)")
+    secondary_y = _axes_by_label(figure, "IF frequency (Hz)")
+    assert secondary_x.get_xlim()[0] > secondary_x.get_xlim()[1]
+    assert secondary_y.get_ylim()[0] > secondary_y.get_ylim()[1]
+    np.testing.assert_allclose(_positions(current, secondary_x.get_xlim()), _positions(flux, primary.get_xlim()))
+    np.testing.assert_allclose(
+        _positions(if_frequency, secondary_y.get_ylim()), _positions(frequency, primary.get_ylim())
+    )
+
+
+def test_plot_1d_secondary_x_axis_tracks_the_primary_one(captured_figures):
+    """The 1D secondary axis labels the same positions as the primary, whichever way it runs."""
+    frequency = np.linspace(4.0e9, 5.0e9, 8)
+    flux = np.linspace(1.0, -1.0, 8)  # descending while the frequency ascends
+    dims = [Dimension(labels=["Frequency (Hz)", "Flux bias (V)"], values=[frequency, flux])]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_1d(), dims=dims)
+
+    result.plot()
+
+    figure = captured_figures[0]
+    secondary = _axes_by_label(figure, "Flux bias (V)")
+    assert secondary.get_xlim()[0] > secondary.get_xlim()[1]
+    np.testing.assert_allclose(_positions(flux, secondary.get_xlim()), _positions(frequency, figure.axes[0].get_xlim()))
+
+
+def test_plot_1d_fit_is_drawn_on_the_primary_axes(captured_figures):
+    """A fit drawn through pyplot must land on the primary axes, not on the secondary twin."""
+    dims = [
+        Dimension(
+            labels=["Frequency (Hz)", "Flux bias (V)"],
+            values=[np.linspace(4.0e9, 5.0e9, 8), np.linspace(1.0, -1.0, 8)],
+        )
+    ]
+    result = WideFitResult(qubit=0, averages=1000, data=_data_1d(), dims=dims)
+
+    result.plot(fit=True)
+
+    figure = captured_figures[0]
+    primary = figure.axes[0]
+    secondary = _axes_by_label(figure, "Flux bias (V)")
+    assert [line.get_label() for line in primary.lines].count("fit") == 1
+    assert [line.get_label() for line in secondary.lines] == []
+
+
+def test_plot_1d_secondary_axis_tracks_a_fit_wider_than_the_data(captured_figures):
+    """A fit reaching past the data widens the primary axis, and the secondary must follow it."""
+    frequency = np.linspace(4.0e9, 5.0e9, 8)
+    bias = np.linspace(1.0, -1.0, 8)
+    dims = [Dimension(labels=["Frequency (Hz)", "Flux bias (V)"], values=[frequency, bias])]
+    result = WideFitResult(qubit=0, averages=1000, data=_data_1d(), dims=dims)
+
+    result.plot(fit=True)
+
+    figure = captured_figures[0]
+    primary_limits = figure.axes[0].get_xlim()
+    secondary = _axes_by_label(figure, "Flux bias (V)")
+    # The fit has to be on the primary axis and to have stretched it past the swept range, otherwise
+    # the alignment below would hold trivially -- autoscale margins alone would not prove anything.
+    span = np.ptp(frequency)
+    assert primary_limits[0] <= frequency.min() - 0.1 * span
+    assert primary_limits[1] >= frequency.max() + 0.1 * span
+    np.testing.assert_allclose(_positions(bias, secondary.get_xlim()), _positions(frequency, primary_limits))
+
+
+def test_plot_1d_secondary_x_axis_of_a_motionless_sweep(captured_figures):
+    """A primary that never moves sets no scale, so the secondary falls back to its own values."""
+    dims = [
+        Dimension(
+            labels=["Frequency (Hz)", "Flux bias (V)"],
+            values=[np.full(8, 4.0e9), np.linspace(-1.0, 1.0, 8)],
+        )
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_1d(), dims=dims)
+
+    result.plot()
+
+    secondary = _axes_by_label(captured_figures[0], "Flux bias (V)")
+    np.testing.assert_allclose(secondary.get_xlim(), (-1.0, 1.0))
+
+
+def test_plot_1d_title_fits_inside_the_figure(captured_figures):
+    """A secondary axis label must not push the title off the top of the canvas."""
+    dims = [
+        Dimension(
+            labels=["Frequency (Hz)", "Flux bias (V)"],
+            values=[np.linspace(4.0e9, 5.0e9, 8), np.linspace(1.0, -1.0, 8)],
+        )
+    ]
+    result = RecordingResult(qubit=0, averages=1000, data=_data_1d(), dims=dims)
+
+    result.plot()
+
+    title_top, figure_top = _title_and_figure_top(captured_figures[0])
+    assert title_top <= figure_top
+
+
+def test_plot_2d_saves_the_figure_it_lays_out(tmp_path, captured_figures):
+    """The saved file must get the same fitted layout as the displayed figure, not the untidied one."""
+    positions_when_saved = []
+    original_savefig = Figure.savefig
+
+    def recording_savefig(self, *args, **kwargs):
+        positions_when_saved.append(self.axes[0].get_position().bounds)
+        return original_savefig(self, *args, **kwargs)
+
+    dims = [
+        Dimension(
+            labels=["Flux bias (V)", "Flux current (A)"], values=[np.linspace(-0.5, 0.5, 5), np.linspace(1.0, -1.0, 5)]
+        ),
+        Dimension(
+            labels=["Frequency (Hz)", "IF frequency (Hz)"],
+            values=[np.linspace(4.0e9, 5.0e9, 4), np.linspace(2.0e8, 1.0e8, 4)],
+        ),
+    ]
+    result = RecordingResult(qubit=1, averages=1000, data=_data_2d(), dims=dims)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(Figure, "savefig", recording_savefig)
+        result.plot(save_to=str(tmp_path / "map.png"))
+
+    assert positions_when_saved == [captured_figures[0].axes[0].get_position().bounds]
+
+
+def test_plot_2d_title_fits_inside_the_figure(captured_figures):
+    """Two twin axis labels must not push the title off the top of the canvas."""
+    dims = [
+        Dimension(
+            labels=["Flux bias (V)", "Flux current (A)"], values=[np.linspace(-0.5, 0.5, 5), np.linspace(1.0, -1.0, 5)]
+        ),
+        Dimension(
+            labels=["Frequency (Hz)", "IF frequency (Hz)"],
+            values=[np.linspace(4.0e9, 5.0e9, 4), np.linspace(2.0e8, 1.0e8, 4)],
+        ),
+    ]
+    result = RecordingResult(qubit=1, averages=1000, data=_data_2d(), dims=dims)
+
+    result.plot()
+
+    title_top, figure_top = _title_and_figure_top(captured_figures[0])
+    assert title_top <= figure_top
 
 
 def test_plot_3d_is_not_supported(captured_figures):


### PR DESCRIPTION
2D `ExperimentResult.plot()` maps were mirrored whenever a sweep ran downwards, and every 2D map had slightly wrong cell geometry. The plot built its mesh edges with `np.linspace(values.min(), values.max(), len(values) + 1)`, which always ascends, while the data was painted in the order it was measured.

Any experiment sweeping a parameter from high to low (for example a flux bias ramped down) therefore produced a map flipped about the midpoint of that axis, with correct-looking tick labels and no warning. **Anyone who has published or fitted a figure from a descending sweep should re-plot it.** Only the rendering was affected: the stored data is intact, so re-plotting an existing `ExperimentResult` is enough to recover the correct figure.

The same edge calculation also treated the first and last swept points as the outer edges of the mesh rather than as cell centres, so `n` points were drawn as `n` cells of width `(n - 1) * step / n`: the axis was compressed and shifted by half a cell, and non-uniformly spaced sweeps (a log sweep, say) were redrawn as an even grid. The error is negligible for a few thousand points but reaches 9% at 11 points.

Each cell is now centred on the point it was measured at, so descending and non-uniformly spaced sweeps are drawn correctly:

```python
import numpy as np

from qilisdk.experiments import Dimension, ExperimentResult


class TwoToneVsFluxBias(ExperimentResult):
    plot_title = "two_tone_vs_flux_bias"


flux = np.arange(0.515, 0.48, -0.0035)  # a ramp played downwards
frequency = np.arange(-0.2e9, -0.05e9, 1e6)
data = np.zeros((len(flux), len(frequency), 2))
data[0, :, 0] = 50.0  # a feature measured at flux[0] == 0.515

result = TwoToneVsFluxBias(
    qubit=0,
    averages=1,
    data=data,
    dims=[Dimension(["Flux bias (V)"], [flux]), Dimension(["Frequency (Hz)"], [frequency])],
)
result.plot()  # the feature now renders at 0.515, not at 0.480
```

Secondary (twin) axes were fixed alongside: they took their limits from the smallest and largest secondary values, which flipped a secondary axis running opposite to its primary one, and left it misaligned with the primary axis. They are now placed by mapping the primary axis limits onto the secondary values, so both axes label the same positions.


fixes https://github.com/qilimanjaro-tech/qilisdk/issues/466