### PR TITLE
Errors for mixing Analog/Digital Paulis

### DIFF
--- a/changes/480.bugfix.md
+++ b/changes/480.bugfix.md
@@ -1,0 +1,1 @@
+Added some better error messages in case a user tries to add a X object to a circuit or tries to add an X gate to a Hamiltonian or Schedule.

--- a/src/qilisdk/analog/exceptions.py
+++ b/src/qilisdk/analog/exceptions.py
@@ -15,3 +15,11 @@
 
 class InvalidHamiltonianOperation(Exception):
     """Raised when an operation cannot be applied to the current Hamiltonian."""
+
+
+class NotAHamiltonianError(ValueError):
+    """Raised when an object that is not a :class:`Hamiltonian` is added to a schedule.
+
+    This most commonly happens when the digital gates (``qilisdk.digital.X`` and friends) are
+    used instead of the analog Pauli helpers of the same name.
+    """

--- a/src/qilisdk/analog/exceptions.py
+++ b/src/qilisdk/analog/exceptions.py
@@ -18,7 +18,7 @@ class InvalidHamiltonianOperation(Exception):
 
 
 class NotAHamiltonianError(ValueError):
-    """Raised when an object that is not a :class:`Hamiltonian` is added to a schedule.
+    """Raised when an object that is not a :class:`Hamiltonian` is used where one is expected.
 
     This most commonly happens when the digital gates (``qilisdk.digital.X`` and friends) are
     used instead of the analog Pauli helpers of the same name.

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -33,7 +33,7 @@ from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.utils.visualization.style import HamiltonianStyle
 from qilisdk.yaml import yaml
 
-from .exceptions import InvalidHamiltonianOperation
+from .exceptions import InvalidHamiltonianOperation, NotAHamiltonianError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -49,6 +49,30 @@ _GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE = (
 
 def _complex_dtype() -> np.dtype:
     return np.dtype(get_settings().complex_precision.dtype)
+
+
+def _reject_digital_object(obj: object, target: str) -> None:
+    """Raise a descriptive error if a digital object is used where a Hamiltonian is expected.
+
+    Importing the digital gates (``qilisdk.digital.X`` and friends) instead of the analog Paulis of
+    the same name is a common mistake.
+
+    Args:
+        obj (object): The object that is being combined with the analog object.
+        target (str): The analog object being combined with, used in the error message.
+
+    Raises:
+        NotAHamiltonianError: If the object is a digital gate.
+    """
+    # Imported here to avoid a circular import between the analog and digital subpackages.
+    from qilisdk.digital.gates import Gate  # ruff: ignore[import-outside-top-level]
+
+    if isinstance(obj, Gate):
+        raise NotAHamiltonianError(
+            f"Cannot use the digital gate {obj!r} with {target}, only Hamiltonian objects are supported. "
+            "This usually means the digital gates were imported instead of the analog Paulis: "
+            "did you mean to import X, Y, Z or I from qilisdk.analog rather than from qilisdk.digital?"
+        )
 
 
 ###############################################################################
@@ -1456,6 +1480,7 @@ class Hamiltonian(Parameterizable):
                 self._add_parameter(parameter.label, parameter)
             self._elements[PauliI(0),] += other
         else:
+            _reject_digital_object(other, "a Hamiltonian")
             raise InvalidHamiltonianOperation(f"Invalid addition between Hamiltonian and {other.__class__.__name__}.")
 
     def _sub_inplace(self, other: Number | PauliOperator | Hamiltonian | Expression | Parameter) -> None:
@@ -1476,6 +1501,7 @@ class Hamiltonian(Parameterizable):
                 self._add_parameter(parameter.label, parameter)
             self._elements[PauliI(0),] -= other
         else:
+            _reject_digital_object(other, "a Hamiltonian")
             raise InvalidHamiltonianOperation(
                 f"Invalid subtraction between Hamiltonian and {other.__class__.__name__}."
             )

--- a/src/qilisdk/analog/hamiltonian.py
+++ b/src/qilisdk/analog/hamiltonian.py
@@ -46,6 +46,9 @@ _GENERIC_VARIABLE_IN_HAMILTONIAN_MESSAGE = (
     "Only Parameters are allowed to be used in hamiltonians. Generic Variables are not supported"
 )
 
+# Name used for this class in the error messages raised for digital objects.
+_REJECT_TARGET = "a Hamiltonian"
+
 
 def _complex_dtype() -> np.dtype:
     return np.dtype(get_settings().complex_precision.dtype)
@@ -1480,7 +1483,7 @@ class Hamiltonian(Parameterizable):
                 self._add_parameter(parameter.label, parameter)
             self._elements[PauliI(0),] += other
         else:
-            _reject_digital_object(other, "a Hamiltonian")
+            _reject_digital_object(other, _REJECT_TARGET)
             raise InvalidHamiltonianOperation(f"Invalid addition between Hamiltonian and {other.__class__.__name__}.")
 
     def _sub_inplace(self, other: Number | PauliOperator | Hamiltonian | Expression | Parameter) -> None:
@@ -1501,7 +1504,7 @@ class Hamiltonian(Parameterizable):
                 self._add_parameter(parameter.label, parameter)
             self._elements[PauliI(0),] -= other
         else:
-            _reject_digital_object(other, "a Hamiltonian")
+            _reject_digital_object(other, _REJECT_TARGET)
             raise InvalidHamiltonianOperation(
                 f"Invalid subtraction between Hamiltonian and {other.__class__.__name__}."
             )

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -20,8 +20,7 @@ from typing import TYPE_CHECKING, Callable, Iterator, Mapping, overload
 from loguru import logger
 from numpy import linspace
 
-from qilisdk.analog.exceptions import NotAHamiltonianError
-from qilisdk.analog.hamiltonian import Hamiltonian
+from qilisdk.analog.hamiltonian import Hamiltonian, _reject_digital_object
 from qilisdk.core.expression import Cos, Expression
 from qilisdk.core.interpolator import Interpolation, Interpolator, ParameterizedNumber, TimeDict
 from qilisdk.core.parameterizable import Parameterizable
@@ -40,29 +39,6 @@ CoeffDict = dict[str, TimeDict]
 InterpDict = dict[str, "Interpolator"]
 
 _DEFAULT_DT = 0.1
-
-
-def _reject_digital_object(obj: object) -> None:
-    """Raise a descriptive error if a digital object is used where a Hamiltonian is expected.
-
-    Importing the digital gates (``qilisdk.digital.X`` and friends) instead of the analog Paulis of
-    the same name is a common mistake.
-
-    Args:
-        obj (object): The object that is being added to the schedule.
-
-    Raises:
-        NotAHamiltonianError: If the object is a digital gate.
-    """
-    # Imported here to avoid a circular import between the analog and digital subpackages.
-    from qilisdk.digital.gates import Gate  # ruff: ignore[import-outside-top-level]
-
-    if isinstance(obj, Gate):
-        raise NotAHamiltonianError(
-            f"Cannot add the gate {type(obj).__name__} to a Schedule, only Hamiltonian objects can be added. "
-            "This usually means the digital gates were imported instead of the analog Paulis: "
-            "did you mean to import X, Y, Z or I from qilisdk.analog rather than from qilisdk.digital?"
-        )
 
 
 @yaml.register_class
@@ -563,7 +539,7 @@ class Schedule(Parameterizable):
         coefficients: Interpolator | TimeDict,
         interpolation: Interpolation = Interpolation.LINEAR,
     ) -> None:
-        _reject_digital_object(hamiltonian)
+        _reject_digital_object(hamiltonian, "a Schedule")
         if not isinstance(hamiltonian, Hamiltonian):
             raise ValueError(f"Expecting a Hamiltonian object but received {type(hamiltonian)} instead.")
 
@@ -618,7 +594,7 @@ class Schedule(Parameterizable):
         if label not in self._hamiltonians:
             raise ValueError(f"Can't update unknown hamiltonian {label}. Did you mean `add_hamiltonian`?")
         if new_hamiltonian is not None:
-            _reject_digital_object(new_hamiltonian)
+            _reject_digital_object(new_hamiltonian, "a Schedule")
             if not isinstance(new_hamiltonian, Hamiltonian):
                 raise ValueError(f"Expecting a Hamiltonian object but received {type(new_hamiltonian)} instead.")
             self._hamiltonians[label] = new_hamiltonian

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -40,6 +40,9 @@ InterpDict = dict[str, "Interpolator"]
 
 _DEFAULT_DT = 0.1
 
+# Name used for this class in the error messages raised for digital objects.
+_REJECT_TARGET = "a Schedule"
+
 
 @yaml.register_class
 class Schedule(Parameterizable):
@@ -539,7 +542,7 @@ class Schedule(Parameterizable):
         coefficients: Interpolator | TimeDict,
         interpolation: Interpolation = Interpolation.LINEAR,
     ) -> None:
-        _reject_digital_object(hamiltonian, "a Schedule")
+        _reject_digital_object(hamiltonian, _REJECT_TARGET)
         if not isinstance(hamiltonian, Hamiltonian):
             raise ValueError(f"Expecting a Hamiltonian object but received {type(hamiltonian)} instead.")
 
@@ -594,7 +597,7 @@ class Schedule(Parameterizable):
         if label not in self._hamiltonians:
             raise ValueError(f"Can't update unknown hamiltonian {label}. Did you mean `add_hamiltonian`?")
         if new_hamiltonian is not None:
-            _reject_digital_object(new_hamiltonian, "a Schedule")
+            _reject_digital_object(new_hamiltonian, _REJECT_TARGET)
             if not isinstance(new_hamiltonian, Hamiltonian):
                 raise ValueError(f"Expecting a Hamiltonian object but received {type(new_hamiltonian)} instead.")
             self._hamiltonians[label] = new_hamiltonian

--- a/src/qilisdk/analog/schedule.py
+++ b/src/qilisdk/analog/schedule.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Callable, Iterator, Mapping, overload
 from loguru import logger
 from numpy import linspace
 
+from qilisdk.analog.exceptions import NotAHamiltonianError
 from qilisdk.analog.hamiltonian import Hamiltonian
 from qilisdk.core.expression import Cos, Expression
 from qilisdk.core.interpolator import Interpolation, Interpolator, ParameterizedNumber, TimeDict
@@ -39,6 +40,29 @@ CoeffDict = dict[str, TimeDict]
 InterpDict = dict[str, "Interpolator"]
 
 _DEFAULT_DT = 0.1
+
+
+def _reject_digital_object(obj: object) -> None:
+    """Raise a descriptive error if a digital object is used where a Hamiltonian is expected.
+
+    Importing the digital gates (``qilisdk.digital.X`` and friends) instead of the analog Paulis of
+    the same name is a common mistake.
+
+    Args:
+        obj (object): The object that is being added to the schedule.
+
+    Raises:
+        NotAHamiltonianError: If the object is a digital gate.
+    """
+    # Imported here to avoid a circular import between the analog and digital subpackages.
+    from qilisdk.digital.gates import Gate  # ruff: ignore[import-outside-top-level]
+
+    if isinstance(obj, Gate):
+        raise NotAHamiltonianError(
+            f"Cannot add the gate {type(obj).__name__} to a Schedule, only Hamiltonian objects can be added. "
+            "This usually means the digital gates were imported instead of the analog Paulis: "
+            "did you mean to import X, Y, Z or I from qilisdk.analog rather than from qilisdk.digital?"
+        )
 
 
 @yaml.register_class
@@ -539,6 +563,7 @@ class Schedule(Parameterizable):
         coefficients: Interpolator | TimeDict,
         interpolation: Interpolation = Interpolation.LINEAR,
     ) -> None:
+        _reject_digital_object(hamiltonian)
         if not isinstance(hamiltonian, Hamiltonian):
             raise ValueError(f"Expecting a Hamiltonian object but received {type(hamiltonian)} instead.")
 
@@ -593,6 +618,7 @@ class Schedule(Parameterizable):
         if label not in self._hamiltonians:
             raise ValueError(f"Can't update unknown hamiltonian {label}. Did you mean `add_hamiltonian`?")
         if new_hamiltonian is not None:
+            _reject_digital_object(new_hamiltonian)
             if not isinstance(new_hamiltonian, Hamiltonian):
                 raise ValueError(f"Expecting a Hamiltonian object but received {type(new_hamiltonian)} instead.")
             self._hamiltonians[label] = new_hamiltonian

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -33,6 +33,9 @@ from .gates import BasicGate, Gate, _reject_analog_object
 if TYPE_CHECKING:
     from qilisdk.core.types import RealNumber
 
+# Name used for this class in the error messages raised for analog objects.
+_REJECT_TARGET = "a Circuit"
+
 
 def _complex_dtype() -> np.dtype:
     return get_settings().complex_precision.dtype
@@ -193,7 +196,7 @@ class Circuit(Parameterizable):
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
         logger.trace("[Circuit] Adding gate: {}", gate)
-        _reject_analog_object(gate, "a Circuit")
+        _reject_analog_object(gate, _REJECT_TARGET)
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -211,7 +214,7 @@ class Circuit(Parameterizable):
             NotAGateError: If any of the objects to be added is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Adding gates: {}", gates)
-        _reject_analog_object(gates, "a Circuit")
+        _reject_analog_object(gates, _REJECT_TARGET)
         if isinstance(gates, Gate):
             self._add(gates)
             return
@@ -229,7 +232,7 @@ class Circuit(Parameterizable):
             NotAGateError: If the object to be inserted is an analog object rather than a gate.
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
-        _reject_analog_object(gate, "a Circuit")
+        _reject_analog_object(gate, _REJECT_TARGET)
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -248,7 +251,7 @@ class Circuit(Parameterizable):
             NotAGateError: If any of the objects to be inserted is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Inserting gates: {} at index: {}", gates, index)
-        _reject_analog_object(gates, "a Circuit")
+        _reject_analog_object(gates, _REJECT_TARGET)
         if isinstance(gates, Gate):
             self._insert(gates, index)
             return
@@ -310,7 +313,7 @@ class Circuit(Parameterizable):
 
     def __add__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Adding {} to circuit.", other)
-        _reject_analog_object(other, "a Circuit")
+        _reject_analog_object(other, _REJECT_TARGET)
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"
@@ -325,7 +328,7 @@ class Circuit(Parameterizable):
 
     def __radd__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Right-adding {} to circuit.", other)
-        _reject_analog_object(other, "a Circuit")
+        _reject_analog_object(other, _REJECT_TARGET)
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -27,7 +27,7 @@ from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.utils.visualization import CircuitStyle
 from qilisdk.yaml import yaml
 
-from .exceptions import QubitOutOfRangeError
+from .exceptions import NotAGateError, QubitOutOfRangeError
 from .gates import BasicGate, Gate
 
 if TYPE_CHECKING:
@@ -59,6 +59,30 @@ def _apply_gate_left(operator: np.ndarray, gate: Gate, nqubits: int) -> np.ndarr
     perm = perm_output + list(range(nqubits, 2 * nqubits))
 
     return np.transpose(contracted, axes=perm).reshape(operator.shape)
+
+
+def _reject_analog_object(obj: object) -> None:
+    """Raise a descriptive error if an analog object is used where a gate is expected.
+
+    Importing the analog Paulis (``qilisdk.analog.X`` and friends) instead of the digital gates of
+    the same name is a common mistake, and a :class:`~qilisdk.analog.Hamiltonian` is iterable, so
+    without this check the failure surfaces as an obscure error about tuples.
+
+    Args:
+        obj (object): The object that is being added to the circuit.
+
+    Raises:
+        NotAGateError: If the object is an analog Hamiltonian or Pauli operator.
+    """
+    # Imported here to avoid a circular import between the analog and digital subpackages.
+    from qilisdk.analog.hamiltonian import Hamiltonian, PauliOperator  # ruff: ignore[import-outside-top-level]
+
+    if isinstance(obj, (Hamiltonian, PauliOperator)):
+        raise NotAGateError(
+            f"Cannot add a {type(obj).__name__} to a Circuit, only Gate objects can be added. "
+            "This usually means the analog Paulis were imported instead of the digital gates: "
+            "did you mean to import X, Y, Z or I from qilisdk.digital rather than from qilisdk.analog?"
+        )
 
 
 @yaml.register_class
@@ -189,9 +213,11 @@ class Circuit(Parameterizable):
             gate (Gate): The quantum gate or a list of quantum gates to be added to the circuit.
 
         Raises:
+            NotAGateError: If the object to be added is an analog object rather than a gate.
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
         logger.trace("[Circuit] Adding gate: {}", gate)
+        _reject_analog_object(gate)
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -204,8 +230,12 @@ class Circuit(Parameterizable):
 
         Args:
             gates (Gate | list[Gate]): The quantum gate or a list of quantum gates to be added to the circuit.
+
+        Raises:
+            NotAGateError: If any of the objects to be added is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Adding gates: {}", gates)
+        _reject_analog_object(gates)
         if isinstance(gates, Gate):
             self._add(gates)
             return
@@ -220,8 +250,10 @@ class Circuit(Parameterizable):
             index (int, optional): The index at which the gate is inserted. Defaults to -1.
 
         Raises:
+            NotAGateError: If the object to be inserted is an analog object rather than a gate.
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
+        _reject_analog_object(gate)
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -235,8 +267,12 @@ class Circuit(Parameterizable):
         Args:
             gates (Gate | list[Gate]): The gate or list of gates to be inserted.
             index (int, optional): The index at which the gate is inserted. Defaults to -1.
+
+        Raises:
+            NotAGateError: If any of the objects to be inserted is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Inserting gates: {} at index: {}", gates, index)
+        _reject_analog_object(gates)
         if isinstance(gates, Gate):
             self._insert(gates, index)
             return
@@ -298,6 +334,7 @@ class Circuit(Parameterizable):
 
     def __add__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Adding {} to circuit.", other)
+        _reject_analog_object(other)
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"
@@ -312,6 +349,7 @@ class Circuit(Parameterizable):
 
     def __radd__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Right-adding {} to circuit.", other)
+        _reject_analog_object(other)
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"

--- a/src/qilisdk/digital/circuit.py
+++ b/src/qilisdk/digital/circuit.py
@@ -27,8 +27,8 @@ from qilisdk.utils.hashing import hash as qili_hash
 from qilisdk.utils.visualization import CircuitStyle
 from qilisdk.yaml import yaml
 
-from .exceptions import NotAGateError, QubitOutOfRangeError
-from .gates import BasicGate, Gate
+from .exceptions import QubitOutOfRangeError
+from .gates import BasicGate, Gate, _reject_analog_object
 
 if TYPE_CHECKING:
     from qilisdk.core.types import RealNumber
@@ -59,30 +59,6 @@ def _apply_gate_left(operator: np.ndarray, gate: Gate, nqubits: int) -> np.ndarr
     perm = perm_output + list(range(nqubits, 2 * nqubits))
 
     return np.transpose(contracted, axes=perm).reshape(operator.shape)
-
-
-def _reject_analog_object(obj: object) -> None:
-    """Raise a descriptive error if an analog object is used where a gate is expected.
-
-    Importing the analog Paulis (``qilisdk.analog.X`` and friends) instead of the digital gates of
-    the same name is a common mistake, and a :class:`~qilisdk.analog.Hamiltonian` is iterable, so
-    without this check the failure surfaces as an obscure error about tuples.
-
-    Args:
-        obj (object): The object that is being added to the circuit.
-
-    Raises:
-        NotAGateError: If the object is an analog Hamiltonian or Pauli operator.
-    """
-    # Imported here to avoid a circular import between the analog and digital subpackages.
-    from qilisdk.analog.hamiltonian import Hamiltonian, PauliOperator  # ruff: ignore[import-outside-top-level]
-
-    if isinstance(obj, (Hamiltonian, PauliOperator)):
-        raise NotAGateError(
-            f"Cannot add a {type(obj).__name__} to a Circuit, only Gate objects can be added. "
-            "This usually means the analog Paulis were imported instead of the digital gates: "
-            "did you mean to import X, Y, Z or I from qilisdk.digital rather than from qilisdk.analog?"
-        )
 
 
 @yaml.register_class
@@ -217,7 +193,7 @@ class Circuit(Parameterizable):
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
         logger.trace("[Circuit] Adding gate: {}", gate)
-        _reject_analog_object(gate)
+        _reject_analog_object(gate, "a Circuit")
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -235,7 +211,7 @@ class Circuit(Parameterizable):
             NotAGateError: If any of the objects to be added is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Adding gates: {}", gates)
-        _reject_analog_object(gates)
+        _reject_analog_object(gates, "a Circuit")
         if isinstance(gates, Gate):
             self._add(gates)
             return
@@ -253,7 +229,7 @@ class Circuit(Parameterizable):
             NotAGateError: If the object to be inserted is an analog object rather than a gate.
             QubitOutOfRangeError: If any qubit index used by the gate is not within the circuit's qubit range.
         """
-        _reject_analog_object(gate)
+        _reject_analog_object(gate, "a Circuit")
         if any(qubit < 0 or qubit >= self.nqubits for qubit in gate.qubits):
             raise QubitOutOfRangeError
 
@@ -272,7 +248,7 @@ class Circuit(Parameterizable):
             NotAGateError: If any of the objects to be inserted is an analog object rather than a gate.
         """
         logger.trace("[Circuit] Inserting gates: {} at index: {}", gates, index)
-        _reject_analog_object(gates)
+        _reject_analog_object(gates, "a Circuit")
         if isinstance(gates, Gate):
             self._insert(gates, index)
             return
@@ -334,7 +310,7 @@ class Circuit(Parameterizable):
 
     def __add__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Adding {} to circuit.", other)
-        _reject_analog_object(other)
+        _reject_analog_object(other, "a Circuit")
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"
@@ -349,7 +325,7 @@ class Circuit(Parameterizable):
 
     def __radd__(self, other: Circuit | Gate) -> Circuit | NotImplementedError:
         logger.trace("[Circuit] Right-adding {} to circuit.", other)
-        _reject_analog_object(other)
+        _reject_analog_object(other, "a Circuit")
         if not isinstance(other, (Circuit, Gate)):
             return NotImplementedError(
                 "Addition is only supported between Circuit objects or a Circuit and a Gate objects"

--- a/src/qilisdk/digital/exceptions.py
+++ b/src/qilisdk/digital/exceptions.py
@@ -38,7 +38,7 @@ class UnsupportedGateError(Exception):
 
 
 class NotAGateError(TypeError):
-    """Raised when an object that is not a :class:`Gate` is added to a circuit.
+    """Raised when an object that is not a :class:`Gate` is used where a gate is expected.
 
     This most commonly happens when the analog Pauli helpers (``qilisdk.analog.X`` and friends)
     are used instead of the digital gates of the same name.

--- a/src/qilisdk/digital/exceptions.py
+++ b/src/qilisdk/digital/exceptions.py
@@ -35,3 +35,11 @@ class InvalidParameterNameError(Exception):
 
 class UnsupportedGateError(Exception):
     """Raised when a gate is not supported by the target backend."""
+
+
+class NotAGateError(TypeError):
+    """Raised when an object that is not a :class:`Gate` is added to a circuit.
+
+    This most commonly happens when the analog Pauli helpers (``qilisdk.analog.X`` and friends)
+    are used instead of the digital gates of the same name.
+    """

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
 
 TBasicGate = TypeVar("TBasicGate", bound="BasicGate")
 
+# Name used for this class in the error messages raised for analog objects.
+_REJECT_TARGET = "a Gate"
+
 
 def _complex_dtype() -> np.dtype:
     return get_settings().complex_precision.dtype
@@ -276,7 +279,7 @@ class Gate(Parameterizable, ABC):
             object: ``NotImplemented``, so that the other operand gets a chance to handle the
                 operation (a :class:`~qilisdk.digital.Circuit` prepends the gate, for instance).
         """
-        _reject_analog_object(other, "a Gate")
+        _reject_analog_object(other, _REJECT_TARGET)
         return NotImplemented
 
     __radd__ = __add__
@@ -291,7 +294,7 @@ class Gate(Parameterizable, ABC):
             object: ``NotImplemented``, so that the other operand gets a chance to handle the
                 operation.
         """
-        _reject_analog_object(other, "a Gate")
+        _reject_analog_object(other, _REJECT_TARGET)
         return NotImplemented
 
     __rsub__ = __sub__

--- a/src/qilisdk/digital/gates.py
+++ b/src/qilisdk/digital/gates.py
@@ -33,6 +33,7 @@ from .exceptions import (
     GateHasNoMatrixError,
     GateNotParameterizedError,
     InvalidParameterNameError,
+    NotAGateError,
     ParametersNotEqualError,
 )
 
@@ -46,6 +47,31 @@ TBasicGate = TypeVar("TBasicGate", bound="BasicGate")
 
 def _complex_dtype() -> np.dtype:
     return get_settings().complex_precision.dtype
+
+
+def _reject_analog_object(obj: object, target: str) -> None:
+    """Raise a descriptive error if an analog object is used where a gate is expected.
+
+    Importing the analog Paulis (``qilisdk.analog.X`` and friends) instead of the digital gates of
+    the same name is a common mistake, and a :class:`~qilisdk.analog.Hamiltonian` is iterable, so
+    without this check the failure surfaces as an obscure error about tuples.
+
+    Args:
+        obj (object): The object that is being combined with the digital object.
+        target (str): The digital object being combined with, used in the error message.
+
+    Raises:
+        NotAGateError: If the object is an analog Hamiltonian or Pauli operator.
+    """
+    # Imported here to avoid a circular import between the analog and digital subpackages.
+    from qilisdk.analog.hamiltonian import Hamiltonian, PauliOperator  # ruff: ignore[import-outside-top-level]
+
+    if isinstance(obj, (Hamiltonian, PauliOperator)):
+        raise NotAGateError(
+            f"Cannot use the analog {type(obj).__name__} with {target}, only Gate objects are supported. "
+            "This usually means the analog Paulis were imported instead of the digital gates: "
+            "did you mean to import X, Y, Z or I from qilisdk.digital rather than from qilisdk.analog?"
+        )
 
 
 class Gate(Parameterizable, ABC):
@@ -239,6 +265,36 @@ class Gate(Parameterizable, ABC):
         if not self.is_parameterized:
             raise GateNotParameterizedError
         super().set_parameter_bounds(ranges=ranges)
+
+    def __add__(self, other: object) -> object:
+        """Reject analog operands, leaving every other operand to handle the operation itself.
+
+        Args:
+            other (object): The object the gate is being added to.
+
+        Returns:
+            object: ``NotImplemented``, so that the other operand gets a chance to handle the
+                operation (a :class:`~qilisdk.digital.Circuit` prepends the gate, for instance).
+        """
+        _reject_analog_object(other, "a Gate")
+        return NotImplemented
+
+    __radd__ = __add__
+
+    def __sub__(self, other: object) -> object:
+        """Reject analog operands, leaving every other operand to handle the operation itself.
+
+        Args:
+            other (object): The object being subtracted from the gate.
+
+        Returns:
+            object: ``NotImplemented``, so that the other operand gets a chance to handle the
+                operation.
+        """
+        _reject_analog_object(other, "a Gate")
+        return NotImplemented
+
+    __rsub__ = __sub__
 
     def __repr__(self) -> str:
         qubits_str = f"{self.qubits[0]}" if self.nqubits == 1 else str(self.qubits).replace("(", "").replace(")", "")

--- a/tests/unit_python/analog/test_hamiltionian.py
+++ b/tests/unit_python/analog/test_hamiltionian.py
@@ -18,7 +18,7 @@ from typing import ClassVar
 import numpy as np
 import pytest
 
-from qilisdk.analog.exceptions import InvalidHamiltonianOperation
+from qilisdk.analog.exceptions import InvalidHamiltonianOperation, NotAHamiltonianError
 from qilisdk.analog.hamiltonian import (
     Hamiltonian,
     I,
@@ -33,6 +33,7 @@ from qilisdk.analog.hamiltonian import (
 )
 from qilisdk.core import Domain, Parameter, QTensor, Variable
 from qilisdk.core.variables import BinaryVariable
+from qilisdk.digital import X as digital_X
 from qilisdk.settings import Precision, get_settings
 
 COMPLEX_DTYPE = get_settings().complex_precision.dtype
@@ -1253,3 +1254,27 @@ def test_hamiltonian_draw(monkeypatch):
     calls.clear()
     H.draw(filepath="dummy_path.png")
     assert calls == ["init", "plot", "save"]
+
+
+def test_hamiltonian_plus_digital_gate_raises_helpful_error():
+    """Adding a digital gate to a Hamiltonian points at the analog/digital import mixup."""
+    hamiltonian = X(0)
+    gate = digital_X(0)
+    with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        _ = hamiltonian + gate
+
+
+def test_hamiltonian_minus_digital_gate_raises_helpful_error():
+    """Subtracting a digital gate from a Hamiltonian gives the same guidance."""
+    hamiltonian = X(0)
+    gate = digital_X(0)
+    with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        _ = hamiltonian - gate
+
+
+def test_pauli_operator_plus_digital_gate_raises_helpful_error():
+    """Adding a digital gate to a bare Pauli operator gives the same guidance."""
+    pauli = PauliX(0)
+    gate = digital_X(0)
+    with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        _ = pauli + gate

--- a/tests/unit_python/analog/test_schedule.py
+++ b/tests/unit_python/analog/test_schedule.py
@@ -1029,13 +1029,15 @@ def test_schedule_extrapolate_extends_the_last_segment():
 def test_schedule_add_digital_gate_raises_helpful_error():
     """Adding a digital gate to a schedule points at the analog/digital import mixup."""
     sched = Schedule()
+    gate = digital_X(0)
     with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        sched.add_hamiltonian("h", digital_X(0), {0.0: 1.0})
+        sched.add_hamiltonian("h", gate, {0.0: 1.0})
 
 
 def test_schedule_update_with_digital_gate_raises_helpful_error():
     """Updating a schedule Hamiltonian with a digital gate gives the same guidance."""
     sched = Schedule()
     sched.add_hamiltonian("h", X(0), {0.0: 1.0})
+    gate = digital_X(0)
     with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        sched.update_hamiltonian("h", digital_X(0))
+        sched.update_hamiltonian("h", gate)

--- a/tests/unit_python/analog/test_schedule.py
+++ b/tests/unit_python/analog/test_schedule.py
@@ -18,10 +18,12 @@ import numpy as np
 import pytest
 
 from qilisdk.analog import Schedule, X, Z
+from qilisdk.analog.exceptions import NotAHamiltonianError
 from qilisdk.analog.hamiltonian import Hamiltonian, PauliX, PauliZ
 from qilisdk.analog.schedule import _TIME_PARAMETER_NAME
 from qilisdk.core.interpolator import Interpolation, Interpolator
 from qilisdk.core.variables import BinaryVariable, Domain, Parameter, Variable
+from qilisdk.digital import X as digital_X
 from qilisdk.settings import get_settings
 
 
@@ -1022,3 +1024,18 @@ def test_schedule_extrapolate_extends_the_last_segment():
 
     assert _isclose(sched.coefficients["driver"][4.0], -1.0)
     assert _isclose(sched.coefficients["driver"][10.0], -4.0)
+
+
+def test_schedule_add_digital_gate_raises_helpful_error():
+    """Adding a digital gate to a schedule points at the analog/digital import mixup."""
+    sched = Schedule()
+    with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        sched.add_hamiltonian("h", digital_X(0), {0.0: 1.0})
+
+
+def test_schedule_update_with_digital_gate_raises_helpful_error():
+    """Updating a schedule Hamiltonian with a digital gate gives the same guidance."""
+    sched = Schedule()
+    sched.add_hamiltonian("h", X(0), {0.0: 1.0})
+    with pytest.raises(NotAHamiltonianError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        sched.update_hamiltonian("h", digital_X(0))

--- a/tests/unit_python/digital/test_circuit.py
+++ b/tests/unit_python/digital/test_circuit.py
@@ -21,10 +21,11 @@ import pytest
 
 import qilisdk.utils.visualization.circuit_renderers
 from qilisdk.analog import X as analog_X
+from qilisdk.analog import Y as analog_Y
 from qilisdk.analog.hamiltonian import PauliX
 from qilisdk.core import Parameter
 from qilisdk.core.comparison import LEQ
-from qilisdk.digital import CNOT, RX, RY, RZ, U1, U2, U3, Circuit, M, S, X
+from qilisdk.digital import CNOT, RX, RY, RZ, U1, U2, U3, Circuit, M, S, X, Y
 from qilisdk.digital.circuit import _apply_gate_left
 from qilisdk.digital.exceptions import GateHasNoMatrixError, NotAGateError, QubitOutOfRangeError
 from qilisdk.digital.gates import BasicGate, Gate
@@ -746,26 +747,53 @@ def test_circuit_rejects_out_of_range_qubit(bad_qubit):
 def test_circuit_add_analog_hamiltonian_raises_helpful_error():
     """Adding an analog Hamiltonian to a circuit points at the analog/digital import mixup."""
     circuit = Circuit(1)
+    hamiltonian = analog_X(0)
     with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        circuit.add(analog_X(0))
+        circuit.add(hamiltonian)
 
 
 def test_circuit_add_analog_pauli_operator_raises_helpful_error():
     """Adding a bare analog Pauli operator to a circuit gives the same guidance."""
     circuit = Circuit(1)
+    pauli = PauliX(0)
     with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        circuit.add(PauliX(0))
+        circuit.add(pauli)
 
 
 def test_circuit_insert_analog_hamiltonian_raises_helpful_error():
     """Inserting an analog Hamiltonian into a circuit points at the analog/digital import mixup."""
     circuit = Circuit(1)
+    hamiltonian = analog_X(0)
     with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        circuit.insert(analog_X(0), 0)
+        circuit.insert(hamiltonian, 0)
 
 
 def test_circuit_add_operator_with_analog_hamiltonian_raises_helpful_error():
     """The ``+`` operator rejects analog Hamiltonians with the same guidance."""
     circuit = Circuit(1)
+    hamiltonian = analog_X(0)
     with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
-        circuit += analog_X(0)
+        circuit += hamiltonian
+
+
+def test_gate_plus_gate_is_not_supported():
+    """Gates do not support arithmetic, so adding two of them raises the usual TypeError."""
+    first, second = X(0), Y(0)
+    with pytest.raises(TypeError, match="unsupported operand type"):
+        _ = first + second
+
+
+def test_gate_plus_analog_hamiltonian_raises_helpful_error():
+    """Adding an analog Hamiltonian to a digital gate points at the import mixup."""
+    gate = X(0)
+    hamiltonian = analog_Y(0)
+    with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        _ = gate + hamiltonian
+
+
+def test_gate_still_supports_addition_with_a_circuit():
+    """Rejecting gate arithmetic does not break prepending a gate to a circuit."""
+    circuit = Circuit(1)
+    circuit.add(X(0))
+    result = Y(0) + circuit
+    assert result.gates == [Y(0), X(0)]

--- a/tests/unit_python/digital/test_circuit.py
+++ b/tests/unit_python/digital/test_circuit.py
@@ -20,11 +20,13 @@ import numpy as np
 import pytest
 
 import qilisdk.utils.visualization.circuit_renderers
+from qilisdk.analog import X as analog_X
+from qilisdk.analog.hamiltonian import PauliX
 from qilisdk.core import Parameter
 from qilisdk.core.comparison import LEQ
 from qilisdk.digital import CNOT, RX, RY, RZ, U1, U2, U3, Circuit, M, S, X
 from qilisdk.digital.circuit import _apply_gate_left
-from qilisdk.digital.exceptions import GateHasNoMatrixError, QubitOutOfRangeError
+from qilisdk.digital.exceptions import GateHasNoMatrixError, NotAGateError, QubitOutOfRangeError
 from qilisdk.digital.gates import BasicGate, Gate
 
 
@@ -739,3 +741,31 @@ def test_circuit_rejects_out_of_range_qubit(bad_qubit):
     gate = X(bad_qubit)
     with pytest.raises(QubitOutOfRangeError):
         circuit.add(gate)
+
+
+def test_circuit_add_analog_hamiltonian_raises_helpful_error():
+    """Adding an analog Hamiltonian to a circuit points at the analog/digital import mixup."""
+    circuit = Circuit(1)
+    with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        circuit.add(analog_X(0))
+
+
+def test_circuit_add_analog_pauli_operator_raises_helpful_error():
+    """Adding a bare analog Pauli operator to a circuit gives the same guidance."""
+    circuit = Circuit(1)
+    with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        circuit.add(PauliX(0))
+
+
+def test_circuit_insert_analog_hamiltonian_raises_helpful_error():
+    """Inserting an analog Hamiltonian into a circuit points at the analog/digital import mixup."""
+    circuit = Circuit(1)
+    with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        circuit.insert(analog_X(0), 0)
+
+
+def test_circuit_add_operator_with_analog_hamiltonian_raises_helpful_error():
+    """The ``+`` operator rejects analog Hamiltonians with the same guidance."""
+    circuit = Circuit(1)
+    with pytest.raises(NotAGateError, match="did you mean to import X, Y, Z or I from qilisdk"):
+        circuit += analog_X(0)


### PR DESCRIPTION
Added some better error messages in case a user tries to add a X object to a circuit or tries to add an X gate to a Hamiltonian or Schedule.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/321