### PR TITLE
Variational annealing allows intermediate results

### DIFF
--- a/changes/485.feature.md
+++ b/changes/485.feature.md
@@ -1,0 +1,17 @@
+Variational annealing can now return expectation values and samples mid-evolution, as per the other analog simulation methods. State tomography remains disabled.
+
+```python
+from qilisdk.analog import Schedule, X, Z
+from qilisdk.backends import AnalogMethod, QiliSim
+from qilisdk.core import InitialState
+from qilisdk.functionals import AnalogEvolution
+from qilisdk.readout import Readout
+schedule = Schedule.linear(-X(0), Z(0), 10.0, 0.1)
+backend = QiliSim(analog_simulation_method=AnalogMethod.variational_annealing())
+result = backend.execute(
+    AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM, store_intermediate_results=True),
+    readout=Readout().with_expectation(observables=[Z(0)]),
+)
+vals = [step[0].real for step in result.get_intermediate_expectation_values()]
+print("Intermediate expectation values of Z(0):", vals)
+```

--- a/changes/485.feature.md
+++ b/changes/485.feature.md
@@ -6,6 +6,7 @@ from qilisdk.backends import AnalogMethod, QiliSim
 from qilisdk.core import InitialState
 from qilisdk.functionals import AnalogEvolution
 from qilisdk.readout import Readout
+
 schedule = Schedule.linear(-X(0), Z(0), 10.0, 0.1)
 backend = QiliSim(analog_simulation_method=AnalogMethod.variational_annealing())
 result = backend.execute(

--- a/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.cpp
@@ -431,7 +431,7 @@ void time_evolution_matrix_free(SparseMatrix rho_0, const std::vector<MatrixFree
     }
 }
 
-void time_evolution_variational_exponential(ExponentialAnsatz& rho_t, const std::vector<MatrixFreeHamiltonian>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, QiliSimConfig& config) {
+void time_evolution_variational_exponential(ExponentialAnsatz& rho_t, const std::vector<MatrixFreeHamiltonian>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, QiliSimConfig& config, std::vector<ExponentialAnsatz>& intermediate_states) {
     /*
     Execute an approximate time evolution functional using a variational approach with an exponential ansatz.
     The state at each point is represented as the exponential of a weighted sum of Pauli strings acting on the + state.
@@ -442,6 +442,7 @@ void time_evolution_variational_exponential(ExponentialAnsatz& rho_t, const std:
         parameters_list (std::vector<std::vector<double>>): The list of parameter values for each Hamiltonian term at each time step.
         step_list (std::vector<double>): The list of time steps.
         config (QiliSimConfig&): Configuration parameters for the time evolution.
+        intermediate_states (std::vector<ExponentialAnsatz>&): Output parameter to hold the ansatz after each time step if requested.
     */
 
     // Set the number of threads
@@ -462,9 +463,15 @@ void time_evolution_variational_exponential(ExponentialAnsatz& rho_t, const std:
 
     // Fixed-step RK4 loop
     for (size_t step_ind = 0; step_ind < step_list.size(); ++step_ind) {
+        // Run the step
         double t_start = (step_ind > 0) ? step_list[step_ind - 1] : 0.0;
         double dt = step_list[step_ind] - t_start;
         iter_rk4(rho_t, t_start, dt, step_list, hamiltonians, parameters_list, config.get_gpu());
+
+        // Store intermediate states if requested
+        if (config.get_store_intermediate_results()) {
+            intermediate_states.push_back(rho_t);
+        }
     }
 }
 

--- a/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.h
+++ b/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.h
@@ -25,6 +25,6 @@
 
 void time_evolution(SparseMatrix rho_0, const std::vector<SparseMatrix>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, NoiseModelCpp& noise_model_cpp, QiliSimConfig& config, DenseMatrix& rho_t, std::vector<DenseMatrix>& intermediate_rhos, bool* output_is_trajectories = nullptr);
 void time_evolution_matrix_free(SparseMatrix rho_0, const std::vector<MatrixFreeHamiltonian>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, NoiseModelCpp& noise_model_cpp, QiliSimConfig& config, DenseMatrix& rho_t, std::vector<DenseMatrix>& intermediate_rhos, bool* output_is_trajectories = nullptr);
-void time_evolution_variational_exponential(ExponentialAnsatz& rho_t_as_h, const std::vector<MatrixFreeHamiltonian>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, QiliSimConfig& config);
+void time_evolution_variational_exponential(ExponentialAnsatz& rho_t_as_h, const std::vector<MatrixFreeHamiltonian>& hamiltonians, const std::vector<std::vector<double>>& parameters_list, const std::vector<double>& step_list, QiliSimConfig& config, std::vector<ExponentialAnsatz>& intermediate_states);
 
 // GCOV_EXCL_BR_STOP

--- a/src/qilisdk_cpp/backends/qilisim/qilisim.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/qilisim.cpp
@@ -266,10 +266,20 @@ py::object QiliSimCpp::execute_analog_evolution(const py::object& functional, co
         }
 
         // Run the evolution
-        time_evolution_variational_exponential(rho_t, hamiltonians, parameters_list, step_list, config);
+        std::vector<ExponentialAnsatz> intermediate_states;
+        time_evolution_variational_exponential(rho_t, hamiltonians, parameters_list, step_list, config, intermediate_states);
 
         // Construct the result object
         py::object result = construct_result_object(rho_t, readout, n_qubits);
+
+        // If we have intermediates, process them too
+        if (config.get_store_intermediate_results()) {
+            py::list inter_results;
+            for (const auto& state_intermediate : intermediate_states) {
+                inter_results.append(construct_result_object(state_intermediate, readout, n_qubits));
+            }
+            return FunctionalResult("readout_results"_a = result, "intermediate_results"_a = inter_results);
+        }
         return FunctionalResult("readout_results"_a = result);
 
         // In all of these methods the state is fully stored

--- a/tests/integration/backends/test_qilisim_specific_integration.py
+++ b/tests/integration/backends/test_qilisim_specific_integration.py
@@ -658,6 +658,30 @@ def test_variational_annealing_expectation_value_bounded():
     assert -1.00001 <= ev.real <= 1.00001
 
 
+def test_variational_annealing_intermediate_results():
+    backend = QiliSim(
+        analog_simulation_method=AnalogMethod.variational_annealing(order=1, shots=100, warmups=5),
+        execution_config=ExecutionConfig(seed=42, num_threads=1),
+    )
+    schedule = _make_annealing_schedule()
+    result = backend.execute(
+        AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM, store_intermediate_results=True),
+        readout=Readout().with_expectation(observables=[pauli_z(0)]).with_sampling(nshots=50),
+    )
+    assert isinstance(result, FunctionalResult)
+    evs = result.get_intermediate_expectation_values()
+    assert len(evs) == len(schedule.tlist)
+    assert all(-1.00001 <= step[0].real <= 1.00001 for step in evs)
+    # The uniform initial state has <Z> = 0, while the final state is the ground state of Z
+    assert abs(evs[0][0].real) < 0.3
+    assert evs[-1][0].real < -0.8
+    samples = result.get_intermediate_samples()
+    assert len(samples) == len(schedule.tlist)
+    # The variational method samples its ansatz, so each step uses the configured variational shots
+    nshots_per_step = sum(result.get_samples().values())
+    assert all(sum(counts.values()) == nshots_per_step for counts in samples)
+
+
 def test_variational_annealing_wrong_initial_state_raises():
     backend = QiliSim(
         analog_simulation_method=AnalogMethod.variational_annealing(order=1, shots=50, warmups=0),

--- a/tests/unit_cpp/qilisim/test_time_evolution.cpp
+++ b/tests/unit_cpp/qilisim/test_time_evolution.cpp
@@ -936,19 +936,33 @@ class TimeEvolutionVariationalTest : public ::testing::Test {
 
 TEST_F(TimeEvolutionVariationalTest, DoesNotThrowForValidInput) {
     ExponentialAnsatz rho_t(1, 1, 50, 0);
-    EXPECT_NO_THROW(time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config));
+    std::vector<ExponentialAnsatz> intermediates;
+    EXPECT_NO_THROW(time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config, intermediates));
+    EXPECT_TRUE(intermediates.empty());
 }
 
 TEST_F(TimeEvolutionVariationalTest, TermCountUnchangedAfterEvolution) {
     ExponentialAnsatz rho_t(1, 1, 50, 0);
     size_t initial_terms = rho_t.get_terms().size();
-    time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config);
+    std::vector<ExponentialAnsatz> intermediates;
+    time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config, intermediates);
     EXPECT_EQ(rho_t.get_terms().size(), initial_terms);
 }
 
 TEST_F(TimeEvolutionVariationalTest, EmptyHamiltonianListThrows) {
     ExponentialAnsatz rho_t(1, 1, 50, 0);
-    EXPECT_ANY_THROW(time_evolution_variational_exponential(rho_t, {}, {}, {}, config));
+    std::vector<ExponentialAnsatz> intermediates;
+    EXPECT_ANY_THROW(time_evolution_variational_exponential(rho_t, {}, {}, {}, config, intermediates));
+}
+
+TEST_F(TimeEvolutionVariationalTest, StoresOneIntermediateAnsatzPerStep) {
+    config.set_store_intermediate_results(true);
+    ExponentialAnsatz rho_t(1, 1, 50, 0);
+    std::vector<ExponentialAnsatz> intermediates;
+    time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config, intermediates);
+    ASSERT_EQ(intermediates.size(), step_list.size());
+    // The last intermediate is the final state, so its terms must match those of rho_t
+    EXPECT_EQ(intermediates.back().get_terms().size(), rho_t.get_terms().size());
 }
 
 TEST_F(TimeEvolutionTest, TimeDependentRateScalingDense) {
@@ -988,7 +1002,8 @@ TEST_F(TimeEvolutionVariationalTest, AnsatzParametersComeFromVariationalConfig) 
     config.set_num_monte_carlo_trajectories(999);  // must NOT leak into the ansatz shots
 
     ExponentialAnsatz rho_t(1, 1, 50, 0);
-    time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config);
+    std::vector<ExponentialAnsatz> intermediates;
+    time_evolution_variational_exponential(rho_t, hamiltonians, params, step_list, config, intermediates);
 
     EXPECT_EQ(rho_t.get_shots(), 37);
     EXPECT_EQ(rho_t.get_warmups(), 3);


### PR DESCRIPTION
Variational annealing can now return expectation values and samples mid-evolution, as per the other analog simulation methods. State tomography remains disabled.

```python
from qilisdk.analog import Schedule, X, Z
from qilisdk.backends import AnalogMethod, QiliSim
from qilisdk.core import InitialState
from qilisdk.functionals import AnalogEvolution
from qilisdk.readout import Readout
schedule = Schedule.linear(-X(0), Z(0), 10.0, 0.1)
backend = QiliSim(analog_simulation_method=AnalogMethod.variational_annealing())
result = backend.execute(
    AnalogEvolution(schedule=schedule, initial_state=InitialState.UNIFORM, store_intermediate_results=True),
    readout=Readout().with_expectation(observables=[Z(0)]),
)
vals = [step[0].real for step in result.get_intermediate_expectation_values()]
print("Intermediate expectation values of Z(0):", vals)
```

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/481