### PR TITLE
Fixed Classical Solver Init

### DIFF
--- a/changes/479.bugfix.md
+++ b/changes/479.bugfix.md
@@ -1,0 +1,1 @@
+A warning is no longer raised if you import a specific non-SCIP classical solver but don't have SCIP installed.

--- a/src/qilisdk/utils/classical_solvers/__init__.py
+++ b/src/qilisdk/utils/classical_solvers/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import cast
 
 from qilisdk._optionals import (
     DependencyGroup,
@@ -20,6 +20,7 @@ from qilisdk._optionals import (
     OptionalFeature,
     RequirementMode,
     Symbol,
+    _OptionalDependencyStub,
     import_optional_dependencies,
 )
 
@@ -53,7 +54,7 @@ _OPTIONAL_FEATURE_BY_SYMBOL: dict[str, OptionalFeature] = {
 __all__ += list(_OPTIONAL_FEATURE_BY_SYMBOL)
 
 
-def __getattr__(name: str) -> Any:  # ruff: ignore[any-type]
+def __getattr__(name: str) -> type[ClassicalSolver] | _OptionalDependencyStub:
     """Lazily import optional solver symbols on first access (PEP 562).
 
     This runs only when normal attribute lookup on the module fails, i.e. the
@@ -77,7 +78,7 @@ def __getattr__(name: str) -> Any:  # ruff: ignore[any-type]
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     imported_feature: ImportedFeature = import_optional_dependencies(feature)
     globals().update(imported_feature.symbols)
-    return imported_feature.symbols[name]
+    return cast("type[ClassicalSolver] | _OptionalDependencyStub", imported_feature.symbols[name])
 
 
 def __dir__() -> list[str]:

--- a/src/qilisdk/utils/classical_solvers/__init__.py
+++ b/src/qilisdk/utils/classical_solvers/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+from typing import Any
 
 from qilisdk._optionals import (
     DependencyGroup,
@@ -45,9 +45,41 @@ OPTIONAL_FEATURES: list[OptionalFeature] = [
         symbols=[Symbol(path="qilisdk.utils.classical_solvers.scip_solver", name="ScipSolver")],
     ),
 ]
-current_module = sys.modules[__name__]
-for feature in OPTIONAL_FEATURES:
+
+_OPTIONAL_FEATURE_BY_SYMBOL: dict[str, OptionalFeature] = {
+    symbol.name: feature for feature in OPTIONAL_FEATURES for symbol in feature.symbols
+}
+
+__all__ += list(_OPTIONAL_FEATURE_BY_SYMBOL)
+
+
+def __getattr__(name: str) -> Any:  # ruff: ignore[any-type]
+    """Lazily import optional solver symbols on first access (PEP 562).
+
+    This runs only when normal attribute lookup on the module fails, i.e. the
+    first time ``name`` is requested. It resolves the whole owning feature, caches
+    every resolved symbol as a real module attribute so subsequent accesses skip
+    this hook, and returns the requested symbol (or a stub raising
+    ``OptionalDependencyError`` if the optional dependency is not installed).
+
+    Args:
+        name: The attribute being accessed on the ``qilisdk.utils.classical_solvers`` module.
+
+    Returns:
+        The imported symbol, or a stub that raises on use when the optional
+        dependency is missing.
+
+    Raises:
+        AttributeError: If ``name`` is not an optional solver symbol.
+    """
+    feature = _OPTIONAL_FEATURE_BY_SYMBOL.get(name)
+    if feature is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     imported_feature: ImportedFeature = import_optional_dependencies(feature)
-    for symbol_name, symbol_obj in imported_feature.symbols.items():
-        setattr(current_module, symbol_name, symbol_obj)
-        __all__ += [symbol_name]  # ruff: ignore[invalid-all-object]
+    globals().update(imported_feature.symbols)
+    return imported_feature.symbols[name]
+
+
+def __dir__() -> list[str]:
+    """Return the module's public attributes, including lazily-imported symbols."""
+    return sorted(__all__)

--- a/src/qilisdk/utils/classical_solvers/__init__.pyi
+++ b/src/qilisdk/utils/classical_solvers/__init__.pyi
@@ -1,0 +1,28 @@
+# Copyright 2026 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base_solver import ClassicalSolver, ClassicalSolverResult
+from .brute_force_solver import BruteForceSolver
+from .scip_solver import ScipSolver
+from .scipy_solver import ScipySolver
+from .simulated_annealing_solver import SimulatedAnnealingSolver
+
+__all__ = [
+    "BruteForceSolver",
+    "ClassicalSolver",
+    "ClassicalSolverResult",
+    "ScipSolver",
+    "ScipySolver",
+    "SimulatedAnnealingSolver",
+]

--- a/tests/unit_python/utils/test_classical_solvers.py
+++ b/tests/unit_python/utils/test_classical_solvers.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import importlib.metadata
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import numpy as np
 import pytest
+from loguru_caplog import loguru_caplog as caplog  # ruff: ignore[unused-import]
+
+import qilisdk.utils.classical_solvers as classical_solvers
+from qilisdk._optionals import OptionalDependencyError
 
 from qilisdk.core.comparison import EQ
 from qilisdk.core.model import QUBO, Model, ObjectiveSense
@@ -372,3 +379,63 @@ def test_simulated_annealing_invalid_effort_raises(num_reads, num_sweeps):
     solver = SimulatedAnnealingSolver(num_reads=num_reads, num_sweeps=num_sweeps)
     with pytest.raises(ValueError, match="must be positive"):
         solver.solve(qubo)
+
+
+def _forget_optional_symbols():
+    """Drop symbols an earlier lazy access cached, so the next one goes through ``__getattr__``."""
+    for name in classical_solvers._OPTIONAL_FEATURE_BY_SYMBOL:
+        classical_solvers.__dict__.pop(name, None)
+
+
+def _reload_without_pyscipopt(mp):
+    """Reload the package as if ``pyscipopt`` were not installed."""
+    real_version = importlib.metadata.version
+
+    def fake_version(name):
+        if name == "pyscipopt":
+            raise PackageNotFoundError(name)
+        return real_version(name)
+
+    mp.setattr(importlib.metadata, "version", fake_version)
+    module = importlib.reload(classical_solvers)
+    _forget_optional_symbols()
+    return module
+
+
+def test_importing_the_package_without_scip_does_not_warn(caplog):  # ruff: ignore[redefined-while-unused]
+    """Importing a solver must stay silent when the optional 'scip' extra is absent."""
+    try:
+        with pytest.MonkeyPatch.context() as mp:
+            module = _reload_without_pyscipopt(mp)
+
+            assert module.BruteForceSolver is not None
+            assert "scip" not in caplog.text
+            assert "unavailable" not in caplog.text
+    finally:
+        importlib.reload(classical_solvers)
+        _forget_optional_symbols()
+
+
+def test_accessing_scip_solver_without_scip_warns_and_stubs(caplog):  # ruff: ignore[redefined-while-unused]
+    """The warning and the stub only appear once ScipSolver itself is requested."""
+    try:
+        with pytest.MonkeyPatch.context() as mp:
+            module = _reload_without_pyscipopt(mp)
+
+            stub = module.ScipSolver
+
+            assert "Optional feature scip unavailable" in caplog.text
+            with pytest.raises(OptionalDependencyError, match=r"pip install qilisdk\[scip\]"):
+                stub()
+    finally:
+        importlib.reload(classical_solvers)
+        _forget_optional_symbols()
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError, match="has no attribute 'NotASolver'"):
+        classical_solvers.NotASolver
+
+
+def test_dir_advertises_the_optional_solver():
+    assert "ScipSolver" in dir(classical_solvers)

--- a/tests/unit_python/utils/test_classical_solvers.py
+++ b/tests/unit_python/utils/test_classical_solvers.py
@@ -23,7 +23,6 @@ from loguru_caplog import loguru_caplog as caplog  # ruff: ignore[unused-import]
 
 import qilisdk.utils.classical_solvers as classical_solvers
 from qilisdk._optionals import OptionalDependencyError
-
 from qilisdk.core.comparison import EQ
 from qilisdk.core.model import QUBO, Model, ObjectiveSense
 from qilisdk.core.variables import BinaryVariable, Domain, OneHot, SpinVariable, Variable


### PR DESCRIPTION
A warning is no longer raised if you import a specific non-SCIP classical solver but don't have SCIP installed.

Fixes https://github.com/qilimanjaro-tech/qilisdk/issues/363