### PR TITLE
Support monte carlo and stabilizer state expectation value with shots

### DIFF
--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_hamiltonian.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_hamiltonian.cpp
@@ -14,6 +14,7 @@
 
 #include "matrix_free_hamiltonian.h"
 #include <algorithm>
+#include <random>
 #include <unordered_map>
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -627,6 +628,31 @@ MatrixFreeHamiltonian MatrixFreeHamiltonian::conjugate() const {
         coeff = std::conj(coeff);
     }
     return result;
+}
+
+Complex sample_expectation_value(const std::vector<std::pair<Complex, double>>& terms, int nshots, int seed) {
+    /*
+    Estimate the expectation value of an observable from a finite number of measurements of each of
+    its Pauli terms, given the exact expectation value of every term.
+
+    Args:
+        terms (std::vector<std::pair<Complex, double>>&): The Pauli terms of the observable, each as
+            its coefficient paired with its exact expectation value in the state being measured.
+        nshots (int): The number of measurements taken of each Pauli term.
+        seed (int): The seed of the generator the measurement outcomes are drawn from.
+
+    Returns:
+        Complex: The estimated expectation value of the observable.
+    */
+    std::mt19937 generator(static_cast<std::mt19937::result_type>(seed));
+    Complex expectation = 0.0;
+    for (const auto& [coefficient, term_expectation] : terms) {
+        double prob_plus = std::min(std::max(0.5 * (1.0 + term_expectation), 0.0), 1.0);
+        std::binomial_distribution<int> distribution(nshots, prob_plus);
+        int plus_counts = distribution(generator);
+        expectation += coefficient * (2.0 * double(plus_counts) / double(nshots) - 1.0);
+    }
+    return expectation;
 }
 
 // GCOV_EXCL_BR_STOP

--- a/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_hamiltonian.h
+++ b/src/qilisdk_cpp/backends/qilisim/representations/matrix_free_hamiltonian.h
@@ -153,4 +153,8 @@ class MatrixFreeHamiltonian {
     size_t size() const { return operators.size(); }
 };
 
+// Estimate the expectation value of an observable from a finite number of measurements
+// (used in parsers.cpp and qtensor.cpp)
+QILISIM_EXPORT Complex sample_expectation_value(const std::vector<std::pair<Complex, double>>& terms, int nshots, int seed);
+
 // GCOV_EXCL_BR_STOP

--- a/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/utils/parsers.cpp
@@ -46,9 +46,13 @@ py::object construct_result_object(const StabilizerStateSum& state, const py::ob
         py::value_error: If an unsupported readout method is provided.
     */
     state.set_seed(static_cast<uint64_t>(config.next_seed()));
+
+    // For each readout type
     py::list results;
     for (py::handle ro_handle : readout) {
         py::object ro = py::reinterpret_borrow<py::object>(ro_handle);
+
+        // For the sampling readout we use the state's .sample() method
         if (py::isinstance(ro, SamplingReadout)) {
             int nshots = ro.attr("nshots").cast<int>();
             bool expand_samples = ro.attr("expand_samples").cast<bool>();
@@ -62,19 +66,33 @@ py::object construct_result_object(const StabilizerStateSum& state, const py::ob
                 qubits_to_measure_list.append(i);
             }
             results.append(SamplingReadoutResult.attr("from_samples")("samples"_a = samples_py, "qubits_to_measure"_a = qubits_to_measure_list, "nqubits"_a = n_qubits, "expand_samples"_a = expand_samples));
+
+            // For the expectation readout we use the state's .expectation_value() method for each observable
+        } else if (py::isinstance(ro, ExpectationReadoutResult)) {
+            throw py::value_error("ExpectationReadoutResult is not a valid readout type. Please use ExpectationReadout instead.");
         } else if (py::isinstance(ro, ExpectationReadout)) {
+            int nshots = ro.attr("nshots").cast<int>();
             std::vector<std::complex<double>> expectations;
-            // parse the observables for which we need to compute the expectation values
             std::vector<MatrixFreeHamiltonian> observables = parse_observables_matrix_free(n_qubits, ro.attr("observables"));
             for (const auto& obs : observables) {
-                double exp_val = state.expectation_value(obs);
-                expectations.push_back(exp_val);
+                if (nshots > 0) {
+                    std::vector<std::pair<Complex, double>> terms;
+                    terms.reserve(obs.size());
+                    for (const auto& [pauli, coefficient] : obs.get_operators()) {
+                        terms.push_back({coefficient, state.expectation_value(MatrixFreeHamiltonian(n_qubits, pauli))});
+                    }
+                    expectations.push_back(sample_expectation_value(terms, nshots, config.next_seed()));
+                } else {
+                    expectations.push_back(state.expectation_value(obs));
+                }
             }
             py::list expectations_py;
             for (const auto& exp_val : expectations) {
                 expectations_py.append(py::cast(exp_val));
             }
-            results.append(ExpectationReadoutResult.attr("from_expectations")("expectation_values"_a = expectations_py));
+            results.append(ExpectationReadoutResult.attr("from_expectations")("expectation_values"_a = expectations_py, "nshots"_a = nshots));
+
+            // For the state tomography readout we use the state's .as_dense() method to get the final state vector
         } else if (py::isinstance(ro, StateTomographyReadout)) {
             std::string method = ro.attr("method").cast<std::string>();
             if (method != "exact") {
@@ -83,6 +101,8 @@ py::object construct_result_object(const StabilizerStateSum& state, const py::ob
             DenseMatrix final_state_dense = state.as_dense();
             py::array final_state_numpy = to_numpy(final_state_dense);
             results.append(StateTomographyReadoutResult("state"_a = QTensor(final_state_numpy)));
+
+            // Otherwise we throw an error
         } else {
             std::string ro_repr = py::repr(ro).cast<std::string>();
             throw py::value_error("Unsupported Readout Method for stabilizer backend: " + ro_repr);
@@ -92,23 +112,41 @@ py::object construct_result_object(const StabilizerStateSum& state, const py::ob
 }
 
 namespace {
-// QSDK-05 / QSDK-06 (CWE-125 / CWE-787): reject out-of-range qubit indices at
-// the C++ trust boundary. The Python layer only guards the upper bound and is
-// bypassed by deserialization (ruamel reconstructs Circuit / Gate / Pauli
-// objects without re-running __init__), so an unvalidated index (e.g. -1)
-// otherwise reaches the matrix-free kernels (undefined shift -> wild mask ->
-// out-of-bounds state access) and the measurement vector (out-of-bounds write).
+
 inline void validate_qubit_index(int qubit, int nqubits, const char* context) {
+    /*
+    Validate that a qubit index is within the valid range for a given number of qubits.
+
+    Args:
+        qubit (int): The qubit index to validate.
+        nqubits (int): The total number of qubits in the system.
+        context (const char*): A string describing the context in which the validation is being performed, for error messages.
+
+    Raises:
+        py::value_error: If the qubit index is out of range [0, nqubits).
+    */
     if (qubit < 0 || qubit >= nqubits) {
         throw py::value_error("Qubit index " + std::to_string(qubit) + " is out of range [0, " + std::to_string(nqubits) + ") for " + context + ".");
     }
 }
 
-// Build the per-step sqrt(rate(t)) multiplier used to scale a base jump operator across an analog
-// evolution. A constant rate yields a constant series; a callable rate(t) is evaluated at every time
-// point in step_list. Validates that each rate value is a finite, non-negative real number (negative
-// rates are unphysical and would make sqrt(rate) NaN, silently poisoning the evolution).
 inline std::vector<double> make_sqrt_rate_series(py::handle rate, const std::vector<double>& step_list, double atol) {
+    /*
+    Build the per-step sqrt(rate(t)) multiplier used to scale a base jump operator across the evolution.
+    A constant rate yields a constant series; a callable rate(t) is evaluated at every time point in step_list. Validates that each rate value is a finite, non-negative real number (
+    negative rates are unphysical and would make sqrt(rate) NaN, silently poisoning the evolution).
+
+    Args:
+        rate (py::handle): The Lindblad rate, either a constant or a callable function of time.
+        step_list (std::vector<double>&): The list of time points at which to evaluate the rate.
+        atol (double): The absolute tolerance for validating the rate values.
+
+    Returns:
+        std::vector<double>: The series of sqrt(rate(t)) values for each time point in step_list.
+
+    Raises:
+        py::value_error: If the rate is not a finite, non-negative real number at any time point in step_list.
+    */
     if (!PyCallable_Check(rate.ptr())) {
         double value = rate.cast<double>();
         if (!std::isfinite(value) || value < -atol) {
@@ -137,11 +175,21 @@ inline std::vector<double> make_sqrt_rate_series(py::handle rate, const std::vec
     return series;
 }
 
-// Resolve the Lindblad jump operators (base, unscaled) and their per-step sqrt(rate) series for a
-// noise pass. Constant-rate passes use jump_operators_with_rates (rate folded into the operator) and
-// get an empty series; time-dependent passes return the base operators with an explicit series.
-// Throws if the pass carries a time-dependent rate but no time axis (step_list) is available.
 inline void collect_lindblad_jumps(py::handle py_noise_pass, double dt, double atol, const std::vector<double>* step_list, std::vector<SparseMatrix>& jump_operators, std::vector<std::vector<double>>& jump_rate_series) {
+    /*
+    Resolve the Lindblad jump operators and their per-step sqrt(rate) series for a noise pass.
+
+    Args:
+        py_noise_pass (py::handle): The Python object representing the noise pass.
+        dt (double): The time step size for the evolution.
+        atol (double): The absolute tolerance for validating rate values.
+        step_list (const std::vector<double>*): The list of time points at which to evaluate time-dependent rates, or nullptr if not applicable.
+        jump_operators (std::vector<SparseMatrix>&): Output vector to hold the resolved jump operators.
+        jump_rate_series (std::vector<std::vector<double>>&): Output vector to hold the per-step sqrt(rate) series for each jump operator.
+
+    Raises:
+        py::value_error: If a time-dependent Lindblad rate is provided but no step_list is available, or if any rate value is invalid (non-finite or negative).
+    */
     py::object lindblad_gen;
     if (py::isinstance(py_noise_pass, SupportsStaticLindblad)) {
         lindblad_gen = py_noise_pass.attr("as_lindblad")();
@@ -260,7 +308,7 @@ inline double average_trajectory_expectation(const DenseMatrix& trajectories, co
     return total.real();
 }
 
-inline py::list trajectory_expectation_values(const DenseMatrix& trajectories, const py::object& expectation_readout, int n_qubits, double atol) {
+inline py::list trajectory_expectation_values(const DenseMatrix& trajectories, const py::object& expectation_readout, int n_qubits, const QiliSimConfig& config, int nshots) {
     /*
     Compute the expectation values of a list of observables over a Monte Carlo ensemble.
 
@@ -268,19 +316,42 @@ inline py::list trajectory_expectation_values(const DenseMatrix& trajectories, c
         trajectories (DenseMatrix&): The batch of Monte Carlo state vectors (dim x n_trajectories).
         expectation_readout (py::object): The ExpectationReadout object containing the list of observables.
         n_qubits (int): The number of qubits in the circuit.
-        atol (double): Absolute tolerance for checking that the expectation value is real.
+        config (QiliSimConfig&): The simulation configuration, used for the tolerance and the shot seeds.
+        nshots (int): The number of measurements per Pauli term used to estimate each expectation
+            value. If it is zero or negative the exact ensemble average is returned instead.
 
     Returns:
         py::list: The list of average expectation values of the observables over the ensemble.
     */
+    double atol = config.get_atol();
     py::list expectations_py;
     DenseMatrix applied;
     for (py::handle obs_handle : expectation_readout.attr("observables")) {
         py::object obs = py::reinterpret_borrow<py::object>(obs_handle);
         if (py::isinstance(obs, Hamiltonian) || py::isinstance(obs, PauliOperator)) {
             std::vector<MatrixFreeHamiltonian> observable = parse_observables_matrix_free(n_qubits, py::make_tuple(obs));
+
+            // Special path if given an nshots > 0
+            if (nshots > 0) {
+                std::vector<std::pair<Complex, double>> terms;
+                terms.reserve(observable[0].size());
+                for (const auto& [pauli, coefficient] : observable[0].get_operators()) {
+                    MatrixFreeHamiltonian(n_qubits, pauli).apply(trajectories, MatrixFreeApplicationType::Left, applied);
+                    terms.push_back({coefficient, average_trajectory_expectation(trajectories, applied, atol)});
+                }
+                Complex sampled = sample_expectation_value(terms, nshots, config.next_seed());
+                if (std::abs(sampled.imag()) > atol) {
+                    throw py::value_error("Encountered an imaginary expectation value while computing the expectation values, try reducing the total tolerance or improving simulation precision.");
+                }
+                expectations_py.append(py::cast(sampled.real()));
+                continue;
+            }
+
+            // Otherwise we can just apply the observable to the trajectories and compute the average
             observable[0].apply(trajectories, MatrixFreeApplicationType::Left, applied);
+
         } else {
+            // If it's a QTensor rather than a Hamiltonian, we expand it to the full Hilbert space
             py::object expanded = py::isinstance(obs, QTensor) ? obs.attr("expand")(n_qubits) : obs;
             std::vector<SparseMatrix> observable = parse_observables(py::make_tuple(expanded), n_qubits, atol);
             applied = observable[0] * trajectories;
@@ -353,9 +424,19 @@ py::object construct_result_object(const DenseMatrix& state_dense, const py::obj
             // If we have an expectation readout, average over the trajectories if we have them,
             // otherwise use the code on the Python side
         } else if (py::isinstance(ro, ExpectationReadout)) {
-            if (state_is_trajectories) {
-                py::list expectations_py = trajectory_expectation_values(state_dense, ro, n_qubits, config.get_atol());
-                results.append(ExpectationReadoutResult.attr("from_expectations")("expectation_values"_a = expectations_py, "nshots"_a = ro.attr("nshots")));
+            int nshots = ro.attr("nshots").cast<int>();
+
+            // Check if the ensemble can be sampled, i.e. all observables are Hamiltonians or PauliOperators
+            // If not we default to the density matrix path, which is slower but works for any observable
+            bool ensemble_can_be_sampled = true;
+            if (nshots > 0) {
+                for (py::handle obs_handle : ro.attr("observables")) {
+                    ensemble_can_be_sampled = ensemble_can_be_sampled && (py::isinstance(obs_handle, Hamiltonian) || py::isinstance(obs_handle, PauliOperator));
+                }
+            }
+            if (state_is_trajectories && ensemble_can_be_sampled) {
+                py::list expectations_py = trajectory_expectation_values(state_dense, ro, n_qubits, config, nshots);
+                results.append(ExpectationReadoutResult.attr("from_expectations")("expectation_values"_a = expectations_py, "nshots"_a = nshots));
             } else {
                 results.append(ExpectationReadoutResult.attr("from_state")("expectation_readout"_a = py::module_::import("copy").attr("copy")(ro), "state"_a = QTensor(state_numpy())));
             }

--- a/src/qilisdk_cpp/core/qtensor.cpp
+++ b/src/qilisdk_cpp/core/qtensor.cpp
@@ -1694,36 +1694,25 @@ Complex QTensorCpp::expectation_value(const MatrixFreeHamiltonian& other, int ns
         Complex: The expectation value of the matrix-free Hamiltonian with respect to this QTensor.
     */
 
+    // The special path if we're simulating sampling
     if (nshots > 0) {
-        // Create the random device
-        std::random_device rd;
-        std::mt19937 gen(rd());
-
         // The expectation value of the identity gives the normalization of this QTensor
         double normalization = expectation_value(MatrixFreeHamiltonian(other.get_nqubits(), 1.0)).real();
         if (normalization <= 0) {
             throw py::value_error("Invalid state: non-positive measurement probability normalization");
         }
 
-        // For each Pauli in the Hamiltonian
-        Complex expectation = 0.0;
+        // The exact expectation value of each Pauli term is what the measurements of it are drawn from
+        std::vector<std::pair<Complex, double>> terms;
+        terms.reserve(other.size());
         for (const auto& [pauli, coefficient] : other.get_operators()) {
-            // The identity term is not measured since it has no shot noise
-            if (pauli.size() == 0) {
-                expectation += coefficient * normalization;
-                continue;
-            }
-
-            // The exact expectation value of the single Pauli term gives the probability of a +1 outcome
             double term_expectation = expectation_value(MatrixFreeHamiltonian(other.get_nqubits(), pauli)).real() / normalization;
-            double prob_plus = std::min(std::max(0.5 * (1.0 + term_expectation), 0.0), 1.0);
-
-            // Sample the number of +1 outcomes and turn the counts back into an estimate of the term
-            std::binomial_distribution<int> dist(nshots, prob_plus);
-            int plus_counts = dist(gen);
-            expectation += coefficient * normalization * (2.0 * double(plus_counts) / double(nshots) - 1.0);
+            terms.push_back({coefficient, term_expectation});
         }
-        return expectation;
+
+        // Sample the expectation value of the Hamiltonian by sampling each Pauli term with nshots shots
+        std::random_device rd;
+        return normalization * sample_expectation_value(terms, nshots, static_cast<int>(rd() & 0x7fffffffU));
     }
 
     Complex expectation = 0.0;

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -312,6 +312,82 @@ def test_monte_carlo_expectation_values_match_ensemble_density_matrix(method):
         )
 
 
+@pytest.mark.parametrize("method", analog_methods)
+def test_monte_carlo_expectation_values_honor_nshots(method):
+    """A Monte Carlo expectation readout with nshots > 0 must carry shot noise: each Pauli term is
+    measured a finite number of times, so the estimate is quantised and only converges to the exact
+    ensemble average as the number of shots grows."""
+    dt = 0.1
+    T = 2.0
+
+    schedule = Schedule(
+        dt=dt,
+        hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
+        coefficients={"h1": {(0, T): lambda t: 1 - t / T}, "h2": {(0, T): lambda t: t / T}},
+    )
+
+    noise_model = NoiseModel()
+    noise_model.add(AmplitudeDamping(t1=2.0))
+
+    def _run(nshots: int) -> float:
+        backend = QiliSim(
+            analog_simulation_method=method,
+            noise_model=noise_model,
+            execution_config=ExecutionConfig(seed=42, num_threads=1, monte_carlo=MonteCarloConfig(trajectories=64)),
+        )
+        result = backend.execute(
+            AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM),
+            readout=Readout().with_expectation(observables=[pauli_z(0)], nshots=nshots),
+        )
+        return result.get_expectation_values()[0]
+
+    exact = _run(0)
+    few_shots = _run(7)
+    many_shots = _run(20000)
+
+    # A seven shot average of +-1 outcomes can only take the values (2 k - 7) / 7
+    assert few_shots != pytest.approx(exact, abs=1e-9)
+    assert 7 * (few_shots + 1) / 2 == pytest.approx(round(7 * (few_shots + 1) / 2), abs=1e-9)
+    assert many_shots == pytest.approx(exact, abs=5e-2)
+
+
+@pytest.mark.parametrize("method", analog_methods)
+def test_monte_carlo_expectation_values_honor_nshots_for_qtensor_observables(method):
+    """QTensor observables cannot be measured term by term, so the Monte Carlo path falls back to the
+    ensemble density matrix, which must still apply shot noise when nshots > 0."""
+    T = 2.0
+
+    schedule = Schedule(
+        dt=0.1,
+        hamiltonians={"h1": pauli_x(0), "h2": pauli_z(0)},
+        coefficients={"h1": {(0, T): lambda t: 1 - t / T}, "h2": {(0, T): lambda t: t / T}},
+    )
+
+    noise_model = NoiseModel()
+    noise_model.add(AmplitudeDamping(t1=2.0))
+
+    observable = QTensor(np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex))
+
+    def _run(nshots: int) -> float:
+        backend = QiliSim(
+            analog_simulation_method=method,
+            noise_model=noise_model,
+            execution_config=ExecutionConfig(seed=42, num_threads=1, monte_carlo=MonteCarloConfig(trajectories=64)),
+        )
+        result = backend.execute(
+            AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM),
+            readout=Readout().with_expectation(observables=[observable], nshots=nshots),
+        )
+        return result.get_expectation_values()[0]
+
+    exact = _run(0)
+    few_shots = _run(7)
+
+    assert few_shots != pytest.approx(exact, abs=1e-9)
+    assert 7 * (few_shots + 1) / 2 == pytest.approx(round(7 * (few_shots + 1) / 2), abs=1e-9)
+    assert _run(20000) == pytest.approx(exact, abs=5e-2)
+
+
 @pytest.mark.parametrize(
     ("initial_state", "noise"),
     [
@@ -1068,6 +1144,47 @@ def test_stabilizer_max_states_truncation_runs():
     samples = result.get_samples()
     total = sum(samples.values())
     assert total == 100
+
+
+def test_stabilizer_expectation_values_honor_nshots():
+    """A stabilizer expectation readout with nshots > 0 must carry shot noise, while a deterministic
+    observable stays exact because its outcome distribution has no spread to sample from."""
+    circuit = Circuit(nqubits=1)
+    circuit.add(H(0))
+
+    def _run(nshots: int) -> float:
+        readout = Readout().with_expectation(observables=[pauli_z(0)], nshots=nshots)
+        result = _stabilizer_backend().execute(DigitalPropagation(circuit=circuit), readout=readout)
+        return complex(result.get_expectation_values()[0]).real
+
+    # <Z> is exactly zero on |+>, so any finite odd number of shots has to disagree with it
+    assert _run(0) == pytest.approx(0.0, abs=1e-12)
+    few_shots = _run(7)
+    assert few_shots != pytest.approx(0.0, abs=1e-9)
+    assert 7 * (few_shots + 1) / 2 == pytest.approx(round(7 * (few_shots + 1) / 2), abs=1e-9)
+    assert _run(20000) == pytest.approx(0.0, abs=5e-2)
+
+    # An eigenstate of the observable gives the same value however few shots are used
+    deterministic = Circuit(nqubits=1)
+    deterministic.add(X(0))
+    readout = Readout().with_expectation(observables=[pauli_z(0)], nshots=3)
+    result = _stabilizer_backend().execute(DigitalPropagation(circuit=deterministic), readout=readout)
+    assert complex(result.get_expectation_values()[0]).real == pytest.approx(-1.0, abs=1e-12)
+
+
+def test_stabilizer_expectation_values_are_reproducible_with_shots():
+    """Sampled stabilizer expectation values are drawn from the configured seed, so the same seed
+    reproduces them and a different seed generally does not."""
+    circuit = Circuit(nqubits=1)
+    circuit.add(H(0))
+    readout = Readout().with_expectation(observables=[pauli_z(0)], nshots=11)
+
+    def _run(seed: int) -> float:
+        result = _stabilizer_backend(seed=seed).execute(DigitalPropagation(circuit=circuit), readout=readout)
+        return complex(result.get_expectation_values()[0]).real
+
+    assert _run(7) == _run(7)
+    assert any(_run(7) != _run(seed) for seed in range(8, 20))
 
 
 def test_stabilizer_seed_reproducibility():

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -1183,8 +1183,10 @@ def test_stabilizer_expectation_values_are_reproducible_with_shots():
         result = _stabilizer_backend(seed=seed).execute(DigitalPropagation(circuit=circuit), readout=readout)
         return complex(result.get_expectation_values()[0]).real
 
-    assert _run(7) == _run(7)
-    assert any(_run(7) != _run(seed) for seed in range(8, 20))
+    sampled = _run(7)
+    repeated = _run(7)
+    assert repeated == sampled
+    assert any(_run(seed) != sampled for seed in range(8, 20))
 
 
 def test_stabilizer_seed_reproducibility():

--- a/tests/unit_cpp/qilisim/test_parsers.cpp
+++ b/tests/unit_cpp/qilisim/test_parsers.cpp
@@ -1888,6 +1888,59 @@ _traj_ro_qt = [ExpectationReadout(observables=[QTensor(sp.csr_matrix(np.array([[
     EXPECT_NEAR(averaged[0], reference[0], 1e-12);
 }
 
+TEST(ConstructResultsTrajectories, ExpectationWithShotsIsSampled) {
+    py::gil_scoped_acquire gil;
+    // The identity term of the second observable carries no shot noise, so only the X(0) term of it
+    // is sampled; the Z(0) term of the first observable is sampled on its own.
+    py::exec(R"(
+from qilisdk.readout import ExpectationReadout
+from qilisdk.analog.hamiltonian import Z, X
+_traj_ro_exp_shots = [ExpectationReadout(observables=[Z(0), 0.5 * X(0) + 2.0 * X(0) * X(0)], nshots=8)]
+_traj_ro_exp_exact = [ExpectationReadout(observables=[Z(0), 0.5 * X(0) + 2.0 * X(0) * X(0)])]
+    )");
+    py::list readout_shots = py::globals()["_traj_ro_exp_shots"].cast<py::list>();
+    py::list readout_exact = py::globals()["_traj_ro_exp_exact"].cast<py::list>();
+
+    DenseMatrix trajectories = two_qubit_trajectories();
+    NoiseModelCpp noise_model_cpp;
+    QiliSimConfig config;
+    std::vector<bool> qubits_to_measure = {true, true};
+
+    std::vector<double> sampled = expectations_of(construct_result_object(trajectories, readout_shots, noise_model_cpp, 2, config, qubits_to_measure, true));
+    std::vector<double> exact = expectations_of(construct_result_object(trajectories, readout_exact, noise_model_cpp, 2, config, qubits_to_measure, true));
+    ASSERT_EQ(sampled.size(), 2u);
+
+    // An eight shot average of +-1 outcomes can only take the values (2 k - 8) / 8
+    EXPECT_NE(sampled[0], exact[0]);
+    EXPECT_NEAR(8.0 * (sampled[0] + 1.0) / 2.0, std::round(8.0 * (sampled[0] + 1.0) / 2.0), 1e-9);
+
+    // The identity term contributes its coefficient exactly, the X(0) term is sampled
+    double x_term = (sampled[1] - 2.0) / 0.5;
+    EXPECT_NEAR(8.0 * (x_term + 1.0) / 2.0, std::round(8.0 * (x_term + 1.0) / 2.0), 1e-9);
+}
+
+TEST(ConstructResultsTrajectories, ExpectationOfQTensorObservableWithShotsIsSampled) {
+    py::gil_scoped_acquire gil;
+    // A QTensor observable cannot be measured term by term, so the shot noise is applied on the
+    // ensemble density matrix instead; the outcomes are still the +-1 eigenvalues of the observable.
+    py::exec(R"(
+from qilisdk.readout import ExpectationReadout
+from qilisdk.core.qtensor import QTensor
+import numpy as np, scipy.sparse as sp
+_traj_ro_qt_shots = [ExpectationReadout(observables=[QTensor(sp.csr_matrix(np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)))], nshots=8)]
+    )");
+    py::list readout = py::globals()["_traj_ro_qt_shots"].cast<py::list>();
+
+    DenseMatrix trajectories = two_qubit_trajectories();
+    NoiseModelCpp noise_model_cpp;
+    QiliSimConfig config;
+    std::vector<bool> qubits_to_measure = {true, true};
+
+    std::vector<double> sampled = expectations_of(construct_result_object(trajectories, readout, noise_model_cpp, 2, config, qubits_to_measure, true));
+    ASSERT_EQ(sampled.size(), 1u);
+    EXPECT_NEAR(8.0 * (sampled[0] + 1.0) / 2.0, std::round(8.0 * (sampled[0] + 1.0) / 2.0), 1e-9);
+}
+
 TEST(ConstructResultsTrajectories, ImaginaryExpectationValueThrows) {
     py::gil_scoped_acquire gil;
     // The raising operator is not Hermitian, so its expectation value over this ensemble has a
@@ -2248,6 +2301,31 @@ TEST(ConstructResultsStabilizer, ExpectationReadout_Succeeds) {
     QiliSimConfig config;
     std::vector<bool> qubits_to_measure = {true};
     EXPECT_NO_THROW({ auto result = construct_result_object(state, readout, noise_model_cpp, 1, config, qubits_to_measure); });
+}
+
+TEST(ConstructResultsStabilizer, ExpectationReadoutWithShotsIsSampled) {
+    py::gil_scoped_acquire gil;
+    py::exec(R"(
+        from qilisdk.readout import ExpectationReadout
+        from qilisdk.analog.hamiltonian import X, Z
+        _stab_ro_exp_shots = [ExpectationReadout(observables=[X(0), Z(0)], nshots=7)]
+    )");
+    // |0> has <X(0)> = 0, so seven shots give a quantised estimate rather than the exact zero, while
+    // <Z(0)> = 1 is deterministic and stays exact however few shots are taken.
+    StabilizerStateSum state(1);
+    py::list readout = py::globals()["_stab_ro_exp_shots"].cast<py::list>();
+    NoiseModelCpp noise_model_cpp;
+    QiliSimConfig config;
+    std::vector<bool> qubits_to_measure = {true};
+
+    py::object result = construct_result_object(state, readout, noise_model_cpp, 1, config, qubits_to_measure);
+    py::list values = result.attr("expectation_values").attr("expectation_values").cast<py::list>();
+    ASSERT_EQ(values.size(), 2u);
+
+    double x_value = values[0].cast<Complex>().real();
+    EXPECT_NE(x_value, 0.0);
+    EXPECT_NEAR(7.0 * (x_value + 1.0) / 2.0, std::round(7.0 * (x_value + 1.0) / 2.0), 1e-9);
+    EXPECT_NEAR(values[1].cast<Complex>().real(), 1.0, 1e-12);
 }
 
 TEST(ConstructResultsStabilizer, StateTomographyReadoutExact_Succeeds) {


### PR DESCRIPTION
Monte Carlo simulations and Stabilizer State simulations now both support expectation values with shots:

```python
from qilisdk.analog.hamiltonian import X, Z
from qilisdk.analog.schedule import Schedule
from qilisdk.backends.backend_config import AnalogMethod, DigitalMethod, ExecutionConfig, MonteCarloConfig
from qilisdk.backends.qilisim import QiliSim
from qilisdk.core.qtensor import InitialState
from qilisdk.digital import Circuit, H
from qilisdk.functionals import AnalogEvolution, DigitalPropagation
from qilisdk.noise import AmplitudeDamping, NoiseModel
from qilisdk.readout import Readout

circuit = Circuit(1)
circuit.add(H(0))
schedule = Schedule(dt=0.1, hamiltonians={"hx": X(0), "hz": Z(0)},
                    coefficients={"hx": {(0, 2.0): lambda t: 1 - t / 2}, "hz": {(0, 2.0): lambda t: t / 2}})
noise = NoiseModel()
noise.add(AmplitudeDamping(t1=2.0))
config = ExecutionConfig(seed=42, num_threads=1)
mc_config = ExecutionConfig(seed=42, num_threads=1, monte_carlo=MonteCarloConfig(trajectories=64))

for nshots in (10, 100, 1000, 0):
    stabilizer = QiliSim(digital_simulation_method=DigitalMethod.stabilizer(), execution_config=config)
    readout = lambda: Readout().with_expectation([Z(0)], nshots=nshots)
    print("stabilizer  nshots=", nshots, stabilizer.execute(DigitalPropagation(circuit), readout()).get_expectation_values())

for nshots in (10, 100, 1000, 0):
    monte_carlo = QiliSim(analog_simulation_method=AnalogMethod.direct(), noise_model=noise, execution_config=mc_config)
    readout = lambda: Readout().with_expectation([Z(0)], nshots=nshots)
    print("monte carlo nshots=", nshots, monte_carlo.execute(AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM), readout()).get_expectation_values())
```

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/437