### PR TITLE
Check nqubits when densitfying large stabilizer states

### DIFF
--- a/changes/482.bugfix.md
+++ b/changes/482.bugfix.md
@@ -1,0 +1,1 @@
+The number of qubits is now checked when trying to densify a large stabilizer state, so that now it throws a nice error rather than crashing.

--- a/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.cpp
@@ -1433,11 +1433,17 @@ DenseMatrix StabilizerState::as_dense() const {
 
     Returns:
         DenseMatrix: The dense vector representation of the StabilizerState.
+
+    Raises:
+        std::invalid_argument: If nqubits is too large for a dense statevector.
     */
-    int dim = 1 << nqubits;
+    if (nqubits > MAX_QUBITS_DENSE_STABILIZER) {
+        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object: it would need 2^" + std::to_string(nqubits) + " amplitudes, and at most " + std::to_string(MAX_QUBITS_DENSE_STABILIZER) + " qubits are supported.");
+    }
+    int64_t dim = int64_t(1) << nqubits;
     DenseMatrix result(dim, 1);
-    for (int i = 0; i < dim; ++i) {
-        std::string b = std::bitset<MAX_ROWS_STABILIZER>(i).to_string().substr(MAX_ROWS_STABILIZER - nqubits);
+    for (int64_t i = 0; i < dim; ++i) {
+        std::string b = std::bitset<MAX_ROWS_STABILIZER>(uint64_t(i)).to_string().substr(MAX_ROWS_STABILIZER - nqubits);
         result(i, 0) = amplitude(b);
     }
     return result;
@@ -1450,8 +1456,14 @@ DenseMatrix StabilizerStateSum::as_dense() const {
 
     Returns:
         DenseMatrix: The dense matrix representation of the StabilizerStateSum.
+
+    Raises:
+        std::invalid_argument: If nqubits is too large for a dense statevector.
     */
-    int dim = 1 << nqubits;
+    if (nqubits > MAX_QUBITS_DENSE_STABILIZER) {
+        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object: it would need 2^" + std::to_string(nqubits) + " amplitudes, and at most " + std::to_string(MAX_QUBITS_DENSE_STABILIZER) + " qubits are supported.");
+    }
+    int64_t dim = int64_t(1) << nqubits;
     DenseMatrix result(dim, 1);
     result.setZero();
     for (size_t k = 0; k < states.size(); ++k) {

--- a/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.cpp
@@ -1438,7 +1438,7 @@ DenseMatrix StabilizerState::as_dense() const {
         std::invalid_argument: If nqubits is too large for a dense statevector.
     */
     if (nqubits > MAX_QUBITS_DENSE_STABILIZER) {
-        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object: it would need 2^" + std::to_string(nqubits) + " amplitudes, and at most " + std::to_string(MAX_QUBITS_DENSE_STABILIZER) + " qubits are supported.");
+        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object.");
     }
     int64_t dim = int64_t(1) << nqubits;
     DenseMatrix result(dim, 1);
@@ -1461,7 +1461,7 @@ DenseMatrix StabilizerStateSum::as_dense() const {
         std::invalid_argument: If nqubits is too large for a dense statevector.
     */
     if (nqubits > MAX_QUBITS_DENSE_STABILIZER) {
-        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object: it would need 2^" + std::to_string(nqubits) + " amplitudes, and at most " + std::to_string(MAX_QUBITS_DENSE_STABILIZER) + " qubits are supported.");
+        throw std::invalid_argument("Stabilizer state of " + std::to_string(nqubits) + " qubits is too big to convert to a dense object.");
     }
     int64_t dim = int64_t(1) << nqubits;
     DenseMatrix result(dim, 1);

--- a/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.h
+++ b/src/qilisdk_cpp/backends/qilisim/representations/stabilizer_state.h
@@ -30,6 +30,9 @@
 
 const int MAX_ROWS_STABILIZER = 1024;
 
+// Largest qubit count that can be expanded into a dense statevector
+const int MAX_QUBITS_DENSE_STABILIZER = 30;
+
 class StabilizerState {
    private:
     std::vector<std::bitset<MAX_ROWS_STABILIZER>> x_bits;

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -1139,6 +1139,7 @@ def test_stabilizer_state_tomography_rejects_too_many_qubits():
     circuit.add(H(0))
     readout = Readout().with_state_tomography()
     backend = _stabilizer_backend()
+    propagation = DigitalPropagation(circuit=circuit)
 
     with pytest.raises(ValueError, match="too big to convert to a dense object"):
-        backend.execute(DigitalPropagation(circuit=circuit), readout=readout)
+        backend.execute(propagation, readout=readout)

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -1130,3 +1130,15 @@ def test_qtensor_sample_is_unaffected_by_backend_thread_count():
     )
 
     assert qtensor.sample(nshots=1000, seed=42) == before
+
+
+def test_stabilizer_state_tomography_rejects_too_many_qubits():
+    """A stabilizer state of 32 qubits used to overflow ``1 << nqubits`` and hand back a 1x1
+    QTensor with nqubits == 0. Converting to a dense object must fail loudly instead."""
+    circuit = Circuit(nqubits=32)
+    circuit.add(H(0))
+    readout = Readout().with_state_tomography()
+    backend = _stabilizer_backend()
+
+    with pytest.raises(ValueError, match="too big to convert to a dense object"):
+        backend.execute(DigitalPropagation(circuit=circuit), readout=readout)

--- a/tests/unit_cpp/qilisim/test_stabilizer_state.cpp
+++ b/tests/unit_cpp/qilisim/test_stabilizer_state.cpp
@@ -1506,4 +1506,24 @@ TEST(StabilizerState, DroppedGlobalPhase_HighRankDefaultsToOne) {
     EXPECT_EQ(ph, cd(1, 0));
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// as_dense: qubit counts too large for a dense statevector must be refused
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST(StabilizerDense, AsDenseRejectsTooManyQubits) {
+    StabilizerState s(MAX_QUBITS_DENSE_STABILIZER + 1);
+    EXPECT_THROW(s.as_dense(), std::invalid_argument);
+
+    StabilizerStateSum sum(MAX_QUBITS_DENSE_STABILIZER + 1);
+    EXPECT_THROW(sum.as_dense(), std::invalid_argument);
+}
+
+TEST(StabilizerDense, AsDenseSmallStateStillWorks) {
+    StabilizerState s(2);
+    s.apply_gate(makeGate("H", {}, {0}));
+    DenseMatrix v = s.as_dense();
+    EXPECT_EQ(v.rows(), 4);
+    EXPECT_NEAR(std::abs(v(0, 0)), 1.0 / std::sqrt(2.0), 1e-12);
+}
+
 // GCOV_EXCL_BR_STOP


### PR DESCRIPTION
The number of qubits is now checked when trying to densify a large stabilizer state, so that now it throws a nice error rather than crashing.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/414