### PR TITLE
Better Ctrl-C handling in QiliSim

### DIFF
--- a/changes/486.bugfix.md
+++ b/changes/486.bugfix.md
@@ -1,0 +1,1 @@
+There are now signal checks in the long running loops, which allow the user to stop a simulation part way through. They have been benchmarked and don't affect performance at all, since it's just checking a flag in memory.

--- a/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/analog/time_evolution.cpp
@@ -14,6 +14,7 @@
 
 #include "time_evolution.h"
 #include "../../../libs/logging.h"
+#include "../../../libs/pybind.h"
 #include "../noise/noise_model.h"
 #include "../utils/matrix_utils.h"
 #include "../utils/random.h"
@@ -143,6 +144,9 @@ void time_evolution(SparseMatrix rho_0, const std::vector<SparseMatrix>& hamilto
 
     // For each time step
     for (size_t step_ind = 0; step_ind < step_list.size(); ++step_ind) {
+        // Let Ctrl-C interrupt the evolution between time steps
+        check_signals();
+
         // Get the current Hamiltonian
         SparseMatrix currentH = combinedH;
         for (size_t h = 0; h < hamiltonians.size(); ++h) {
@@ -333,6 +337,9 @@ void time_evolution_matrix_free(SparseMatrix rho_0, const std::vector<MatrixFree
         const size_t max_iters = 1000000;  // Just in case to prevent infinite loops
         DenseMatrix k_saved;
         while (current_time < step_list.back()) {
+            // Let Ctrl-C interrupt the evolution between time steps
+            check_signals();
+
             // Make sure the next step doesn't go beyond the final time point
             dt = std::min(dt, step_list.back() - current_time);
 
@@ -362,6 +369,9 @@ void time_evolution_matrix_free(SparseMatrix rho_0, const std::vector<MatrixFree
     } else if (config.get_time_evolution_method() == "integrate_rk4_matrix_free") {
         // For each time step
         for (size_t step_ind = 0; step_ind < step_list.size(); ++step_ind) {
+            // Let Ctrl-C interrupt the evolution between time steps
+            check_signals();
+
             // Determine the time step and starting time
             double t_start = (step_ind > 0) ? step_list[step_ind - 1] : 0.0;
             double dt = step_list[step_ind] - t_start;
@@ -396,6 +406,9 @@ void time_evolution_matrix_free(SparseMatrix rho_0, const std::vector<MatrixFree
         int nqubits = hamiltonians[0].get_nqubits();
         // For each time step
         for (size_t step_ind = 0; step_ind < step_list.size(); ++step_ind) {
+            // Let Ctrl-C interrupt the evolution between time steps
+            check_signals();
+
             // Build the Hamiltonian for this step
             MatrixFreeHamiltonian currentH(nqubits);
             for (size_t h = 0; h < hamiltonians.size(); ++h) {
@@ -462,6 +475,9 @@ void time_evolution_variational_exponential(ExponentialAnsatz& rho_t, const std:
 
     // Fixed-step RK4 loop
     for (size_t step_ind = 0; step_ind < step_list.size(); ++step_ind) {
+        // Let Ctrl-C interrupt the evolution between time steps
+        check_signals();
+
         double t_start = (step_ind > 0) ? step_list[step_ind - 1] : 0.0;
         double dt = step_list[step_ind] - t_start;
         iter_rk4(rho_t, t_start, dt, step_list, hamiltonians, parameters_list, config.get_gpu());

--- a/src/qilisdk_cpp/backends/qilisim/digital/sampling.cpp
+++ b/src/qilisdk_cpp/backends/qilisim/digital/sampling.cpp
@@ -230,6 +230,9 @@ void sampling(const std::vector<Gate>& gates, int n_qubits, const SparseMatrixCo
     for (int i = 0; i < int(optimized_gates.size()); ++i) {
         const auto& gate = optimized_gates[i];
 
+        // Let Ctrl-C interrupt the circuit between gates
+        check_signals();
+
         // If it's a measurement
         if (gate.get_name() == "M") {
             // Check for adjacent measurements and if we have any, do them all at once
@@ -442,6 +445,9 @@ void sampling_matrix_free(const std::vector<Gate>& gates, int n_qubits, const Sp
     for (int i = 0; i < int(optimized_gates.size()); ++i) {
         const auto& gate = optimized_gates[i];
 
+        // Let Ctrl-C interrupt the circuit between gates
+        check_signals();
+
         // Convert gate to a matrix-free operator
         MatrixFreeOperator op(gate);
 
@@ -583,6 +589,10 @@ void sampling_stabilizer(const std::vector<Gate>& gates, int n_qubits, const Sta
     std::vector<bool> qubits_measured(n_qubits, false);
     for (int i = 0; i < int(gates.size()); ++i) {
         const auto& gate = gates[i];
+
+        // Let Ctrl-C interrupt the circuit between gates
+        check_signals();
+
         state.apply_gate(gate);
     }
 }

--- a/src/qilisdk_cpp/libs/pybind.cpp
+++ b/src/qilisdk_cpp/libs/pybind.cpp
@@ -120,6 +120,22 @@ void error(std::string message) {
     }
 }
 
+void check_signals() {
+    /*
+    Run any pending Python signal handlers, so that a Ctrl-C (or any other signal) interrupts a
+    long-running C++ routine instead of only being raised once it returns to Python.
+
+    Cheap enough to call once per iteration of a simulation loop: with no signal pending it is a
+    flag check, and it is a no-op when called from a thread other than the main one.
+
+    Raises:
+        py::error_already_set: If a signal handler raised, e.g. KeyboardInterrupt for SIGINT.
+    */
+    if (PyErr_CheckSignals() != 0) {
+        throw py::error_already_set();
+    }
+}
+
 // GCOVR_EXCL_START
 void finalize_all_pybind_types() {
     QUBO = py::object();

--- a/src/qilisdk_cpp/libs/pybind.h
+++ b/src/qilisdk_cpp/libs/pybind.h
@@ -81,6 +81,9 @@ void info(std::string message);
 void warning(std::string message);
 void error(std::string message);
 
+// This should be called regularly during long-running loops to check for things like Ctrl-C
+void check_signals();
+
 #pragma GCC visibility pop
 
 // GCOV_EXCL_BR_STOP


### PR DESCRIPTION
There are now signal checks in the long running loops, which allow the user to stop a simulation part way through. They have been benchmarked and don't affect performance at all, since it's just checking a flag in memory.

Resolves https://github.com/qilimanjaro-tech/qilisdk/issues/416