### PR TITLE
Variational Annealing now returns float for expectation values

### DIFF
--- a/changes/483.bugfix.md
+++ b/changes/483.bugfix.md
@@ -1,0 +1,1 @@
+Variational annealing now returns expectation values as a float instead of a complex, to be more consistent with the other simulation methods.

--- a/src/qilisdk/readout/readout_result.py
+++ b/src/qilisdk/readout/readout_result.py
@@ -333,8 +333,14 @@ class ExpectationReadoutResult(ReadoutResult[ExpectationReadout]):
     """
 
     @classmethod
-    def from_expectations(cls, expectation_values: list[float], nshots: int | None = None) -> Self:
-        return cls(expectation_values=expectation_values, nshots=nshots)
+    def from_expectations(cls, expectation_values: list[Number], nshots: int | None = None) -> Self:
+        try:
+            real_expectation_values: list[int | float] = [_assert_real(value) for value in expectation_values]
+        except ValueError:
+            raise ValueError(
+                "Encountered an imaginary expectation value while computing the expectation values, try reducing the total tolerance or improving simulation precision."
+            )
+        return cls(expectation_values=real_expectation_values, nshots=nshots)
 
     @classmethod
     def from_state(cls, expectation_readout: ExpectationReadout, state: QTensor) -> Self:

--- a/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
@@ -63,7 +63,7 @@ py::object construct_result_object(const StabilizerStateSum& state, const py::ob
             }
             results.append(SamplingReadoutResult.attr("from_samples")("samples"_a = samples_py, "qubits_to_measure"_a = qubits_to_measure_list, "nqubits"_a = n_qubits, "expand_samples"_a = expand_samples));
         } else if (py::isinstance(ro, ExpectationReadout)) {
-            std::vector<std::complex<double>> expectations;
+            std::vector<double> expectations;
             // parse the observables for which we need to compute the expectation values
             std::vector<MatrixFreeHamiltonian> observables = parse_observables_matrix_free(n_qubits, ro.attr("observables"));
             for (const auto& obs : observables) {
@@ -194,7 +194,7 @@ py::object construct_result_object(const ExponentialAnsatz& state, const py::obj
     for (py::handle ro_handle : readout) {
         py::object ro = py::reinterpret_borrow<py::object>(ro_handle);
         if (py::isinstance(ro, ExpectationReadout)) {
-            std::vector<Complex> expectations;
+            std::vector<double> expectations;
             // parse the observables for which we need to compute the expectation values
             std::vector<MatrixFreeHamiltonian> observables = parse_observables_matrix_free(n_qubits, ro.attr("observables"));
             for (const auto& obs : observables) {

--- a/tests/unit_python/readout/test_readout_result.py
+++ b/tests/unit_python/readout/test_readout_result.py
@@ -151,6 +151,16 @@ class TestExpectationReadoutResult:
         with pytest.raises(ValueError, match="imaginary expectation"):
             ExpectationReadoutResult.from_state(expectation_readout=readout, state=ket(0))
 
+    def test_from_expectations_converts_real_valued_complex_to_float(self):
+        result = ExpectationReadoutResult.from_expectations(expectation_values=[complex(-3.5, 0.0)])
+        assert isinstance(result.expectation_values[0], float)
+        assert result.expectation_values == [-3.5]
+
+    def test_from_expectations_imag_raises(self):
+        expectation_values = [complex(-3.5, 1.0)]
+        with pytest.raises(ValueError, match="imaginary expectation"):
+            ExpectationReadoutResult.from_expectations(expectation_values=expectation_values)
+
     def test_init_from_expectation_values(self):
         result = ExpectationReadoutResult(expectation_values=[0.5])
         assert result.expectation_values == [0.5]


### PR DESCRIPTION
Variational annealing now returns expectation values as a float instead of a complex, to be more consistent with the other simulation methods.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/447